### PR TITLE
"Accounts Endpoint" to be consumed by Ceres Tag Integration Configura…

### DIFF
--- a/cdip-admin-portal/cdip_admin/api/serializers.py
+++ b/cdip-admin-portal/cdip_admin/api/serializers.py
@@ -27,6 +27,14 @@ class InboundIntegrationConfigurationSerializer(serializers.ModelSerializer):
         fields = ['state',] + read_only_fields
 
 
+class CeresTagIdentifiersSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = InboundIntegrationConfiguration
+        read_only_fields = ['name', 'id']
+        fields = read_only_fields
+
+
 class OutboundIntegrationTypeSerializer(serializers.ModelSerializer):
     class Meta:
         model = OutboundIntegrationType

--- a/cdip-admin-portal/cdip_admin/api/urls.py
+++ b/cdip-admin-portal/cdip_admin/api/urls.py
@@ -26,6 +26,8 @@ urlpatterns = [
 
     path('v1.0/integrations/inbound/configurations', InboundIntegrationConfigurationListView.as_view(),
          name='inboundintegrationconfiguration_list'),
+    path('v1.0/integrations/inbound/configurations/ceres_tag', CeresTagIdentifiersListView.as_view(),
+         name='inboundintegration_cerestag_list'),
     path('v1.0/integrations/inbound/configurations/<pk>', InboundIntegrationConfigurationDetailsView.as_view(),
          name='inboundintegrationconfigurations_detail'),
 

--- a/cdip-admin-portal/cdip_admin/api/views.py
+++ b/cdip-admin-portal/cdip_admin/api/views.py
@@ -112,6 +112,20 @@ class InboundIntegrationConfigurationListView(generics.ListAPIView):
         return self.list(request, *args, **kwargs)
 
 
+class CeresTagIdentifiersListView(generics.ListAPIView):
+    """ Returns List of Identifiers used during the software provider configuration setup for Ceres Tag Integrations
+    """
+    serializer_class = CeresTagIdentifiersSerializer
+    filter_backends = [DjangoFilterBackend]
+    filter_class = CeresTagIdentifiersFilter
+    permission_classes = (rest_framework.permissions.IsAuthenticated,)
+
+    queryset = InboundIntegrationConfiguration.objects.all()
+
+    def get(self, request, *args, **kwargs):
+        return self.list(request, *args, **kwargs)
+
+
 class InboundIntegrationConfigurationDetailsView(generics.RetrieveUpdateAPIView):
 
     queryset = InboundIntegrationConfiguration.objects.all()


### PR DESCRIPTION
"Accounts Endpoint" that Ceres Tag will be configured to call to get a list of "farm identifiers" or in our case inbound integrations to display to their customers when selecting a software provider to share their tracking data with.