### PR TITLE
Alternative Pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,5 +129,5 @@ workflows:
           - build
           filters:
             branches:
-              only: feat/new-pipeline
+              only: main
 


### PR DESCRIPTION
# Description

This PR adds two CircleCI jobs to create an alternative pipeline that will run at the same time, creating another docker image and then it will be pushed to the same registry following a semantic version approach

[JIRA Ticket](https://allenai.atlassian.net/browse/SIK-548?atlOrigin=eyJpIjoiMDgzYmUyMzkyNDljNGNhNTgxZmQ5NWUxODFjNjhjNTciLCJwIjoiaiJ9)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How this should be tested?

Images should present in both registries
Reviewing the created images

