### PR TITLE
SIK-1803: Gundi 2.0 API - Ordering Destinations

### DIFF
--- a/cdip_admin/api/v2/views.py
+++ b/cdip_admin/api/v2/views.py
@@ -109,7 +109,7 @@ class DestinationView(
     """
     permission_classes = [permissions.IsSuperuser | permissions.IsOrgAdmin | permissions.IsOrgViewer]
     filter_backends = [filters.OrderingFilter, django_filters.rest_framework.DjangoFilterBackend]
-    ordering_fields = ['id', 'name']
+    ordering_fields = ['id', 'name', 'endpoint', 'type__name', 'owner__name']
     ordering = ['id']
     filterset_fields = {
         'endpoint': ['exact', 'iexact', 'in'],


### PR DESCRIPTION
### What does this PR do?
This is a quick fix in the filters implemented in [SIK-1803](https://allenai.atlassian.net/browse/SIK-1803) to support ordering destinations also by url, owner, and type.

### Relevant link(s)
[SIK-1803](https://allenai.atlassian.net/browse/SIK-1803)

[SIK-1803]: https://allenai.atlassian.net/browse/SIK-1803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SIK-1803]: https://allenai.atlassian.net/browse/SIK-1803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ