### PR TITLE
SIK-2364: Update api v2 path

### DIFF
--- a/cdip_admin/api/urls.py
+++ b/cdip_admin/api/urls.py
@@ -2,7 +2,6 @@ from django.conf.urls import url
 from django.urls import path, include
 from rest_framework_swagger.views import get_swagger_view
 from api.views import *
-from . import v2 as api_v2
 
 schema_view = get_swagger_view(title="CDIP ADMIN API")
 
@@ -88,7 +87,5 @@ urlpatterns = [
         BridgeIntegrationView.as_view(),
         name="bridge-integration-view",
     ),
-    url(r"^docs/", schema_view),
-    # API v2 (Gundi 2.0)
-    path(r'v2/', include(api_v2.urls)),
+    url(r"^docs/", schema_view)
 ]

--- a/cdip_admin/cdip_admin/urls.py
+++ b/cdip_admin/cdip_admin/urls.py
@@ -18,9 +18,10 @@ from django.contrib import admin
 from django.urls import path, include
 from website.views import welcome, date, about, index, login_view, logout_view
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
-
+from api import v2 as api_v2
 
 urlpatterns = [
+    path(r'v2/', include(api_v2.urls)),  # API v2 (Gundi 2.0)
     path("admin/", admin.site.urls),
     path("", welcome, name="welcome"),
     path("date", date),


### PR DESCRIPTION
### What does this PR do?
- Update URLs config to remove `/api/` from the URL path in v2, so the full api URL is `api.gundiservice.org/v2/`
- This is covered by regression tests.
- We need to update URLs in other apps or services using API v2 after merging this.

### Relevant link(s)
[SIK-2364](https://allenai.atlassian.net/browse/SIK-2364)

[SIK-2364]: https://allenai.atlassian.net/browse/SIK-2364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ