### PR TITLE
SIK-2712: Metrics in Gundi v2

### DIFF
--- a/cdip_admin/integrations/management/commands/get_metrics.py
+++ b/cdip_admin/integrations/management/commands/get_metrics.py
@@ -56,7 +56,7 @@ class Command(BaseCommand):
             created_at__lte=end,
             is_duplicate=False,
         )
-        self.stdout.write(f"Receive observations (skipping duplicates): {unique_traces_in_range.count()}")
+        self.stdout.write(f"Received observations (without duplicates): {unique_traces_in_range.count()}")
         dispatched_observations = unique_traces_in_range.filter(
             has_error=False,
             delivered_at__isnull=False


### PR DESCRIPTION
### What does this PR do?
- Adds a command to get metrics from gundi traces in gundi v2, including:
    - Observations Received
    - Observations Dispatched
    - Data Loss
    - Latency: p50, p95, p99

### Example:
```
Computing metrics between: 2023-12-11T00:00:00Z and 2023-12-13T00:00:00Z...
Receive observations (skipping duplicates): 5
Dispatched observations: 4
Data loss: 0.2
Latency p50 [ms]: 9686
Latency p95 [ms]: 28397
Latency p99 [ms]: 30233
Done!
```

### Relevant link(s)
[SIK-2712](https://allenai.atlassian.net/browse/SIK-2712)

[SIK-2712]: https://allenai.atlassian.net/browse/SIK-2712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ