### PR TITLE
GUNDI-2690: Update django to get a security patch

### DIFF
--- a/dependencies/requirements-dev.txt
+++ b/dependencies/requirements-dev.txt
@@ -115,7 +115,7 @@ deprecated==1.2.14
     # via opentelemetry-api
 distlib==0.3.7
     # via virtualenv
-django==3.2.15
+django==3.2.25
     # via
     #   -r requirements.in
     #   django-bootstrap4
@@ -299,6 +299,7 @@ httpx==0.24.1
     #   gundi-client-v2
     #   movebank-client
     #   respx
+    #   smartconnect-client
 identify==2.5.27
     # via pre-commit
 idna==2.10
@@ -581,7 +582,7 @@ six==1.15.0
     #   python-jose
     #   social-auth-app-django
     #   social-auth-core
-smartconnect-client @ https://github.com/PADAS/smartconnect-client/releases/download/v1.4.6/smartconnect_client-1.4.6-py3-none-any.whl
+smartconnect-client @ https://github.com/PADAS/smartconnect-client/releases/download/v1.5.2/smartconnect_client-1.5.2-py3-none-any.whl
     # via -r requirements.in
 sniffio==1.3.0
     # via
@@ -623,6 +624,8 @@ tzdata==2023.3
     #   django-celery-beat
 tzlocal==5.0.1
     # via dateparser
+unidecode==1.3.8
+    # via -r requirements.in
 untangle==1.2.1
     # via smartconnect-client
 uritemplate==4.1.1

--- a/dependencies/requirements.in
+++ b/dependencies/requirements.in
@@ -2,7 +2,7 @@ aiofiles==23.2.1
 movebank-client==1.0.0
 celery==5.2.3
 celery-once==1.2.0
-Django==3.2.15
+Django==3.2.25
 PyJWT==1.7.1
 #asgiref==3.2.10
 beautifulsoup4==4.9.1

--- a/dependencies/requirements.txt
+++ b/dependencies/requirements.txt
@@ -105,7 +105,7 @@ defusedxml==0.7.1
     #   untangle
 deprecated==1.2.14
     # via opentelemetry-api
-django==3.2.15
+django==3.2.25
     # via
     #   -r requirements.in
     #   django-bootstrap4


### PR DESCRIPTION
### What does this PR do?
- Updates the Django version to 3.2.25 to get the latest security patches including [this one](https://docs.djangoproject.com/en/dev/releases/3.2.25/) which was recently released.
- Regenerate requirements files

### Relevant link(s)
[GUNDI-2690](https://allenai.atlassian.net/browse/GUNDI-2690)