### PR TITLE
GUNDI-3065: EULA API Improvements

### DIFF
--- a/cdip_admin/accounts/admin.py
+++ b/cdip_admin/accounts/admin.py
@@ -36,6 +36,11 @@ class EULAAdmin(admin.ModelAdmin):
     )
     list_filter = ("active", )
 
+    def get_readonly_fields(self, request, obj=None):
+        if not obj:  # New EULAs are always added as active
+            return ['active']
+        return []
+
 
 @admin.register(UserAgreement)
 class UserAgreementAdmin(admin.ModelAdmin):

--- a/cdip_admin/api/v2/tests/test_eula_api.py
+++ b/cdip_admin/api/v2/tests/test_eula_api.py
@@ -79,3 +79,20 @@ def test_new_eula_requires_new_acceptance(request, api_client, user, eula_v1):
     assert response_data.get("version") == eula_new_version.version
     assert response_data.get("eula_url") == eula_new_version.eula_url
     assert response_data.get("accepted") == False
+
+
+@pytest.mark.parametrize("user", [
+    ("superuser"),
+    ("org_admin_user"),
+    ("org_viewer_user"),
+])
+def test_retrieve_active_eula(request, api_client, user):
+    user = request.getfixturevalue(user)
+    api_client.force_authenticate(user)
+
+    response = api_client.get(
+        reverse("eula-list")
+    )
+
+    # No active EULA exists
+    assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/cdip_admin/api/v2/views.py
+++ b/cdip_admin/api/v2/views.py
@@ -56,7 +56,10 @@ class EULAView(
 
     # Overriden to return a single object (the active eula)
     def list(self, request, *args, **kwargs):
-        instance = self.get_object()
+        try:
+            instance = self.get_object()
+        except EULA.DoesNotExist:  # No active EULA
+            return Response(status=status.HTTP_404_NOT_FOUND)
         serializer = self.get_serializer(instance)
         return Response(serializer.data)
 


### PR DESCRIPTION
### What does this PR do?
- Makes the `/eula/` endpoint return 404 when there isn't an active EULA
- Disallow changing the active field while adding new EULAs from the Django admin
- Adds test coverage for the negative scenario where there isn't an active EULA

Screenshoot of the Django admin while adding a new EULA  (active is read only)
![eula_active_disabled](https://github.com/PADAS/cdip/assets/9864478/86bb97b0-dc22-406a-bd78-2c426fd0ddd6)


### Relevant link(s)
[GUNDI-3065](https://allenai.atlassian.net/browse/GUNDI-3065)

[GUNDI-3065]: https://allenai.atlassian.net/browse/GUNDI-3065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ