### PR TITLE
GUNDI-3096: Update dispatchers command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 repos:
-- repo: git://github.com/pre-commit/mirrors-autopep8
-  rev: 'v1.5.6'  # Use the sha / tag you want to point at
-  hooks:
-  - id: autopep8
+#- repo: git://github.com/hhatto/autopep8
+#  rev: 'v2.1.0'  # Use the sha / tag you want to point at
+#  hooks:
+#  - id: autopep8
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v3.4.0  # Use the ref you want to point at
   hooks:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -229,14 +233,14 @@
         "filename": "cdip_admin/api/v2/tests/test_integrations_api.py",
         "hashed_secret": "f424c840dadb52c20b6277fac4ca56ce729bc9b9",
         "is_verified": false,
-        "line_number": 1244
+        "line_number": 1251
       },
       {
         "type": "Secret Keyword",
         "filename": "cdip_admin/api/v2/tests/test_integrations_api.py",
         "hashed_secret": "12436f4d8e8d63b983d6b2a5184fa2ff83545d86",
         "is_verified": false,
-        "line_number": 1282
+        "line_number": 1289
       }
     ],
     "cdip_admin/cdip_admin/settings.py": [
@@ -254,7 +258,7 @@
         "filename": "cdip_admin/conftest.py",
         "hashed_secret": "27d933b78d3ea4a51a3ff26aef5831c92d43925c",
         "is_verified": false,
-        "line_number": 1937
+        "line_number": 1938
       }
     ],
     "cdip_admin/integrations/migrations/0047_init_erinreach_config_schema.py": [
@@ -292,5 +296,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-29T21:31:29Z"
+  "generated_at": "2024-05-10T15:58:48Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -258,7 +258,7 @@
         "filename": "cdip_admin/conftest.py",
         "hashed_secret": "27d933b78d3ea4a51a3ff26aef5831c92d43925c",
         "is_verified": false,
-        "line_number": 1938
+        "line_number": 2057
       }
     ],
     "cdip_admin/integrations/migrations/0047_init_erinreach_config_schema.py": [
@@ -296,5 +296,5 @@
       }
     ]
   },
-  "generated_at": "2024-05-10T15:58:48Z"
+  "generated_at": "2024-05-10T19:53:38Z"
 }

--- a/cdip_admin/api/v2/tests/test_activity_logs_api.py
+++ b/cdip_admin/api/v2/tests/test_activity_logs_api.py
@@ -35,7 +35,7 @@ def _test_list_activity_logs(api_client, user, expected_logs, params=None):
 
 def test_list_logs_as_superuser(
         api_client, superuser, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, observation_delivery_succeeded_event
+        integrations_list_er, observation_delivery_succeeded_event
 ):
     _test_list_activity_logs(
         api_client=api_client,
@@ -87,7 +87,7 @@ def test_filter_logs_by_integration_as_superuser(
 
 def test_filter_logs_by_integration_as_org_admin(
         api_client, org_admin_user, provider_lotek_panthera, provider_movebank_ewt,
-        destination_movebank, smart_integration, integrations_list,
+        destination_movebank, smart_integration, integrations_list_er,
 ):
     integration_id = str(provider_lotek_panthera.id)
     _test_list_activity_logs(
@@ -102,7 +102,7 @@ def test_filter_logs_by_integration_as_org_admin(
 
 def test_filter_logs_by_type_data_change_as_superuser(
         api_client, superuser, provider_lotek_panthera, provider_movebank_ewt,
-        destination_movebank, smart_integration, integrations_list,
+        destination_movebank, smart_integration, integrations_list_er,
         observation_delivery_succeeded_event, observation_delivery_succeeded_event_2,
 ):
     _test_list_activity_logs(
@@ -119,7 +119,7 @@ def test_filter_logs_by_type_data_change_as_superuser(
 
 def test_filter_logs_by_type_data_change_as_org_admin(
         api_client, org_admin_user, provider_lotek_panthera, provider_movebank_ewt,
-        destination_movebank, smart_integration, integrations_list,
+        destination_movebank, smart_integration, integrations_list_er,
         observation_delivery_succeeded_event, observation_delivery_succeeded_event_2,
 ):
     user_integrations = get_user_integrations_qs(user=org_admin_user)
@@ -138,7 +138,7 @@ def test_filter_logs_by_type_data_change_as_org_admin(
 
 def test_filter_logs_by_type_event_as_org_admin(
         api_client, org_admin_user_2, provider_lotek_panthera, provider_movebank_ewt,
-        destination_movebank, smart_integration, integrations_list,
+        destination_movebank, smart_integration, integrations_list_er,
         observation_delivery_succeeded_event, observation_delivery_succeeded_event_2,
 ):
     integration_id = str(destination_movebank.id)
@@ -158,7 +158,7 @@ def test_filter_logs_by_type_event_as_org_admin(
 
 def test_filter_logs_by_origin_portal_as_superuser(
         api_client, superuser, provider_lotek_panthera, provider_movebank_ewt,
-        destination_movebank, smart_integration, integrations_list,
+        destination_movebank, smart_integration, integrations_list_er,
         observation_delivery_succeeded_event, observation_delivery_succeeded_event_2,
 ):
     _test_list_activity_logs(
@@ -175,7 +175,7 @@ def test_filter_logs_by_origin_portal_as_superuser(
 
 def test_filter_logs_by_origin_portal_as_org_admin(
         api_client, org_admin_user, provider_lotek_panthera, provider_movebank_ewt,
-        destination_movebank, smart_integration, integrations_list,
+        destination_movebank, smart_integration, integrations_list_er,
         observation_delivery_succeeded_event, observation_delivery_succeeded_event_2,
 ):
     user_integrations = get_user_integrations_qs(user=org_admin_user)
@@ -213,7 +213,7 @@ def test_filter_logs_by_origin_dispatcher_as_org_admin(
 
 def test_filter_logs_by_log_level_as_superuser(
         api_client, superuser, provider_lotek_panthera, provider_movebank_ewt,
-        destination_movebank, smart_integration, integrations_list,
+        destination_movebank, smart_integration, integrations_list_er,
         observation_delivery_succeeded_event, observation_delivery_succeeded_event_2,
 ):
     _test_list_activity_logs(
@@ -230,7 +230,7 @@ def test_filter_logs_by_log_level_as_superuser(
 
 def test_filter_logs_by_log_level_as_org_admin(
         api_client, org_admin_user, provider_lotek_panthera, provider_movebank_ewt,
-        destination_movebank, smart_integration, integrations_list,
+        destination_movebank, smart_integration, integrations_list_er,
         observation_delivery_succeeded_event, observation_delivery_succeeded_event_2, observation_delivery_failed_event,
 ):
     user_integrations = get_user_integrations_qs(user=org_admin_user)
@@ -249,7 +249,7 @@ def test_filter_logs_by_log_level_as_org_admin(
 
 def test_filter_logs_in_date_range_as_superuser(
         api_client, superuser, provider_lotek_panthera, provider_movebank_ewt,
-        destination_movebank, smart_integration, integrations_list,
+        destination_movebank, smart_integration, integrations_list_er,
         observation_delivery_succeeded_event, observation_delivery_succeeded_event_2,
 ):
     selected_events = ActivityLog.objects.all()[2:4]
@@ -268,7 +268,7 @@ def test_filter_logs_in_date_range_as_superuser(
 
 def test_get_logs_with_multiple_filters_as_org_admin(
         api_client, org_admin_user, provider_lotek_panthera, provider_movebank_ewt,
-        destination_movebank, smart_integration, integrations_list,
+        destination_movebank, smart_integration, integrations_list_er,
         observation_delivery_succeeded_event, observation_delivery_succeeded_event_2,
         observation_delivery_failed_event, observation_delivery_failed_event_2
 ):
@@ -277,7 +277,7 @@ def test_get_logs_with_multiple_filters_as_org_admin(
         user=org_admin_user,
         params={  # Get events of log level info or higher for a single connection from lotek to an ER site
             "from_date": observation_delivery_succeeded_event.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-            "integration__in": ",".join([str(provider_lotek_panthera.id), str(integrations_list[1].id)]),
+            "integration__in": ",".join([str(provider_lotek_panthera.id), str(integrations_list_er[1].id)]),
             "log_level": ActivityLog.LogLevels.INFO.value,
             "log_type": ActivityLog.LogTypes.EVENT.value,
         },
@@ -287,7 +287,7 @@ def test_get_logs_with_multiple_filters_as_org_admin(
 
 def test_search_logs_by_value_as_org_admin(
         api_client, org_admin_user, provider_lotek_panthera, provider_movebank_ewt,
-        destination_movebank, smart_integration, integrations_list,
+        destination_movebank, smart_integration, integrations_list_er,
         observation_delivery_succeeded_event, observation_delivery_succeeded_event_2,
         observation_delivery_failed_event, observation_delivery_failed_event_2
 ):
@@ -303,7 +303,7 @@ def test_search_logs_by_value_as_org_admin(
 
 def test_search_logs_by_value_as_superuser(
         api_client, superuser, provider_lotek_panthera, provider_movebank_ewt,
-        destination_movebank, smart_integration, integrations_list,
+        destination_movebank, smart_integration, integrations_list_er,
         observation_delivery_succeeded_event, observation_delivery_succeeded_event_2,
         observation_delivery_failed_event, observation_delivery_failed_event_2
 ):
@@ -319,7 +319,7 @@ def test_search_logs_by_value_as_superuser(
 
 def test_search_logs_and_filter_as_superuser(
         api_client, superuser, provider_lotek_panthera, provider_movebank_ewt,
-        destination_movebank, smart_integration, integrations_list,
+        destination_movebank, smart_integration, integrations_list_er,
         observation_delivery_succeeded_event, observation_delivery_succeeded_event_2,
         observation_delivery_failed_event, observation_delivery_failed_event_2
 ):
@@ -425,11 +425,11 @@ def test_cannot_revert_activity_of_not_reversible_activity_as_org_admin(
 
 def test_cannot_revert_activity_of_other_org_as_org_admin(
         api_client, org_admin_user_2, provider_lotek_panthera, destination_movebank,
-        integrations_list, observation_delivery_failed_event_2
+        integrations_list_er, observation_delivery_failed_event_2
 ):
     # Get the activity log for a change that belongs to another org
     log = ActivityLog.objects.filter(
-        integration=integrations_list[1],
+        integration=integrations_list_er[1],
         is_reversible=True,
     ).first()
 

--- a/cdip_admin/api/v2/tests/test_connections_api.py
+++ b/cdip_admin/api/v2/tests/test_connections_api.py
@@ -55,47 +55,51 @@ def _test_list_connections(api_client, user, provider_list):
         assert provider.owner.description == connection["owner"].get("description")
 
 
-def test_list_connections_as_superuser(api_client, superuser, organization, provider_lotek_panthera, provider_movebank_ewt, integrations_list,
+def test_list_connections_as_superuser(api_client, superuser, organization, provider_lotek_panthera, provider_movebank_ewt,
+                                       integrations_list_er,
                                        route_1,
                                        route_2):
     _test_list_connections(
         api_client=api_client,
         user=superuser,
         # The superuser can see all the connections
-        provider_list=integrations_list + [provider_lotek_panthera, provider_movebank_ewt]
+        provider_list=integrations_list_er + [provider_lotek_panthera, provider_movebank_ewt]
     )
 
 
-def test_list_connections_as_org_admin(api_client, org_admin_user, organization, provider_lotek_panthera, provider_movebank_ewt, integrations_list,
+def test_list_connections_as_org_admin(api_client, org_admin_user, organization, provider_lotek_panthera, provider_movebank_ewt,
+                                       integrations_list_er,
                                        route_1,
                                        route_2):
     _test_list_connections(
         api_client=api_client,
         user=org_admin_user,  # Belongs to one organization
         # Org admins can only see providers of their organizations
-        provider_list=integrations_list[:5] + [provider_lotek_panthera]
+        provider_list=integrations_list_er[:5] + [provider_lotek_panthera]
     )
 
 
-def test_list_connections_as_org_admin_2(api_client, org_admin_user_2, organization, provider_lotek_panthera, provider_movebank_ewt, integrations_list,
+def test_list_connections_as_org_admin_2(api_client, org_admin_user_2, organization, provider_lotek_panthera, provider_movebank_ewt,
+                                         integrations_list_er,
                                          route_1,
                                          route_2):
     _test_list_connections(
         api_client=api_client,
         user=org_admin_user_2,  # Belongs to one organization
         # Org admins can only see providers of their organizations
-        provider_list=integrations_list[5:]+ [provider_movebank_ewt]
+        provider_list=integrations_list_er[5:] + [provider_movebank_ewt]
     )
 
 
-def test_list_connections_as_org_viewer(api_client, org_viewer_user, organization, provider_lotek_panthera, provider_movebank_ewt, integrations_list,
+def test_list_connections_as_org_viewer(api_client, org_viewer_user, organization, provider_lotek_panthera, provider_movebank_ewt,
+                                        integrations_list_er,
                                         route_1,
                                         route_2):
     _test_list_connections(
         api_client=api_client,
         user=org_viewer_user,  # Belongs to one organization
         # Org viewer can only see providers of their organizations
-        provider_list=integrations_list[:5] + [provider_lotek_panthera]
+        provider_list=integrations_list_er[:5] + [provider_lotek_panthera]
     )
 
 
@@ -117,7 +121,7 @@ def _test_filter_connections(api_client, user, filters, expected_integrations):
 
 def test_filter_connections_by_provider_type_as_superuser(
         api_client, superuser, organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, route_1, route_2
+        integrations_list_er, route_1, route_2
 ):
     _test_filter_connections(
         api_client=api_client,
@@ -131,7 +135,7 @@ def test_filter_connections_by_provider_type_as_superuser(
 
 def test_filter_connections_by_provider_type_as_org_admin(
         api_client, org_admin_user_2, organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, route_1, route_2
+        integrations_list_er, route_1, route_2
 ):
     _test_filter_connections(
         api_client=api_client,
@@ -145,7 +149,7 @@ def test_filter_connections_by_provider_type_as_org_admin(
 
 def test_filter_connections_by_provider_type_as_org_viewer(
         api_client, org_viewer_user_2, organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, route_1, route_2
+        integrations_list_er, route_1, route_2
 ):
     _test_filter_connections(
         api_client=api_client,
@@ -159,7 +163,7 @@ def test_filter_connections_by_provider_type_as_org_viewer(
 
 def test_filter_connections_by_destination_type_as_superuser(
         api_client, superuser, organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, route_1, route_2, integration_type_er
+        integrations_list_er, route_1, route_2, integration_type_er
 ):
     _test_filter_connections(
         api_client=api_client,
@@ -173,7 +177,7 @@ def test_filter_connections_by_destination_type_as_superuser(
 
 def test_filter_connections_by_destination_type_as_org_admin(
         api_client, org_admin_user, organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, route_1, route_2, integration_type_er
+        integrations_list_er, route_1, route_2, integration_type_er
 ):
     _test_filter_connections(
         api_client=api_client,
@@ -187,7 +191,7 @@ def test_filter_connections_by_destination_type_as_org_admin(
 
 def test_filter_connections_by_destination_type_as_org_viewer(
         api_client, org_viewer_user, organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, route_1, route_2, integration_type_er
+        integrations_list_er, route_1, route_2, integration_type_er
 ):
     _test_filter_connections(
         api_client=api_client,
@@ -201,7 +205,7 @@ def test_filter_connections_by_destination_type_as_org_viewer(
 
 def test_filter_connections_by_multiple_destination_urls_as_superuser(
         api_client, superuser, organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, route_1, route_2, integration_type_er
+        integrations_list_er, route_1, route_2, integration_type_er
 ):
     selected_destinations = route_2.destinations.all()
     _test_filter_connections(
@@ -218,7 +222,7 @@ def test_filter_connections_by_multiple_destination_urls_as_superuser(
 
 def test_filter_connections_by_multiple_destination_urls_as_org_admin(
         api_client, org_admin_user, organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, route_1, route_2, integration_type_er
+        integrations_list_er, route_1, route_2, integration_type_er
 ):
     selected_destinations = route_1.destinations.all()
     _test_filter_connections(
@@ -235,7 +239,7 @@ def test_filter_connections_by_multiple_destination_urls_as_org_admin(
 
 def test_filter_connections_by_multiple_destination_urls_as_org_viewer(
         api_client, org_viewer_user_2, organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, route_1, route_2, integration_type_er
+        integrations_list_er, route_1, route_2, integration_type_er
 ):
     selected_destinations = route_1.destinations.all()
     _test_filter_connections(
@@ -252,7 +256,7 @@ def test_filter_connections_by_multiple_destination_urls_as_org_viewer(
 
 def test_filter_connections_by_owner_exact_as_superuser(
         api_client, superuser, organization, other_organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, route_1, route_2, integration_type_er
+        integrations_list_er, route_1, route_2, integration_type_er
 ):
     _test_filter_connections(
         api_client=api_client,
@@ -260,13 +264,13 @@ def test_filter_connections_by_owner_exact_as_superuser(
         filters={
             "owner": str(other_organization.id)
         },
-        expected_integrations=integrations_list[5:]+[provider_movebank_ewt]
+        expected_integrations=integrations_list_er[5:] + [provider_movebank_ewt]
     )
 
 
 def test_filter_connections_by_multiple_owners_as_superuser(
         api_client, superuser, organization, other_organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, route_1, route_2, integration_type_er
+        integrations_list_er, route_1, route_2, integration_type_er
 ):
     _test_filter_connections(
         api_client=api_client,
@@ -274,13 +278,13 @@ def test_filter_connections_by_multiple_owners_as_superuser(
         filters={
             "owner__in": ",".join([str(organization.id), str(other_organization.id)])
         },
-        expected_integrations=integrations_list + [provider_lotek_panthera, provider_movebank_ewt]
+        expected_integrations=integrations_list_er + [provider_lotek_panthera, provider_movebank_ewt]
     )
 
 
 def test_filter_connections_by_owner_exact_as_org_admin(
         api_client, org_admin_user, organization, other_organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, route_1, route_2, integration_type_er
+        integrations_list_er, route_1, route_2, integration_type_er
 ):
     _test_filter_connections(
         api_client=api_client,
@@ -288,13 +292,13 @@ def test_filter_connections_by_owner_exact_as_org_admin(
         filters={
             "owner": str(organization.id)
         },
-        expected_integrations=integrations_list[:5] + [provider_lotek_panthera]
+        expected_integrations=integrations_list_er[:5] + [provider_lotek_panthera]
     )
 
 
 def test_filter_connections_by_multiple_owners_as_org_admin(
         api_client, org_admin_user, organization, other_organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, route_1, route_2, integration_type_er
+        integrations_list_er, route_1, route_2, integration_type_er
 ):
     _test_filter_connections(
         api_client=api_client,
@@ -302,13 +306,13 @@ def test_filter_connections_by_multiple_owners_as_org_admin(
         filters={
             "owner__in": ",".join([str(organization.id), str(other_organization.id)])
         },
-        expected_integrations=integrations_list[:5] + [provider_lotek_panthera]
+        expected_integrations=integrations_list_er[:5] + [provider_lotek_panthera]
     )
 
 
 def test_filter_connections_by_owner_exact_as_org_viewer(
         api_client, org_viewer_user, organization, other_organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, route_1, route_2, integration_type_er
+        integrations_list_er, route_1, route_2, integration_type_er
 ):
     _test_filter_connections(
         api_client=api_client,
@@ -316,13 +320,13 @@ def test_filter_connections_by_owner_exact_as_org_viewer(
         filters={
             "owner": str(organization.id)
         },
-        expected_integrations=integrations_list[:5] + [provider_lotek_panthera]
+        expected_integrations=integrations_list_er[:5] + [provider_lotek_panthera]
     )
 
 
 def test_filter_connections_by_multiple_owners_as_org_viewer(
         api_client, org_viewer_user_2, organization, other_organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, route_1, route_2, integration_type_er
+        integrations_list_er, route_1, route_2, integration_type_er
 ):
     _test_filter_connections(
         api_client=api_client,
@@ -330,7 +334,7 @@ def test_filter_connections_by_multiple_owners_as_org_viewer(
         filters={
             "owner__in": ",".join([str(organization.id), str(other_organization.id)])
         },
-        expected_integrations=integrations_list[5:] + [provider_movebank_ewt]
+        expected_integrations=integrations_list_er[5:] + [provider_movebank_ewt]
     )
 
 
@@ -363,14 +367,14 @@ def test_global_search_connections_as_superuser(
         api_client, superuser, organization, other_organization,
         integration_type_er, integration_type_movebank, integration_type_lotek,
         integration_type_smart, smart_action_auth, smart_action_push_events,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera,
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera,
         route_1, route_2
 ):
     _test_global_search_connections(
         api_client=api_client,
         user=superuser,
         search_term="pamdas.org",  # Looking connections with earth ranger sites
-        expected_integrations=integrations_list + [provider_movebank_ewt, provider_lotek_panthera]  # Connected providers
+        expected_integrations=integrations_list_er + [provider_movebank_ewt, provider_lotek_panthera]  # Connected providers
     )
 
 
@@ -378,14 +382,14 @@ def test_global_search_connections_as_org_admin(
         api_client, org_admin_user, organization, other_organization,
         integration_type_er, integration_type_movebank, integration_type_lotek,
         integration_type_smart, smart_action_auth, smart_action_push_events,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera,
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera,
         route_1, route_2
 ):
     _test_global_search_connections(
         api_client=api_client,
         user=org_admin_user,
         search_term="Lewa",  # Looking connections owned by Lewa
-        expected_integrations=integrations_list[:5]+[provider_lotek_panthera]
+        expected_integrations=integrations_list_er[:5] + [provider_lotek_panthera]
     )
 
 
@@ -393,7 +397,7 @@ def test_global_search_connections_as_org_viewer(
         api_client, org_viewer_user_2, organization, other_organization,
         integration_type_er, integration_type_movebank, integration_type_lotek,
         integration_type_smart, smart_action_auth, smart_action_push_events,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera,
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera,
         route_1, route_2
 ):
     _test_global_search_connections(

--- a/cdip_admin/api/v2/tests/test_integrations_api.py
+++ b/cdip_admin/api/v2/tests/test_integrations_api.py
@@ -51,7 +51,7 @@ def _test_list_integrations(api_client, user, organization):
             assert "data" in configuration
 
 
-def test_list_integrations_as_superuser(api_client, superuser, organization, integrations_list):
+def test_list_integrations_as_superuser(api_client, superuser, organization, integrations_list_er):
     _test_list_integrations(
         api_client=api_client,
         user=superuser,
@@ -59,7 +59,7 @@ def test_list_integrations_as_superuser(api_client, superuser, organization, int
     )
 
 
-def test_list_integrations_as_org_admin(api_client, org_admin_user, organization, integrations_list):
+def test_list_integrations_as_org_admin(api_client, org_admin_user, organization, integrations_list_er):
     _test_list_integrations(
         api_client=api_client,
         user=org_admin_user,
@@ -67,7 +67,7 @@ def test_list_integrations_as_org_admin(api_client, org_admin_user, organization
     )
 
 
-def test_list_integrations_as_org_viewer(api_client, org_viewer_user, organization, integrations_list):
+def test_list_integrations_as_org_viewer(api_client, org_viewer_user, organization, integrations_list_er):
     _test_list_integrations(
         api_client=api_client,
         user=org_viewer_user,
@@ -422,8 +422,8 @@ def _test_filter_integrations(api_client, user, filters, expected_integrations):
         assert dest.get("id") in expected_integrations_ids
 
 
-def test_filter_integrations_exact_as_superuser(api_client, superuser, organization, integrations_list):
-    destination = integrations_list[0]
+def test_filter_integrations_exact_as_superuser(api_client, superuser, organization, integrations_list_er):
+    destination = integrations_list_er[0]
     _test_filter_integrations(
         api_client=api_client,
         user=superuser,
@@ -444,8 +444,8 @@ def test_filter_integrations_exact_as_superuser(api_client, superuser, organizat
     )
 
 
-def test_filter_integrations_iexact_as_superuser(api_client, superuser, organization, integrations_list):
-    destination = integrations_list[0]
+def test_filter_integrations_iexact_as_superuser(api_client, superuser, organization, integrations_list_er):
+    destination = integrations_list_er[0]
     _test_filter_integrations(
         api_client=api_client,
         user=superuser,
@@ -463,7 +463,7 @@ def test_filter_integrations_iexact_as_superuser(api_client, superuser, organiza
     )
 
 
-def test_filter_integrations_exact_as_org_admin(api_client, org_admin_user, organization, integrations_list):
+def test_filter_integrations_exact_as_org_admin(api_client, org_admin_user, organization, integrations_list_er):
     _test_filter_integrations(
         api_client=api_client,
         user=org_admin_user,
@@ -480,7 +480,8 @@ def test_filter_integrations_exact_as_org_admin(api_client, org_admin_user, orga
     )
 
 
-def test_filter_integrations_exact_as_org_viewer(api_client, org_viewer_user, organization, integration_type_er, integrations_list):
+def test_filter_integrations_exact_as_org_viewer(api_client, org_viewer_user, organization, integration_type_er,
+                                                 integrations_list_er):
     # Viewer belongs to organization which owns the first 5 integrations of type EarthRanger
     _test_filter_integrations(
         api_client=api_client,
@@ -498,10 +499,11 @@ def test_filter_integrations_exact_as_org_viewer(api_client, org_viewer_user, or
     )
 
 
-def test_filter_integrations_multiselect_as_superuser(api_client, superuser, organization, other_organization, integrations_list):
+def test_filter_integrations_multiselect_as_superuser(api_client, superuser, organization, other_organization,
+                                                      integrations_list_er):
     # Superuser can see integrations owned by any organizations
     owners = [organization, other_organization]
-    base_urls = [d.base_url for d in integrations_list[1::2]]
+    base_urls = [d.base_url for d in integrations_list_er[1::2]]
     _test_filter_integrations(
         api_client=api_client,
         user=superuser,
@@ -518,11 +520,12 @@ def test_filter_integrations_multiselect_as_superuser(api_client, superuser, org
     )
 
 
-def test_filter_integrations_multiselect_as_org_admin(api_client, org_admin_user, organization, other_organization, integrations_list):
+def test_filter_integrations_multiselect_as_org_admin(api_client, org_admin_user, organization, other_organization,
+                                                      integrations_list_er):
     # Org Admins can see integrations owned by the organizations they belong to
     # This org admin belongs to "organization" owning the first 5 integrations of "integrations_list"
     owners = org_admin_user.accountprofile.organizations.all()
-    base_urls = [d.base_url for d in integrations_list[:3]]  # Select three out of five possible base_urls
+    base_urls = [d.base_url for d in integrations_list_er[:3]]  # Select three out of five possible base_urls
     _test_filter_integrations(
         api_client=api_client,
         user=org_admin_user,
@@ -539,11 +542,12 @@ def test_filter_integrations_multiselect_as_org_admin(api_client, org_admin_user
     )
 
 
-def test_filter_integrations_multiselect_as_org_viewer(api_client, org_viewer_user, organization, other_organization, integrations_list):
+def test_filter_integrations_multiselect_as_org_viewer(api_client, org_viewer_user, organization, other_organization,
+                                                       integrations_list_er):
     # Org Viewer can see integrations owned by the organizations they belong to
     # This org viewer belongs to "organization" owning the first 5 integrations of "integrations_list"
     owners = org_viewer_user.accountprofile.organizations.all()
-    base_urls = [d.base_url for d in integrations_list[:2]]  # Select two out of five possible base_urls
+    base_urls = [d.base_url for d in integrations_list_er[:2]]  # Select two out of five possible base_urls
     _test_filter_integrations(
         api_client=api_client,
         user=org_viewer_user,
@@ -560,7 +564,8 @@ def test_filter_integrations_multiselect_as_org_viewer(api_client, org_viewer_us
     )
 
 
-def test_filter_integrations_by_action_type_as_superuser(api_client, superuser, organization, other_organization, integrations_list):
+def test_filter_integrations_by_action_type_as_superuser(api_client, superuser, organization, other_organization,
+                                                         integrations_list_er):
     _test_filter_integrations(
         api_client=api_client,
         user=superuser,
@@ -575,7 +580,8 @@ def test_filter_integrations_by_action_type_as_superuser(api_client, superuser, 
     )
 
 
-def test_filter_integrations_by_action_type_as_org_admin(api_client, org_admin_user, organization, other_organization, integrations_list):
+def test_filter_integrations_by_action_type_as_org_admin(api_client, org_admin_user, organization, other_organization,
+                                                         integrations_list_er):
     # Org Admins can see integrations owned by the organizations they belong to
     # This org admin belongs to "organization" owning the first 5 integrations of "integrations_list"
     _test_filter_integrations(
@@ -584,11 +590,12 @@ def test_filter_integrations_by_action_type_as_org_admin(api_client, org_admin_u
         filters={  # Integrations which can be used as data provider
             "action_type": IntegrationAction.ActionTypes.PULL_DATA.value
         },
-        expected_integrations=integrations_list[:5]
+        expected_integrations=integrations_list_er[:5]
     )
 
 
-def test_filter_integrations_by_action_type_as_org_viewer(api_client, org_viewer_user, organization, other_organization, integrations_list):
+def test_filter_integrations_by_action_type_as_org_viewer(api_client, org_viewer_user, organization, other_organization,
+                                                          integrations_list_er):
     # Org Viewer can see integrations owned by the organizations they belong to
     # This org viewer belongs to "organization" owning the first 5 integrations of "integrations_list"
     owners = org_viewer_user.accountprofile.organizations.all()
@@ -730,7 +737,7 @@ def test_filter_integrations_types_by_action_type_as_superuser(
         api_client, superuser, organization, other_organization,
         integration_type_er, integration_type_movebank, integration_type_lotek,
         integration_type_smart, smart_action_auth, smart_action_push_events,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera
 ):
     _test_filter_integration_types(
         api_client=api_client,
@@ -746,7 +753,7 @@ def test_filter_integrations_types_by_action_type_as_org_admin(
         api_client, org_admin_user, organization, other_organization,
         integration_type_er, integration_type_movebank, integration_type_lotek,
         integration_type_smart, smart_action_auth, smart_action_push_events,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera
 ):
     _test_filter_integration_types(
         api_client=api_client,
@@ -764,7 +771,7 @@ def test_filter_integrations_types_type_as_org_viewer(
         api_client, org_viewer_user, organization, other_organization,
         integration_type_er, integration_type_movebank, integration_type_lotek,
         integration_type_smart, smart_action_auth, smart_action_push_events,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera
 ):
     _test_filter_integration_types(
         api_client=api_client,
@@ -780,7 +787,7 @@ def test_filter_integrations_types_by_action_type_and_in_use_as_superuser(
         api_client, superuser, organization, other_organization,
         integration_type_er, integration_type_movebank, integration_type_lotek,
         integration_type_smart, smart_action_auth, smart_action_push_events,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera
 ):
     _test_filter_integration_types(
         api_client=api_client,
@@ -797,7 +804,7 @@ def test_filter_integrations_types_by_action_type_and_in_use_as_org_admin(
         api_client, org_admin_user_2, organization, other_organization,
         integration_type_er, integration_type_movebank, integration_type_lotek,
         integration_type_smart, smart_action_auth, smart_action_push_events,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera
 ):
     _test_filter_integration_types(
         api_client=api_client,
@@ -814,7 +821,7 @@ def test_filter_integrations_types_type_and_in_use_as_org_viewer(
         api_client, org_viewer_user, organization, other_organization,
         integration_type_er, integration_type_movebank, integration_type_lotek,
         integration_type_smart, smart_action_auth, smart_action_push_events,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera
 ):
     _test_filter_integration_types(
         api_client=api_client,
@@ -831,7 +838,7 @@ def test_filter_integrations_types_by_search_term_as_superuser(
         api_client, superuser, organization, other_organization,
         integration_type_er, integration_type_movebank, integration_type_lotek,
         integration_type_smart, smart_action_auth, smart_action_push_events,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera
 ):
     _test_filter_integration_types(
         api_client=api_client,
@@ -848,7 +855,7 @@ def test_filter_integrations_types_by_search_term_as_org_admin(
         api_client, org_admin_user, organization, other_organization,
         integration_type_er, integration_type_movebank, integration_type_lotek,
         integration_type_smart, smart_action_auth, smart_action_push_events,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera
 ):
     _test_filter_integration_types(
         api_client=api_client,
@@ -865,7 +872,7 @@ def test_filter_integrations_types_by_search_term_as_org_viewer(
         api_client, org_viewer_user_2, organization, other_organization,
         integration_type_er, integration_type_movebank, integration_type_lotek,
         integration_type_smart, smart_action_auth, smart_action_push_events,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera
 ):
     _test_filter_integration_types(
         api_client=api_client,
@@ -904,7 +911,7 @@ def test_filter_integrations_urls_by_search_term_as_superuser(
         api_client, superuser, organization, other_organization,
         integration_type_er, integration_type_movebank, integration_type_lotek,
         integration_type_smart, smart_action_auth, smart_action_push_events,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera,
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera,
 ):
     _test_filter_integration_urls(
         api_client=api_client,
@@ -922,7 +929,7 @@ def test_filter_integrations_urls_by_search_term_as_org_admin(
         api_client, org_admin_user, organization, other_organization,
         integration_type_er, integration_type_movebank, integration_type_lotek,
         integration_type_smart, smart_action_auth, smart_action_push_events,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera,
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera,
 ):
     _test_filter_integration_urls(
         api_client=api_client,
@@ -932,7 +939,7 @@ def test_filter_integrations_urls_by_search_term_as_org_admin(
         extra_filters={
             "action_type": "push"  # Integrations used as destinations
         },
-        expected_integrations=integrations_list[:5]  # First 5 ER integrations are owned by organization
+        expected_integrations=integrations_list_er[:5]  # First 5 ER integrations are owned by organization
     )
 
 
@@ -940,7 +947,7 @@ def test_filter_integrations_urls_by_search_term_as_org_viewer(
         api_client, org_viewer_user, organization, other_organization,
         integration_type_er, integration_type_movebank, integration_type_lotek,
         integration_type_smart, smart_action_auth, smart_action_push_events,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera,
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera,
 ):
     _test_filter_integration_urls(
         api_client=api_client,
@@ -980,7 +987,7 @@ def test_filter_integrations_owner_by_search_term_as_superuser(
         api_client, superuser, organization, other_organization,
         integration_type_er, integration_type_movebank, integration_type_lotek,
         integration_type_smart, smart_action_auth, smart_action_push_events,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera,
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera,
 ):
     _test_filter_integration_owners(
         api_client=api_client,
@@ -998,7 +1005,7 @@ def test_filter_integrations_owner_by_search_term_as_org_admin(
         api_client, org_admin_user, organization, other_organization,
         integration_type_er, integration_type_movebank, integration_type_lotek,
         integration_type_smart, smart_action_auth, smart_action_push_events,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera,
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera,
 ):
     _test_filter_integration_owners(
         api_client=api_client,
@@ -1016,7 +1023,7 @@ def test_filter_integrations_owner_by_search_term_as_org_viewer(
         api_client, org_viewer_user_2, organization, other_organization,
         integration_type_er, integration_type_movebank, integration_type_lotek,
         integration_type_smart, smart_action_auth, smart_action_push_events,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera,
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera,
 ):
     _test_filter_integration_owners(
         api_client=api_client,
@@ -1059,13 +1066,13 @@ def test_global_search_integrations_as_superuser(
         api_client, superuser, organization, other_organization,
         integration_type_er, integration_type_movebank, integration_type_lotek,
         integration_type_smart, smart_action_auth, smart_action_push_events,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera,
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera,
 ):
     _test_global_search_integrations(
         api_client=api_client,
         user=superuser,
         search_term="pamdas.org",  # Looking for earth ranger integrations
-        expected_integrations=integrations_list  # As superuser can see all the integrations
+        expected_integrations=integrations_list_er  # As superuser can see all the integrations
     )
 
 
@@ -1073,7 +1080,7 @@ def test_global_search_integrations_as_org_admin(
         api_client, org_admin_user_2, organization, other_organization,
         integration_type_er, integration_type_movebank, integration_type_lotek,
         integration_type_smart, smart_action_auth, smart_action_push_events,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera,
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera,
 ):
     _test_global_search_integrations(
         api_client=api_client,
@@ -1087,7 +1094,7 @@ def test_global_search_integrations_as_org_viewer(
         api_client, org_viewer_user, organization, other_organization,
         integration_type_er, integration_type_movebank, integration_type_lotek,
         integration_type_smart, smart_action_auth, smart_action_push_events,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera,
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera,
 ):
     _test_global_search_integrations(
         api_client=api_client,
@@ -1101,7 +1108,7 @@ def test_global_search_integrations_combined_with_filters_as_superuser(
         api_client, superuser, organization, other_organization,
         integration_type_er, integration_type_movebank, integration_type_lotek,
         integration_type_smart, smart_action_auth, smart_action_push_events,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera,
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera,
 ):
     _test_global_search_integrations(
         api_client=api_client,
@@ -1111,7 +1118,7 @@ def test_global_search_integrations_combined_with_filters_as_superuser(
         extra_filters={
             "action_type": "push"  # Destinations
         },
-        expected_integrations=integrations_list  # As superuser can see all the integrations
+        expected_integrations=integrations_list_er  # As superuser can see all the integrations
     )
 
 
@@ -1119,7 +1126,7 @@ def test_global_search_integrations_combined_with_filters_as_org_admin(
         api_client, org_admin_user_2, organization, other_organization,
         integration_type_er, integration_type_movebank, integration_type_lotek,
         integration_type_smart, smart_action_auth, smart_action_push_events,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera,
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera,
 ):
     _test_global_search_integrations(
         api_client=api_client,
@@ -1138,7 +1145,7 @@ def test_global_search_integrations_combined_with_filters_as_org_viewer(
         api_client, org_viewer_user, organization, other_organization,
         integration_type_er, integration_type_movebank, integration_type_lotek,
         integration_type_smart, smart_action_auth, smart_action_push_events,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera,
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera,
 ):
     _test_global_search_integrations(
         api_client=api_client,
@@ -1400,4 +1407,3 @@ def test_delete_integration_as_org_admin(
         user=org_admin_user,
         integration=provider_lotek_panthera
     )
-

--- a/cdip_admin/api/v2/tests/test_routes_api.py
+++ b/cdip_admin/api/v2/tests/test_routes_api.py
@@ -30,21 +30,21 @@ def _test_list_routes(api_client, user):
         assert "additional" in route
 
 
-def test_list_routes_as_superuser(api_client, superuser, organization, integrations_list):
+def test_list_routes_as_superuser(api_client, superuser, organization, integrations_list_er):
     _test_list_routes(
         api_client=api_client,
         user=superuser,
     )
 
 
-def test_list_routes_as_org_admin(api_client, org_admin_user, organization, integrations_list):
+def test_list_routes_as_org_admin(api_client, org_admin_user, organization, integrations_list_er):
     _test_list_routes(
         api_client=api_client,
         user=org_admin_user,
     )
 
 
-def test_list_routes_as_org_viewer(api_client, org_viewer_user, organization, integrations_list):
+def test_list_routes_as_org_viewer(api_client, org_viewer_user, organization, integrations_list_er):
     _test_list_routes(
         api_client=api_client,
         user=org_viewer_user,
@@ -77,7 +77,7 @@ def _test_create_route(api_client, user, data):
         assert response_data["configuration"] is not None
 
 
-def test_create_route_as_superuser(api_client, superuser, organization, integrations_list, provider_lotek_panthera):
+def test_create_route_as_superuser(api_client, superuser, organization, integrations_list_er, provider_lotek_panthera):
     _test_create_route(
         api_client=api_client,
         user=superuser,
@@ -88,7 +88,7 @@ def test_create_route_as_superuser(api_client, superuser, organization, integrat
                 str(provider_lotek_panthera.id)
             ],
             "destinations": [
-                str(i.id) for i in integrations_list[2:4]
+                str(i.id) for i in integrations_list_er[2:4]
             ],
             # "configuration": {},  # This should be optional
             "additional": {}
@@ -97,7 +97,7 @@ def test_create_route_as_superuser(api_client, superuser, organization, integrat
 
 
 def test_create_route_as_org_admin(
-        api_client, org_admin_user_2, organization, other_organization, integrations_list, provider_movebank_ewt
+        api_client, org_admin_user_2, organization, other_organization, integrations_list_er, provider_movebank_ewt
 ):
     _test_create_route(
         api_client=api_client,
@@ -109,7 +109,7 @@ def test_create_route_as_org_admin(
                 str(provider_movebank_ewt.id)
             ],
             "destinations": [
-                str(integrations_list[5].id)
+                str(integrations_list_er[5].id)
             ],
             "additional": {}
         }
@@ -117,7 +117,7 @@ def test_create_route_as_org_admin(
 
 
 def test_create_route_with_configuration_as_org_admin(
-        api_client, org_admin_user_2, organization, other_organization, integrations_list, provider_movebank_ewt
+        api_client, org_admin_user_2, organization, other_organization, integrations_list_er, provider_movebank_ewt
 ):
     _test_create_route(
         api_client=api_client,
@@ -129,7 +129,7 @@ def test_create_route_with_configuration_as_org_admin(
                 str(provider_movebank_ewt.id)
             ],
             "destinations": [
-                str(integrations_list[5].id)
+                str(integrations_list_er[5].id)
             ],
             "configuration": {
                 "name": "Route settings for EWT",
@@ -143,7 +143,7 @@ def test_create_route_with_configuration_as_org_admin(
 
 
 def test_create_route_with_configuration_id_as_org_admin(
-        api_client, org_admin_user_2, organization, other_organization, integrations_list, provider_movebank_ewt, route_2
+        api_client, org_admin_user_2, organization, other_organization, integrations_list_er, provider_movebank_ewt, route_2
 ):
     _test_create_route(
         api_client=api_client,
@@ -155,7 +155,7 @@ def test_create_route_with_configuration_id_as_org_admin(
                 str(provider_movebank_ewt.id)
             ],
             "destinations": [
-                str(integrations_list[5].id)
+                str(integrations_list_er[5].id)
             ],
             "configuration": str(route_2.configuration.id),  # Reuse config from other route
             "additional": {}
@@ -175,7 +175,7 @@ def _test_cannot_create_route(api_client, user, data):
 
 
 def test_cannot_create_route_as_org_viewer(
-        api_client, org_viewer_user, organization, other_organization, integrations_list, provider_movebank_ewt, route_2
+        api_client, org_viewer_user, organization, other_organization, integrations_list_er, provider_movebank_ewt, route_2
 ):
     _test_cannot_create_route(
         api_client=api_client,
@@ -187,7 +187,7 @@ def test_cannot_create_route_as_org_viewer(
                 str(provider_movebank_ewt.id)
             ],
             "destinations": [
-                str(integrations_list[5].id)
+                str(integrations_list_er[5].id)
             ],
             "configuration": str(route_2.configuration.id),  # Reuse config from other route
             "additional": {}
@@ -196,7 +196,7 @@ def test_cannot_create_route_as_org_viewer(
 
 
 def test_cannot_create_route_for_other_organization_as_org_admin(
-        api_client, org_admin_user, organization, other_organization, integrations_list, provider_movebank_ewt, route_2
+        api_client, org_admin_user, organization, other_organization, integrations_list_er, provider_movebank_ewt, route_2
 ):
     _test_cannot_create_route(
         api_client=api_client,
@@ -208,7 +208,7 @@ def test_cannot_create_route_for_other_organization_as_org_admin(
                 str(provider_movebank_ewt.id)
             ],
             "destinations": [
-                str(integrations_list[5].id)
+                str(integrations_list_er[5].id)
             ],
             "configuration": str(route_2.configuration.id),  # Reuse config from other route
             "additional": {}
@@ -245,17 +245,17 @@ def _test_retrieve_route_details(api_client, user, route):
 
 
 def test_retrieve_route_details_as_superuser(
-        api_client, superuser, organization, other_organization, integrations_list, route_1, route_2
+        api_client, superuser, organization, other_organization, integrations_list_er, route_1, route_2
 ):
     _test_retrieve_route_details(
         api_client=api_client,
         user=superuser,
-        route=integrations_list[0].default_route
+        route=integrations_list_er[0].default_route
     )
 
 
 def test_retrieve_route_details_as_org_admin(
-        api_client, org_admin_user, organization, other_organization, integrations_list, route_1, route_2
+        api_client, org_admin_user, organization, other_organization, integrations_list_er, route_1, route_2
 ):
     _test_retrieve_route_details(
         api_client=api_client,
@@ -265,7 +265,7 @@ def test_retrieve_route_details_as_org_admin(
 
 
 def test_retrieve_route_details_as_org_viewer(
-        api_client, org_viewer_user_2, organization, other_organization, integrations_list, route_1, route_2
+        api_client, org_viewer_user_2, organization, other_organization, integrations_list_er, route_1, route_2
 ):
     _test_retrieve_route_details(
         api_client=api_client,
@@ -283,7 +283,7 @@ def _test_cannot_retrieve_unrelated_route_details(api_client, user, route):
 
 
 def test_cannot_retrieve_unrelated_route_details_as_org_viewer(
-        api_client, org_viewer_user_2, organization, other_organization, integrations_list, route_1, route_2
+        api_client, org_viewer_user_2, organization, other_organization, integrations_list_er, route_1, route_2
 ):
     _test_cannot_retrieve_unrelated_route_details(
         api_client=api_client,
@@ -293,7 +293,7 @@ def test_cannot_retrieve_unrelated_route_details_as_org_viewer(
 
 
 def test_cannot_retrieve_unrelated_route_details_as_org_admin(
-        api_client, org_admin_user, organization, other_organization, integrations_list, route_1, route_2
+        api_client, org_admin_user, organization, other_organization, integrations_list_er, route_1, route_2
 ):
     _test_cannot_retrieve_unrelated_route_details(
         api_client=api_client,
@@ -359,7 +359,7 @@ def _test_full_update_route(api_client, user, route, new_data):
 
 
 def test_full_update_route_as_superuser(
-        api_client, superuser, organization, other_organization, integrations_list,
+        api_client, superuser, organization, other_organization, integrations_list_er,
         provider_lotek_panthera, provider_movebank_ewt, route_1, route_2, smart_integration, smart_route_configuration
 ):
     _test_full_update_route(
@@ -384,7 +384,7 @@ def test_full_update_route_as_superuser(
 
 
 def test_partial_update_route_as_superuser(
-        api_client, superuser, organization, other_organization, integrations_list,
+        api_client, superuser, organization, other_organization, integrations_list_er,
         provider_lotek_panthera, provider_movebank_ewt, route_1, route_2
 ):
     _test_partial_update_route(
@@ -398,7 +398,7 @@ def test_partial_update_route_as_superuser(
 
 
 def test_update_route_configuration_as_org_admin(
-        api_client, org_admin_user, organization, other_organization, integrations_list,
+        api_client, org_admin_user, organization, other_organization, integrations_list_er,
         provider_lotek_panthera, provider_movebank_ewt, route_1, route_2, er_route_configuration_rangers
 ):
     _test_partial_update_route(
@@ -412,7 +412,7 @@ def test_update_route_configuration_as_org_admin(
 
 
 def test_add_destination_in_default_route_as_superuser(
-        api_client, superuser, organization, other_organization, integrations_list,
+        api_client, superuser, organization, other_organization, integrations_list_er,
         provider_lotek_panthera, provider_movebank_ewt, route_1, route_2
 ):
     default_route = provider_lotek_panthera.default_route
@@ -422,13 +422,13 @@ def test_add_destination_in_default_route_as_superuser(
         user=superuser,
         route=default_route,
         new_data={  # Add one destination
-            "destinations": [*current_destinations, str(integrations_list[1].id)]
+            "destinations": [*current_destinations, str(integrations_list_er[1].id)]
         }
     )
 
 
 def test_add_destination_in_route_as_org_admin(
-        api_client, org_admin_user_2, organization, other_organization, integrations_list,
+        api_client, org_admin_user_2, organization, other_organization, integrations_list_er,
         provider_lotek_panthera, provider_movebank_ewt, route_1, route_2, smart_integration
 ):
     current_destinations = [str(d.id) for d in route_2.destinations.all()]
@@ -443,7 +443,7 @@ def test_add_destination_in_route_as_org_admin(
 
 
 def test_cannot_add_destination_in_route_as_org_viewer(
-        api_client, org_viewer_user_2, organization, other_organization, integrations_list,
+        api_client, org_viewer_user_2, organization, other_organization, integrations_list_er,
         provider_lotek_panthera, provider_movebank_ewt, route_1, route_2, smart_integration
 ):
     current_destinations = [str(d.id) for d in route_2.destinations.all()]
@@ -459,7 +459,7 @@ def test_cannot_add_destination_in_route_as_org_viewer(
 
 
 def test_cannot_add_destination_in_unrelated_route_as_org_admin(
-        api_client, org_admin_user, organization, other_organization, integrations_list,
+        api_client, org_admin_user, organization, other_organization, integrations_list_er,
         provider_lotek_panthera, provider_movebank_ewt, route_1, route_2, smart_integration
 ):
     current_destinations = [str(d.id) for d in route_2.destinations.all()]
@@ -475,7 +475,7 @@ def test_cannot_add_destination_in_unrelated_route_as_org_admin(
 
 
 def test_cannot_add_unrelated_destination_in_route_as_org_admin(
-        api_client, org_admin_user, organization, other_organization, integrations_list,
+        api_client, org_admin_user, organization, other_organization, integrations_list_er,
         provider_lotek_panthera, provider_movebank_ewt, route_1, route_2, smart_integration
 ):
     current_destinations = [str(d.id) for d in route_1.destinations.all()]
@@ -491,7 +491,7 @@ def test_cannot_add_unrelated_destination_in_route_as_org_admin(
 
 
 def test_cannot_change_route_owner_to_unrelated_org_as_org_admin(
-        api_client, org_admin_user, organization, other_organization, integrations_list,
+        api_client, org_admin_user, organization, other_organization, integrations_list_er,
         provider_lotek_panthera, provider_movebank_ewt, route_1, route_2, smart_integration
 ):
     api_client.force_authenticate(org_admin_user)
@@ -506,7 +506,7 @@ def test_cannot_change_route_owner_to_unrelated_org_as_org_admin(
 
 
 def test_update_data_provider_in_route_as_superuser(
-        api_client, superuser, organization, other_organization, integrations_list,
+        api_client, superuser, organization, other_organization, integrations_list_er,
         provider_lotek_panthera, provider_movebank_ewt, route_1, route_2
 ):
     default_route = provider_lotek_panthera.default_route
@@ -521,7 +521,7 @@ def test_update_data_provider_in_route_as_superuser(
 
 
 def test_update_data_provider_in_route_as_org_admin(
-        api_client, org_admin_user, organization, other_organization, integrations_list,
+        api_client, org_admin_user, organization, other_organization, integrations_list_er,
         provider_lotek_panthera, provider_movebank_ewt, route_1, route_2
 ):
     _test_partial_update_route(
@@ -529,20 +529,20 @@ def test_update_data_provider_in_route_as_org_admin(
         user=org_admin_user,
         route=route_1,
         new_data={  # Change the data provider
-            "data_providers": [str(integrations_list[2].id)]
+            "data_providers": [str(integrations_list_er[2].id)]
         }
     )
 
 
 def test_cannot_update_data_provider_in_route_as_org_viewer(
-        api_client, org_viewer_user_2, organization, other_organization, integrations_list,
+        api_client, org_viewer_user_2, organization, other_organization, integrations_list_er,
         provider_lotek_panthera, provider_movebank_ewt, route_1, route_2, smart_integration
 ):
     api_client.force_authenticate(org_viewer_user_2)
     response = api_client.patch(
         reverse("routes-detail", kwargs={"pk": route_2.id}),
         data={  # Change the data provider
-            "data_providers": [str(integrations_list[7].id)]
+            "data_providers": [str(integrations_list_er[7].id)]
         }
     )
     # Viewers cannot do write operations
@@ -550,7 +550,7 @@ def test_cannot_update_data_provider_in_route_as_org_viewer(
 
 
 def test_cannot_add_unrelated_provider_in_route_as_org_admin(
-        api_client, org_admin_user, organization, other_organization, integrations_list,
+        api_client, org_admin_user, organization, other_organization, integrations_list_er,
         provider_lotek_panthera, provider_movebank_ewt, route_1, route_2, smart_integration
 ):
     api_client.force_authenticate(org_admin_user)
@@ -581,7 +581,7 @@ def _test_cannot_delete_route(api_client, user, route):
 
 
 def test_delete_route_as_superuser(
-        api_client, superuser, organization, other_organization, integrations_list, route_1, route_2
+        api_client, superuser, organization, other_organization, integrations_list_er, route_1, route_2
 ):
     _test_delete_route(
         api_client=api_client,
@@ -591,7 +591,7 @@ def test_delete_route_as_superuser(
 
 
 def test_delete_route_as_org_admin(
-        api_client, org_admin_user, organization, other_organization, integrations_list, route_1, route_2
+        api_client, org_admin_user, organization, other_organization, integrations_list_er, route_1, route_2
 ):
     _test_delete_route(
         api_client=api_client,
@@ -601,7 +601,7 @@ def test_delete_route_as_org_admin(
 
 
 def test_cannot_delete_route_as_org_viewer(
-        api_client, org_viewer_user_2, organization, other_organization, integrations_list, route_1, route_2
+        api_client, org_viewer_user_2, organization, other_organization, integrations_list_er, route_1, route_2
 ):
     _test_cannot_delete_route(
         api_client=api_client,
@@ -611,7 +611,7 @@ def test_cannot_delete_route_as_org_viewer(
 
 
 def test_cannot_delete_unrelated_route_as_org_admin(
-        api_client, org_admin_user, organization, other_organization, integrations_list, route_1, route_2
+        api_client, org_admin_user, organization, other_organization, integrations_list_er, route_1, route_2
 ):
     _test_cannot_delete_route(
         api_client=api_client,
@@ -644,7 +644,7 @@ def _test_filter_routes(api_client, user, filters, expected_routes):
 
 def test_filter_routes_by_provider_as_superuser(
         api_client, superuser, organization, other_organization,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera,
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera,
         route_1, route_2
 ):
     _test_filter_routes(
@@ -659,10 +659,10 @@ def test_filter_routes_by_provider_as_superuser(
 
 def test_filter_routes_by_destination_as_superuser(
         api_client, superuser, organization, other_organization,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera,
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera,
         route_1, route_2
 ):
-    selected_destination = integrations_list[6]
+    selected_destination = integrations_list_er[6]
     _test_filter_routes(
         api_client=api_client,
         user=superuser,
@@ -675,10 +675,10 @@ def test_filter_routes_by_destination_as_superuser(
 
 def test_filter_routes_by_destination_url_as_superuser(
         api_client, superuser, organization, other_organization,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera,
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera,
         route_1, route_2
 ):
-    selected_destination = integrations_list[5]
+    selected_destination = integrations_list_er[5]
     _test_filter_routes(
         api_client=api_client,
         user=superuser,
@@ -691,10 +691,10 @@ def test_filter_routes_by_destination_url_as_superuser(
 
 def test_filter_routes_by_destination_url_as_org_admin(
         api_client, org_admin_user_2, organization, other_organization,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera,
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera,
         route_1, route_2
 ):
-    selected_destination = integrations_list[5]
+    selected_destination = integrations_list_er[5]
     _test_filter_routes(
         api_client=api_client,
         user=org_admin_user_2,
@@ -708,7 +708,7 @@ def test_filter_routes_by_destination_url_as_org_admin(
 
 def test_global_search_routes_by_route_name_as_superuser(
         api_client, superuser, organization, other_organization,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera,
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera,
         route_1, route_2
 ):
     _test_filter_routes(
@@ -724,7 +724,7 @@ def test_global_search_routes_by_route_name_as_superuser(
 
 def test_global_search_routes_by_destination_url_as_org_admin(
         api_client, org_admin_user, organization, other_organization,
-        integrations_list, provider_movebank_ewt, provider_lotek_panthera,
+        integrations_list_er, provider_movebank_ewt, provider_lotek_panthera,
         route_1, route_2
 ):
     selected_destination = route_1.destinations.last()

--- a/cdip_admin/api/v2/tests/test_sources_api.py
+++ b/cdip_admin/api/v2/tests/test_sources_api.py
@@ -35,7 +35,7 @@ def _test_list_sources(api_client, user, expected_sources, filters=None):
 
 def test_list_sources_as_superuser(
         api_client, superuser, organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, lotek_sources, movebank_sources, route_1, route_2,
+        integrations_list_er, lotek_sources, movebank_sources, route_1, route_2,
 
 ):
     _test_list_sources(
@@ -48,7 +48,7 @@ def test_list_sources_as_superuser(
 
 def test_list_sources_as_org_admin(
         api_client, org_admin_user, organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, lotek_sources, movebank_sources, route_1, route_2
+        integrations_list_er, lotek_sources, movebank_sources, route_1, route_2
 ):
     _test_list_sources(
         api_client=api_client,
@@ -60,7 +60,7 @@ def test_list_sources_as_org_admin(
 
 def test_list_sources_as_org_admin_2(
         api_client, org_admin_user_2, organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, lotek_sources, movebank_sources, route_1, route_2
+        integrations_list_er, lotek_sources, movebank_sources, route_1, route_2
 ):
     _test_list_sources(
         api_client=api_client,
@@ -72,7 +72,7 @@ def test_list_sources_as_org_admin_2(
 
 def test_list_sources_as_org_viewer(
         api_client, org_viewer_user, organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, lotek_sources, movebank_sources, route_1, route_2
+        integrations_list_er, lotek_sources, movebank_sources, route_1, route_2
 ):
     _test_list_sources(
         api_client=api_client,
@@ -84,7 +84,7 @@ def test_list_sources_as_org_viewer(
 
 def test_filter_sources_by_external_id_as_superuser(
         api_client, superuser, organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, lotek_sources, movebank_sources, route_1, route_2
+        integrations_list_er, lotek_sources, movebank_sources, route_1, route_2
 ):
     selected_sources = lotek_sources[1::2] + movebank_sources[:2]  # pick some sources semi-randomly
     _test_list_sources(
@@ -101,7 +101,7 @@ def test_filter_sources_by_external_id_as_superuser(
 
 def test_filter_sources_by_external_id_as_org_admin(
         api_client, org_admin_user_2, organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, lotek_sources, movebank_sources, route_1, route_2
+        integrations_list_er, lotek_sources, movebank_sources, route_1, route_2
 ):
     selected_sources = movebank_sources[::2]  # pick some sources semi-randomly
     _test_list_sources(
@@ -118,7 +118,7 @@ def test_filter_sources_by_external_id_as_org_admin(
 
 def test_filter_sources_by_external_id_as_org_viewer(
         api_client, org_viewer_user, organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, lotek_sources, movebank_sources, route_1, route_2
+        integrations_list_er, lotek_sources, movebank_sources, route_1, route_2
 ):
     _test_list_sources(
         api_client=api_client,
@@ -132,7 +132,7 @@ def test_filter_sources_by_external_id_as_org_viewer(
 
 def test_filter_sources_by_provider_type_as_superuser(
         api_client, superuser, organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, lotek_sources, movebank_sources, route_1, route_2
+        integrations_list_er, lotek_sources, movebank_sources, route_1, route_2
 ):
     _test_list_sources(
         api_client=api_client,
@@ -146,7 +146,7 @@ def test_filter_sources_by_provider_type_as_superuser(
 
 def test_filter_sources_by_provider_type_as_org_admin(
         api_client, org_admin_user_2, organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, lotek_sources, movebank_sources, route_1, route_2
+        integrations_list_er, lotek_sources, movebank_sources, route_1, route_2
 ):
     _test_list_sources(
         api_client=api_client,
@@ -160,7 +160,7 @@ def test_filter_sources_by_provider_type_as_org_admin(
 
 def test_filter_sources_by_provider_type_as_org_viewer(
         api_client, org_viewer_user_2, organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, lotek_sources, movebank_sources, route_1, route_2
+        integrations_list_er, lotek_sources, movebank_sources, route_1, route_2
 ):
     _test_list_sources(
         api_client=api_client,
@@ -174,7 +174,7 @@ def test_filter_sources_by_provider_type_as_org_viewer(
 
 def test_filter_sources_by_destination_type_as_superuser(
         api_client, superuser, organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, lotek_sources, movebank_sources, route_1, route_2, integration_type_er
+        integrations_list_er, lotek_sources, movebank_sources, route_1, route_2, integration_type_er
 ):
     _test_list_sources(
         api_client=api_client,
@@ -188,7 +188,7 @@ def test_filter_sources_by_destination_type_as_superuser(
 
 def test_filter_sources_by_destination_type_as_org_admin(
         api_client, org_admin_user, organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, lotek_sources, movebank_sources, route_1, route_2, integration_type_er
+        integrations_list_er, lotek_sources, movebank_sources, route_1, route_2, integration_type_er
 ):
     _test_list_sources(
         api_client=api_client,
@@ -202,7 +202,7 @@ def test_filter_sources_by_destination_type_as_org_admin(
 
 def test_filter_sources_by_destination_type_as_org_viewer(
         api_client, org_viewer_user_2, organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, lotek_sources, movebank_sources, route_1, route_2, integration_type_er
+        integrations_list_er, lotek_sources, movebank_sources, route_1, route_2, integration_type_er
 ):
     _test_list_sources(
         api_client=api_client,
@@ -216,9 +216,9 @@ def test_filter_sources_by_destination_type_as_org_viewer(
 
 def test_filter_sources_by_multiple_destination_urls_as_superuser(
         api_client, superuser, organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, lotek_sources, movebank_sources, route_1, route_2, integration_type_er
+        integrations_list_er, lotek_sources, movebank_sources, route_1, route_2, integration_type_er
 ):
-    selected_destinations = integrations_list[:6]  # All the sources are connected to the first 6
+    selected_destinations = integrations_list_er[:6]  # All the sources are connected to the first 6
     _test_list_sources(
         api_client=api_client,
         user=superuser,
@@ -233,9 +233,9 @@ def test_filter_sources_by_multiple_destination_urls_as_superuser(
 
 def test_filter_sources_by_multiple_destination_urls_as_org_admin(
         api_client, org_admin_user, organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, lotek_sources, movebank_sources, route_1, route_2, integration_type_er
+        integrations_list_er, lotek_sources, movebank_sources, route_1, route_2, integration_type_er
 ):
-    selected_destinations = integrations_list  # All the destinations
+    selected_destinations = integrations_list_er  # All the destinations
     _test_list_sources(
         api_client=api_client,
         user=org_admin_user,
@@ -250,9 +250,9 @@ def test_filter_sources_by_multiple_destination_urls_as_org_admin(
 
 def test_filter_sources_by_multiple_destination_urls_as_org_viewer(
         api_client, org_viewer_user_2, organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, lotek_sources, movebank_sources, route_1, route_2, integration_type_er
+        integrations_list_er, lotek_sources, movebank_sources, route_1, route_2, integration_type_er
 ):
-    selected_destinations = integrations_list  # All the destinations
+    selected_destinations = integrations_list_er  # All the destinations
     _test_list_sources(
         api_client=api_client,
         user=org_viewer_user_2,
@@ -267,7 +267,7 @@ def test_filter_sources_by_multiple_destination_urls_as_org_viewer(
 
 def test_filter_sources_by_owner_exact_as_superuser(
         api_client, superuser, organization, other_organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, lotek_sources, movebank_sources, route_1, route_2, integration_type_er
+        integrations_list_er, lotek_sources, movebank_sources, route_1, route_2, integration_type_er
 ):
     _test_list_sources(
         api_client=api_client,
@@ -281,7 +281,7 @@ def test_filter_sources_by_owner_exact_as_superuser(
 
 def test_filter_sources_by_multiple_owners_as_superuser(
         api_client, superuser, organization, other_organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, lotek_sources, movebank_sources, route_1, route_2, integration_type_er
+        integrations_list_er, lotek_sources, movebank_sources, route_1, route_2, integration_type_er
 ):
     _test_list_sources(
         api_client=api_client,
@@ -295,7 +295,7 @@ def test_filter_sources_by_multiple_owners_as_superuser(
 
 def test_filter_sources_by_owner_exact_as_org_admin(
         api_client, org_admin_user, organization, other_organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, lotek_sources, movebank_sources, route_1, route_2, integration_type_er
+        integrations_list_er, lotek_sources, movebank_sources, route_1, route_2, integration_type_er
 ):
     _test_list_sources(
         api_client=api_client,
@@ -309,7 +309,7 @@ def test_filter_sources_by_owner_exact_as_org_admin(
 
 def test_filter_sources_by_multiple_owners_as_org_admin(
         api_client, org_admin_user, organization, other_organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, lotek_sources, movebank_sources, route_1, route_2, integration_type_er
+        integrations_list_er, lotek_sources, movebank_sources, route_1, route_2, integration_type_er
 ):
     _test_list_sources(
         api_client=api_client,
@@ -323,7 +323,7 @@ def test_filter_sources_by_multiple_owners_as_org_admin(
 
 def test_filter_sources_by_owner_exact_as_org_viewer(
         api_client, org_viewer_user, organization, other_organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, lotek_sources, movebank_sources, route_1, route_2, integration_type_er
+        integrations_list_er, lotek_sources, movebank_sources, route_1, route_2, integration_type_er
 ):
     _test_list_sources(
         api_client=api_client,
@@ -337,7 +337,7 @@ def test_filter_sources_by_owner_exact_as_org_viewer(
 
 def test_filter_sources_by_multiple_owners_as_org_viewer(
         api_client, org_viewer_user_2, organization, other_organization, provider_lotek_panthera, provider_movebank_ewt,
-        integrations_list, lotek_sources, movebank_sources, route_1, route_2, integration_type_er
+        integrations_list_er, lotek_sources, movebank_sources, route_1, route_2, integration_type_er
 ):
     _test_list_sources(
         api_client=api_client,
@@ -378,7 +378,7 @@ def test_global_search_sources_as_superuser(
         api_client, superuser, organization, other_organization,
         integration_type_er, integration_type_movebank, integration_type_lotek,
         integration_type_smart, smart_action_auth, smart_action_push_events,
-        integrations_list, lotek_sources, movebank_sources, provider_movebank_ewt, provider_lotek_panthera,
+        integrations_list_er, lotek_sources, movebank_sources, provider_movebank_ewt, provider_lotek_panthera,
         route_1, route_2
 ):
     _test_list_sources(
@@ -395,7 +395,7 @@ def test_global_search_sources_as_org_admin(
         api_client, org_admin_user, organization, other_organization,
         integration_type_er, integration_type_movebank, integration_type_lotek,
         integration_type_smart, smart_action_auth, smart_action_push_events,
-        integrations_list, lotek_sources, movebank_sources, provider_movebank_ewt, provider_lotek_panthera,
+        integrations_list_er, lotek_sources, movebank_sources, provider_movebank_ewt, provider_lotek_panthera,
         route_1, route_2
 ):
     _test_list_sources(
@@ -412,7 +412,7 @@ def test_global_search_sources_as_org_viewer(
         api_client, org_viewer_user_2, organization, other_organization,
         integration_type_er, integration_type_movebank, integration_type_lotek,
         integration_type_smart, smart_action_auth, smart_action_push_events,
-        integrations_list, lotek_sources, movebank_sources, provider_movebank_ewt, provider_lotek_panthera,
+        integrations_list_er, lotek_sources, movebank_sources, provider_movebank_ewt, provider_lotek_panthera,
         route_1, route_2
 ):
     _test_list_sources(

--- a/cdip_admin/conftest.py
+++ b/cdip_admin/conftest.py
@@ -742,7 +742,7 @@ def cellstop_integration(
 
 
 @pytest.fixture
-def integrations_list(
+def integrations_list_er(
         organization,
         other_organization,
         integration_type_er,
@@ -836,14 +836,14 @@ def route_1(
         organization,
         lotek_sources,
         provider_lotek_panthera,
-        integrations_list,
+        integrations_list_er,
 ):
     rule, _ = Route.objects.get_or_create(
         name=f"Device Set to multiple destinations",
         owner=organization,
     )
     rule.data_providers.add(provider_lotek_panthera)
-    rule.destinations.add(*integrations_list)
+    rule.destinations.add(*integrations_list_er)
     # Filter data coming only from a subset of sources
     SourceFilter.objects.create(
         type=SourceFilter.SourceFilterTypes.SOURCE_LIST,
@@ -891,7 +891,7 @@ def route_2(
         other_organization,
         movebank_sources,
         provider_movebank_ewt,
-        integrations_list,
+        integrations_list_er,
         er_route_configuration_elephants,
 ):
     route, _ = Route.objects.get_or_create(
@@ -899,7 +899,7 @@ def route_2(
         owner=other_organization,
     )
     route.data_providers.add(provider_movebank_ewt)
-    route.destinations.add(integrations_list[5])
+    route.destinations.add(integrations_list_er[5])
     # Filter data coming only from a subset of sources
     SourceFilter.objects.create(
         type=SourceFilter.SourceFilterTypes.SOURCE_LIST,
@@ -1011,13 +1011,13 @@ def trap_tagger_to_movebank_observation_trace(provider_trap_tagger):
 
 
 @pytest.fixture
-def event_delivered_trace(provider_trap_tagger, integrations_list):
+def event_delivered_trace(provider_trap_tagger, integrations_list_er):
     trace = GundiTrace(
         # We save only IDs, no sensitive data is saved
         data_provider=provider_trap_tagger,
         related_to=None,
         object_type="ev",
-        destination=integrations_list[0],
+        destination=integrations_list_er[0],
         delivered_at="2023-07-10T19:35:34.425974Z",
         external_id="c258f9f7-1a2e-4932-8d60-3acd2f59a1b2",
     )
@@ -1026,13 +1026,13 @@ def event_delivered_trace(provider_trap_tagger, integrations_list):
 
 
 @pytest.fixture
-def event_delivered_trace2(provider_trap_tagger, integrations_list):
+def event_delivered_trace2(provider_trap_tagger, integrations_list_er):
     trace = GundiTrace(
         # We save only IDs, no sensitive data is saved
         data_provider=provider_trap_tagger,
         related_to=None,
         object_type="ev",
-        destination=integrations_list[1],
+        destination=integrations_list_er[1],
         delivered_at="2023-07-10T19:36:15.425974Z",
         external_id="b358f9f7-1a2e-4932-8d60-3acd2f59a15f",
     )
@@ -1042,14 +1042,14 @@ def event_delivered_trace2(provider_trap_tagger, integrations_list):
 
 @pytest.fixture
 def attachment_delivered_trace(
-        provider_trap_tagger, event_delivered_trace, integrations_list
+        provider_trap_tagger, event_delivered_trace, integrations_list_er
 ):
     trace = GundiTrace(
         # We save only IDs, no sensitive data is saved
         data_provider=provider_trap_tagger,
         related_to=event_delivered_trace.object_id,
         object_type="ev",
-        destination=integrations_list[0],
+        destination=integrations_list_er[0],
         delivered_at="2023-07-10T19:37:48.425974Z",
         external_id="c258f9f7-1a2e-4932-8d60-3acd2f59a1b2",
     )
@@ -1066,7 +1066,7 @@ def mock_cloud_storage(mocker):
 
 @pytest.fixture
 def trap_tagger_observation_delivered_event(
-        mocker, trap_tagger_event_trace, integrations_list
+        mocker, trap_tagger_event_trace, integrations_list_er
 ):
     message = mocker.MagicMock()
     event_dict = {
@@ -1079,7 +1079,7 @@ def trap_tagger_observation_delivered_event(
             "related_to": None,
             "external_id": "35983ced-1216-4d43-81da-01ee90ba9b80",
             "data_provider_id": str(trap_tagger_event_trace.data_provider.id),
-            "destination_id": str(integrations_list[0].id),
+            "destination_id": str(integrations_list_er[0].id),
             "delivered_at": "2023-07-11 18:19:19.215015+00:00",
         },
     }
@@ -1116,7 +1116,7 @@ def trap_tagger_to_movebank_observation_delivered_event(
 
 @pytest.fixture
 def trap_tagger_observation_delivered_event_two(
-        mocker, trap_tagger_event_trace, integrations_list
+        mocker, trap_tagger_event_trace, integrations_list_er
 ):
     message = mocker.MagicMock()
     event_dict = {
@@ -1129,7 +1129,7 @@ def trap_tagger_observation_delivered_event_two(
             "related_to": None,
             "external_id": "46983ced-1216-4d43-81da-01ee90ba9b81",
             "data_provider_id": str(trap_tagger_event_trace.data_provider.id),
-            "destination_id": str(integrations_list[1].id),
+            "destination_id": str(integrations_list_er[1].id),
             "delivered_at": "2023-07-11 18:19:19.215015+00:00",
         },
     }
@@ -1140,7 +1140,7 @@ def trap_tagger_observation_delivered_event_two(
 
 @pytest.fixture
 def trap_tagger_observation_delivery_failed_event(
-        mocker, trap_tagger_event_trace, integrations_list
+        mocker, trap_tagger_event_trace, integrations_list_er
 ):
     message = mocker.MagicMock()
     event_dict = {
@@ -1152,7 +1152,7 @@ def trap_tagger_observation_delivery_failed_event(
             "gundi_id": str(trap_tagger_event_trace.object_id),
             "related_to": None,
             "data_provider_id": str(trap_tagger_event_trace.data_provider.id),
-            "destination_id": str(integrations_list[0].id),
+            "destination_id": str(integrations_list_er[0].id),
             "delivered_at": "2023-07-11 18:19:19.215015+00:00",
         },
     }
@@ -1163,7 +1163,7 @@ def trap_tagger_observation_delivery_failed_event(
 
 @pytest.fixture
 def trap_tagger_observation_delivery_failed_event_two(
-        mocker, trap_tagger_event_trace, integrations_list
+        mocker, trap_tagger_event_trace, integrations_list_er
 ):
     message = mocker.MagicMock()
     event_dict = {
@@ -1175,7 +1175,7 @@ def trap_tagger_observation_delivery_failed_event_two(
             "gundi_id": str(trap_tagger_event_trace.object_id),
             "related_to": None,
             "data_provider_id": str(trap_tagger_event_trace.data_provider.id),
-            "destination_id": str(integrations_list[1].id),
+            "destination_id": str(integrations_list_er[1].id),
             "delivered_at": "2023-07-11 18:19:19.215015+00:00",
         },
     }
@@ -1778,8 +1778,8 @@ def observation_delivery_succeeded_event(provider_lotek_panthera, destination_mo
 
 
 @pytest.fixture
-def observation_delivery_succeeded_event_2(provider_movebank_ewt, integrations_list):
-    destination = integrations_list[0]
+def observation_delivery_succeeded_event_2(provider_movebank_ewt, integrations_list_er):
+    destination = integrations_list_er[0]
     return ActivityLog.objects.create(
         log_level=ActivityLog.LogLevels.DEBUG,
         log_type=ActivityLog.LogTypes.EVENT,
@@ -1821,8 +1821,8 @@ def observation_delivery_failed_event(provider_lotek_panthera, destination_moveb
 
 
 @pytest.fixture
-def observation_delivery_failed_event_2(provider_lotek_panthera, integrations_list):
-    destination = integrations_list[1]
+def observation_delivery_failed_event_2(provider_lotek_panthera, integrations_list_er):
+    destination = integrations_list_er[1]
     return ActivityLog.objects.create(
         log_level=ActivityLog.LogLevels.ERROR,
         log_type=ActivityLog.LogTypes.EVENT,
@@ -1924,7 +1924,7 @@ def pull_observations_action_custom_log_event(mocker, provider_lotek_panthera):
 
 
 @pytest.fixture
-def mock_dispatcher_secrets():
+def mock_dispatcher_secrets_er(dispatcher_source_release_1):
     return {'env_vars': {'REDIS_HOST': '127.0.0.1', 'BUCKET_NAME': 'cdip-files-dev', 'LOGGING_LEVEL': 'INFO',
                          'GCP_PROJECT_ID': 'cdip-test-proj', 'KEYCLOAK_REALM': 'cdip-test',
                          'KEYCLOAK_ISSUER': 'https://cdip-test.pamdas.org/auth/realms/cdip-dev',
@@ -1941,13 +1941,69 @@ def mock_dispatcher_secrets():
                                     'concurrency': 4, 'max_instances': 2, 'min_instances': 0,
                                     'vpc_connector': 'cdip-cloudrun-connector',
                                     'service_account': 'er-serverless-dispatchers@cdip-78ca.iam.gserviceaccount.com',
-                                    'source_code_path': 'er-serverless-dispatchers-v1-src.zip'}}
+                                    'source_code_path': dispatcher_source_release_1}}
 
 
 @pytest.fixture
-def mock_get_dispatcher_defaults_from_gcp_secrets(mocker, mock_dispatcher_secrets):
+def mock_dispatcher_secrets_smart(dispatcher_source_release_1):
+    return {'env_vars': {'REDIS_HOST': '127.0.0.1', 'BUCKET_NAME': 'cdip-files-dev', 'LOGGING_LEVEL': 'INFO',
+                         'GCP_PROJECT_ID': 'cdip-test-proj', 'KEYCLOAK_REALM': 'cdip-test',
+                         'KEYCLOAK_ISSUER': 'https://cdip-test.pamdas.org/auth/realms/cdip-dev',
+                         'KEYCLOAK_SERVER': 'https://cdip-test.pamdas.org', 'PORTAL_AUTH_TTL': '300',
+                         'DEAD_LETTER_TOPIC': 'dispatchers-dead-letter-dev', 'KEYCLOAK_AUDIENCE': 'cdip-test',
+                         'TRACE_ENVIRONMENT': 'dev', 'CLOUD_STORAGE_TYPE': 'google',
+                         'GUNDI_API_BASE_URL': 'https://api.dev.gundiservice.org', 'KEYCLOAK_CLIENT_ID': 'cdip-test-id',
+                         'CDIP_ADMIN_ENDPOINT': 'https://cdip-prod01.pamdas.org',
+                         'KEYCLOAK_CLIENT_UUID': 'test1234-5b2c-474b-99b1-aa85b8e6dabc',
+                         'MAX_EVENT_AGE_SECONDS': '86400',
+                         'KEYCLOAK_CLIENT_SECRET': 'test1234-d163-11ab-22b1-8f97f875e123',
+                         'DISPATCHER_EVENTS_TOPIC': 'dispatcher-events-dev'},
+            'deployment_settings': {'cpu': '1', 'region': 'us-central1', 'bucket_name': 'dispatchers-code-dev',
+                                    'concurrency': 4, 'max_instances': 2, 'min_instances': 0,
+                                    'vpc_connector': 'cdip-cloudrun-connector',
+                                    'service_account': 'er-serverless-dispatchers@cdip-78ca.iam.gserviceaccount.com',
+                                    'docker_image_url': dispatcher_source_release_1}}
+
+
+@pytest.fixture
+def mock_dispatcher_secrets_wps_watch(dispatcher_source_release_1):
+    return {'env_vars': {'REDIS_HOST': '127.0.0.1', 'BUCKET_NAME': 'cdip-files-dev', 'LOGGING_LEVEL': 'INFO',
+                         'GCP_PROJECT_ID': 'cdip-test-proj', 'KEYCLOAK_REALM': 'cdip-test',
+                         'KEYCLOAK_ISSUER': 'https://cdip-test.pamdas.org/auth/realms/cdip-dev',
+                         'KEYCLOAK_SERVER': 'https://cdip-test.pamdas.org', 'PORTAL_AUTH_TTL': '300',
+                         'DEAD_LETTER_TOPIC': 'dispatchers-dead-letter-dev', 'KEYCLOAK_AUDIENCE': 'cdip-test',
+                         'TRACE_ENVIRONMENT': 'dev', 'CLOUD_STORAGE_TYPE': 'google',
+                         'GUNDI_API_BASE_URL': 'https://api.dev.gundiservice.org', 'KEYCLOAK_CLIENT_ID': 'cdip-test-id',
+                         'CDIP_ADMIN_ENDPOINT': 'https://cdip-prod01.pamdas.org',
+                         'KEYCLOAK_CLIENT_UUID': 'test1234-5b2c-474b-99b1-aa85b8e6dabc',
+                         'MAX_EVENT_AGE_SECONDS': '86400',
+                         'KEYCLOAK_CLIENT_SECRET': 'test1234-d163-11ab-22b1-8f97f875e123',
+                         'DISPATCHER_EVENTS_TOPIC': 'dispatcher-events-dev'},
+            'deployment_settings': {'cpu': '1', 'region': 'us-central1', 'bucket_name': 'dispatchers-code-dev',
+                                    'concurrency': 4, 'max_instances': 2, 'min_instances': 0,
+                                    'vpc_connector': 'cdip-cloudrun-connector',
+                                    'service_account': 'er-serverless-dispatchers@cdip-78ca.iam.gserviceaccount.com',
+                                    'docker_image_url': dispatcher_source_release_1}}
+
+
+@pytest.fixture
+def mock_get_dispatcher_defaults_from_gcp_secrets(mocker, mock_dispatcher_secrets_er):
     mock = mocker.MagicMock()
-    mock.return_value = mock_dispatcher_secrets
+    mock.return_value = mock_dispatcher_secrets_er
+    return mock
+
+
+@pytest.fixture
+def mock_get_dispatcher_defaults_from_gcp_secrets_smart(mocker, mock_dispatcher_secrets_smart):
+    mock = mocker.MagicMock()
+    mock.return_value = mock_dispatcher_secrets_smart
+    return mock
+
+
+@pytest.fixture
+def mock_get_dispatcher_defaults_from_gcp_secrets_wps_watch(mocker, mock_dispatcher_secrets_wps_watch):
+    mock = mocker.MagicMock()
+    mock.return_value = mock_dispatcher_secrets_wps_watch
     return mock
 
 
@@ -2388,3 +2444,105 @@ def eula_v2():
         version="Gundi_EULA_2024-05-05",
         eula_url="https://projectgundi.org/Legal-Pages/User-Agreement"
     )
+
+@pytest.fixture
+def dispatcher_source_release_1():
+    return "release-20231218"
+
+
+@pytest.fixture
+def dispatcher_source_release_2():
+    return "release-20240510"
+
+
+@pytest.fixture
+def outbound_integrations_list_er(
+        mocker, settings, mock_get_dispatcher_defaults_from_gcp_secrets,
+        organization, legacy_integration_type_earthranger
+):
+    # Override settings so a DispatcherDeployment is created
+    settings.GCP_ENVIRONMENT_ENABLED = True
+    # Mock the task to trigger the dispatcher deployment
+    mocked_deployment_task = mocker.MagicMock()
+    mocker.patch(
+        "deployments.models.deploy_serverless_dispatcher", mocked_deployment_task
+    )
+    # Mock calls to external services
+    mocker.patch("integrations.models.v1.models.get_dispatcher_defaults_from_gcp_secrets", mock_get_dispatcher_defaults_from_gcp_secrets)
+    # Patch on_commit to execute the function immediately
+    mocker.patch("deployments.models.transaction.on_commit", lambda fn: fn())
+    mocker.patch("integrations.models.v1.models.transaction.on_commit", lambda fn: fn())
+    integrations = []
+    for i in range(5):
+        integration = OutboundIntegrationConfiguration.objects.create(
+            name=f"EarthRanger Integration v1 Test {i}",
+            endpoint=f"https://test{i}.fakepamdas.org",
+            type=legacy_integration_type_earthranger,
+            owner=organization
+        )
+        integrations.append(integration)
+    return integrations
+
+
+@pytest.fixture
+def outbound_integrations_list_smart(
+        mocker, settings, mock_get_dispatcher_defaults_from_gcp_secrets_smart,
+        organization, legacy_integration_type_smart
+):
+    # Override settings so a DispatcherDeployment is created
+    settings.GCP_ENVIRONMENT_ENABLED = True
+    # Mock the task to trigger the dispatcher deployment
+    mocked_deployment_task = mocker.MagicMock()
+    mocker.patch(
+        "deployments.models.deploy_serverless_dispatcher", mocked_deployment_task
+    )
+    # Mock calls to external services
+    mocker.patch(
+        "integrations.models.v1.models.get_dispatcher_defaults_from_gcp_secrets",
+        mock_get_dispatcher_defaults_from_gcp_secrets_smart
+    )
+    # Patch on_commit to execute the function immediately
+    mocker.patch("deployments.models.transaction.on_commit", lambda fn: fn())
+    mocker.patch("integrations.models.v1.models.transaction.on_commit", lambda fn: fn())
+    integrations = []
+    for i in range(5):
+        integration = OutboundIntegrationConfiguration.objects.create(
+            name=f"SMART Integration v1 Test {i}",
+            endpoint=f"https://test{i}.fakesmartconnect.com",
+            type=legacy_integration_type_smart,
+            owner=organization
+        )
+        integrations.append(integration)
+    return integrations
+
+
+@pytest.fixture
+def outbound_integrations_list_wpswatch(
+        mocker, settings, mock_get_dispatcher_defaults_from_gcp_secrets_wps_watch,
+        organization, legacy_integration_type_wpswatch
+):
+    # Override settings so a DispatcherDeployment is created
+    settings.GCP_ENVIRONMENT_ENABLED = True
+    # Mock the task to trigger the dispatcher deployment
+    mocked_deployment_task = mocker.MagicMock()
+    mocker.patch(
+        "deployments.models.deploy_serverless_dispatcher", mocked_deployment_task
+    )
+    # Mock calls to external services
+    mocker.patch(
+        "integrations.models.v1.models.get_dispatcher_defaults_from_gcp_secrets",
+        mock_get_dispatcher_defaults_from_gcp_secrets_wps_watch
+    )
+    # Patch on_commit to execute the function immediately
+    mocker.patch("deployments.models.transaction.on_commit", lambda fn: fn())
+    mocker.patch("integrations.models.v1.models.transaction.on_commit", lambda fn: fn())
+    integrations = []
+    for i in range(5):
+        integration = OutboundIntegrationConfiguration.objects.create(
+            name=f"WPS Watch Integration v1 Test {i}",
+            endpoint=f"https://test{i}.fakeswpswatch.com",
+            type=legacy_integration_type_wpswatch,
+            owner=organization
+        )
+        integrations.append(integration)
+    return integrations

--- a/cdip_admin/conftest.py
+++ b/cdip_admin/conftest.py
@@ -516,6 +516,17 @@ def integration_type_wpswatch():
 
 
 @pytest.fixture
+def wpswatch_action_push_events(integration_type_wpswatch):
+    return IntegrationAction.objects.create(
+        integration_type=integration_type_wpswatch,
+        type=IntegrationAction.ActionTypes.PUSH_DATA,
+        name="Push Events",
+        value="push_events",
+        description="Push Event data to WPA Watch API",
+    )
+
+
+@pytest.fixture
 def provider_lotek_panthera(
         get_random_id,
         organization,
@@ -743,6 +754,9 @@ def cellstop_integration(
 
 @pytest.fixture
 def integrations_list_er(
+        mocker,
+        settings,
+        mock_get_dispatcher_defaults_from_gcp_secrets,
         organization,
         other_organization,
         integration_type_er,
@@ -753,6 +767,19 @@ def integrations_list_er(
         er_action_push_positions,
         er_action_push_events,
 ):
+    # Override settings so a DispatcherDeployment is created
+    settings.GCP_ENVIRONMENT_ENABLED = True
+    # Mock the task to trigger the dispatcher deployment
+    mocked_deployment_task = mocker.MagicMock()
+    mocker.patch(
+        "deployments.models.deploy_serverless_dispatcher", mocked_deployment_task
+    )
+    # Mock calls to external services
+    mocker.patch("integrations.models.v2.models.get_dispatcher_defaults_from_gcp_secrets",
+                 mock_get_dispatcher_defaults_from_gcp_secrets)
+    # Patch on_commit to execute the function immediately
+    mocker.patch("deployments.models.transaction.on_commit", lambda fn: fn())
+    mocker.patch("integrations.models.v2.models.transaction.on_commit", lambda fn: fn())
     integrations = []
     for i in range(10):
         # Create the integration
@@ -785,6 +812,98 @@ def integrations_list_er(
         )
         IntegrationConfiguration.objects.create(
             integration=integration, action=er_action_pull_events
+        )
+        integrations.append(integration)
+        ensure_default_route(integration=integration)
+    return integrations
+
+
+@pytest.fixture
+def integrations_list_smart(
+        mocker,
+        settings,
+        mock_get_dispatcher_defaults_from_gcp_secrets_smart,
+        organization,
+        other_organization,
+        integration_type_smart,
+        get_random_id,
+        smart_action_auth,
+        smart_action_push_events,
+):
+    # Override settings so a DispatcherDeployment is created
+    settings.GCP_ENVIRONMENT_ENABLED = True
+    # Mock the task to trigger the dispatcher deployment
+    mocked_deployment_task = mocker.MagicMock()
+    mocker.patch(
+        "deployments.models.deploy_serverless_dispatcher", mocked_deployment_task
+    )
+    # Mock calls to external services
+    mocker.patch("integrations.models.v2.models.get_dispatcher_defaults_from_gcp_secrets",
+                 mock_get_dispatcher_defaults_from_gcp_secrets_smart)
+    # Patch on_commit to execute the function immediately
+    mocker.patch("deployments.models.transaction.on_commit", lambda fn: fn())
+    mocker.patch("integrations.models.v2.models.transaction.on_commit", lambda fn: fn())
+    integrations = []
+    for i in range(5):
+        # Create the integration
+        site_url = f"{get_random_id()}.smart.fakewps.org"
+        integration, _ = Integration.objects.get_or_create(
+            type=integration_type_smart,
+            name=f"SMART Site Test {i}",
+            owner=organization if i < 5 else other_organization,
+            base_url=site_url,
+        )
+        # Configure actions
+        IntegrationConfiguration.objects.create(
+            integration=integration,
+            action=smart_action_auth,
+            data={
+                "api_key": f"SMART-{get_random_id()}-KEY",
+            },
+        )
+        IntegrationConfiguration.objects.create(
+            integration=integration, action=smart_action_push_events
+        )
+        integrations.append(integration)
+        ensure_default_route(integration=integration)
+    return integrations
+
+
+@pytest.fixture
+def integrations_list_wpswatch(
+        mocker,
+        settings,
+        mock_get_dispatcher_defaults_from_gcp_secrets_wps_watch,
+        organization,
+        integration_type_wpswatch,
+        get_random_id,
+        wpswatch_action_push_events
+):
+    # Override settings so a DispatcherDeployment is created
+    settings.GCP_ENVIRONMENT_ENABLED = True
+    # Mock the task to trigger the dispatcher deployment
+    mocked_deployment_task = mocker.MagicMock()
+    mocker.patch(
+        "deployments.models.deploy_serverless_dispatcher", mocked_deployment_task
+    )
+    # Mock calls to external services
+    mocker.patch("integrations.models.v2.models.get_dispatcher_defaults_from_gcp_secrets",
+                 mock_get_dispatcher_defaults_from_gcp_secrets_wps_watch)
+    # Patch on_commit to execute the function immediately
+    mocker.patch("deployments.models.transaction.on_commit", lambda fn: fn())
+    mocker.patch("integrations.models.v2.models.transaction.on_commit", lambda fn: fn())
+    integrations = []
+    for i in range(5):
+        # Create the integration
+        site_url = f"{get_random_id()}.wpswatch.fakewps.org"
+        integration, _ = Integration.objects.get_or_create(
+            type=integration_type_wpswatch,
+            name=f"WPS Watch Site Test {i}",
+            owner=organization,
+            base_url=site_url,
+        )
+        IntegrationConfiguration.objects.create(
+            integration=integration, action=wpswatch_action_push_events
         )
         integrations.append(integration)
         ensure_default_route(integration=integration)

--- a/cdip_admin/deployments/management/commands/dispatchers.py
+++ b/cdip_admin/deployments/management/commands/dispatchers.py
@@ -109,7 +109,7 @@ class Command(BaseCommand):
                 IntegrationModel = Integration if options.get("v2") else OutboundIntegrationConfiguration
                 type_cleaned = type.lower().strip()
                 integration_type_q = Q(type__value=type_cleaned) if options.get("v2") else Q(type__slug=type_cleaned)
-                source_field = "docker_image_url" if options.get("v2") else "source_code_path"
+                source_field = "source_code_path" if type_cleaned == "earth_ranger"  else "docker_image_url"
                 source_lookup = f"{related_dispatcher_field}__configuration__deployment_settings__{source_field}"
                 source_outdated_q = ~Q(**{source_lookup: source})
                 integrations_to_update = IntegrationModel.objects.filter(

--- a/cdip_admin/deployments/management/commands/dispatchers.py
+++ b/cdip_admin/deployments/management/commands/dispatchers.py
@@ -56,10 +56,20 @@ class Command(BaseCommand):
             help="Deploy serverless dispatchers for integrations using legacy dispatchers",
         )
         parser.add_argument(
+            "--update-source",
+            type=str,
+            help="Update source code of serverless dispatchers with the specified version",
+        )
+        parser.add_argument(
             "--max",
             type=int,
             default=10,
             help="Specify the maximum number of deployments to list or deploy",
+        )
+        parser.add_argument(
+            "--integration",
+            type=str,
+            help="Select a single integration by ID",
         )
 
     def handle(self, *args, **options):
@@ -68,34 +78,50 @@ class Command(BaseCommand):
             self.list_deployments(options=options)
         elif options["list_missing"]:
             self.list_integrations_using_kafka_dispatchers(options=options)
-        elif integration_id := options["deploy"]:
+        elif integration_id := options.get("deploy"):
+            integration = self._get_integration_by_id(integration_id=integration_id, options=options)
+            self.deploy_dispatchers([integration])
+        elif options["deploy_missing"]:
             if not options.get("v1") and not options.get("v2"):
                 self.stdout.write("Please specify a Gundi version (v1 or v2)")
                 return
-            integration = None
-            if options["v1"]:
-                try:
-                    integration = OutboundIntegrationConfiguration.objects.get(
-                        id=integration_id
-                    )
-                except OutboundIntegrationConfiguration.DoesNotExist:
-                    self.stdout.write(f"Integration {integration_id} v1 not found")
-                    return
-            if options["v2"]:
-                try:
-                    integration = Integration.objects.get(id=integration_id)
-                except Integration.DoesNotExist:
-                    self.stdout.write(f"Integration {integration_id} v2 not found")
-                    return
-            self.deploy_dispatchers([integration])
-        elif options["deploy_missing"]:
             integrations = self._get_integrations_using_kafka_dispatchers()
             if type := options["type"]:
                 integrations = integrations.filter(type__slug=type.lower().strip())
             if max_deploys := options["max"]:
                 integrations = integrations[:max_deploys]
             self.deploy_dispatchers(integrations)
-
+        elif source := options.get("update_source"):
+            if not options.get("v1") and not options.get("v2"):
+                self.stdout.write("Please specify a Gundi version (v1 or v2)")
+                return
+            if integration_id := options["integration"]:
+                integration = self._get_integration_by_id(integration_id=integration_id, options=options)
+                if not integration:
+                    self.stderr.write("Integration not found")
+                    return
+                new_settings = {"source_code_path": source} if integration.is_er_site else {"docker_image_url": source}
+                integrations_to_update = [integration]
+            elif type := options.get("type"):
+                if "max" not in options:
+                    self.stdout.write("Please either specify a maximum number of integrations to update or an integration ID")
+                    return
+                new_settings = {"source_code_path": source} if type == "earthranger" else {"docker_image_url": source}
+                if options.get("v1"):
+                    integrations_to_update = OutboundIntegrationConfiguration.objects.filter(
+                        type__slug=type.lower().strip()
+                    )[:options["max"]]
+                else:
+                    integrations_to_update = Integration.objects.filter(
+                        type__value=type.lower().strip()
+                    )[:options["max"]]
+            else:
+                self.stdout.write("Please specify an integration ID or a type")
+                return
+            self.update_dispatchers(
+                integrations=integrations_to_update,
+                deployment_settings=new_settings
+            )
         self.stdout.write(self.style.SUCCESS("Done."))
 
     def list_deployments(self, options):
@@ -217,6 +243,48 @@ class Command(BaseCommand):
                     f"Deployment triggered for {integration.name} ({version})"
                 )
 
+    def update_dispatchers(self, integrations, env_vars=None, deployment_settings=None):
+        self.stdout.write(self.style.SUCCESS(f"Updating dispatchers for {len(integrations)} integrations..."))
+        for integration in integrations:
+            try:
+                # Skip if the integration is not an ER, SMART site, or WPS Watch Site
+                if not (integration.is_er_site or integration.is_smart_site or integration.is_wpswatch_site):
+                    self.stdout.write(
+                        f"Integration {integration.name} is not an ER, SMART or WPS Watch site. Skipped"
+                    )
+                    continue
+
+                self.stdout.write(
+                    f"Updating dispatcher for {integration.name} with env_vars: {env_vars}, deployment_settings {deployment_settings}..."
+                )
+
+                if isinstance(integration, OutboundIntegrationConfiguration):
+                    version = "v1"
+                    dispatcher_deployment = integration.dispatcher_by_outbound
+                elif isinstance(integration, Integration):
+                    version = "v2"
+                    dispatcher_deployment = integration.dispatcher_by_integration
+                else:
+                    self.stdout.write(
+                        f"Unknown integration type: {integration}. Skipped"
+                    )
+                    continue
+                # Updating the dispatcher configuration will triggers the re-deployment
+                if env_vars:
+                    dispatcher_deployment.configuration["env_vars"].update(env_vars)
+                if deployment_settings:
+                    dispatcher_deployment.configuration["deployment_settings"].update(deployment_settings)
+                dispatcher_deployment.save()
+
+            except Exception as e:
+                self.stdout.write(
+                    f"Error deploying dispatcher for {integration.name}: {e}"
+                )
+            else:
+                self.stdout.write(
+                    f"Update triggered for {integration.name} ({version})\nDispatcher: {dispatcher_deployment.name}"
+                )
+
     def list_integrations_using_kafka_dispatchers(self, options):
         integrations = self._get_integrations_using_kafka_dispatchers()
         if type := options["type"]:
@@ -233,3 +301,21 @@ class Command(BaseCommand):
         return OutboundIntegrationConfiguration.objects.filter(
             ~Q(additional__has_key="broker") | Q(additional__broker="kafka")
         )
+
+    def _get_integration_by_id(self, integration_id, options):
+        integration = None
+        if options["v1"]:
+            try:
+                integration = OutboundIntegrationConfiguration.objects.get(
+                    id=integration_id
+                )
+            except OutboundIntegrationConfiguration.DoesNotExist:
+                self.stdout.write(f"Integration {integration_id} v1 not found")
+                return None
+        if options["v2"]:
+            try:
+                integration = Integration.objects.get(id=integration_id)
+            except Integration.DoesNotExist:
+                self.stdout.write(f"Integration {integration_id} v2 not found")
+                return None
+        return integration

--- a/cdip_admin/deployments/management/commands/dispatchers.py
+++ b/cdip_admin/deployments/management/commands/dispatchers.py
@@ -114,7 +114,7 @@ class Command(BaseCommand):
                 source_outdated_q = ~Q(**{source_lookup: source})
                 integrations_to_update = IntegrationModel.objects.filter(
                     integration_type_q & source_outdated_q
-                )[:options["max"]]
+                ).order_by("name")[:options["max"]]
                 new_settings = {"source_code_path": source} if type_cleaned == "earth_ranger" else {"docker_image_url": source}
             else:
                 self.stdout.write("Please specify an integration ID or a type")

--- a/cdip_admin/deployments/tests/test_commands.py
+++ b/cdip_admin/deployments/tests/test_commands.py
@@ -133,6 +133,7 @@ def test_call_dispatchers_command_deploy_with_integration_id(
     assert mock_deploy_serverless_dispatcher.delay.called
 
 
+@pytest.mark.parametrize("gundi_version", ["v1", "v2"])
 @pytest.mark.parametrize("integration_type", [
     "earth_ranger",
     "smart_connect",
@@ -141,16 +142,22 @@ def test_call_dispatchers_command_deploy_with_integration_id(
 @override_settings(GCP_ENVIRONMENT_ENABLED=True)
 def test_call_dispatchers_command_update_source_by_type_with_max_v1(
     request,
+    gundi_version,
     integration_type,
     mocker,
     capsys,
     organization,
-    outbound_integrations_list_er,
-    outbound_integrations_list_smart,
-    outbound_integrations_list_wpswatch,
     dispatcher_source_release_1,
     dispatcher_source_release_2
 ):
+    if gundi_version == "v1":
+        integrations_er = request.getfixturevalue("outbound_integrations_list_er")
+        integrations_smart = request.getfixturevalue("outbound_integrations_list_smart")
+        integrations_wps = request.getfixturevalue("outbound_integrations_list_wpswatch")
+    else:
+        integrations_er = request.getfixturevalue("integrations_list_er")
+        integrations_smart = request.getfixturevalue("integrations_list_smart")
+        integrations_wps = request.getfixturevalue("integrations_list_wpswatch")
     # Mock the celery task doing the actual deployment
     mocker.patch("deployments.models.transaction.on_commit", lambda fn: fn())
     mock_deploy_serverless_dispatcher = mocker.MagicMock()
@@ -160,31 +167,33 @@ def test_call_dispatchers_command_update_source_by_type_with_max_v1(
     )
 
     call_command(
-        "dispatchers", "--v1", "--type", integration_type, "--max", "2", "--update-source", dispatcher_source_release_2
+        "dispatchers", f"--{gundi_version}", "--type", integration_type, "--max", "2", "--update-source", dispatcher_source_release_2
     )
     captured = capsys.readouterr()
 
     source_key = "source_code_path" if integration_type == "earth_ranger" else "docker_image_url"
     if integration_type == "earth_ranger":
-        integrations_list = outbound_integrations_list_er
+        integrations_list = integrations_er
     elif integration_type == "smart_connect":
-        integrations_list = outbound_integrations_list_smart
+        integrations_list = integrations_smart
     else:
-        integrations_list = outbound_integrations_list_wpswatch
+        integrations_list = integrations_wps
     sorted_integrations = sorted(integrations_list, key=lambda i: i.name)
     for integration in sorted_integrations[:2]:
         # Check that configuration was updated to the new release
         integration.refresh_from_db()
-        source_code_settings = integration.dispatcher_by_outbound.configuration.get("deployment_settings", {}).get(source_key)
+        dispatcher = integration.dispatcher_by_outbound if gundi_version == "v1" else integration.dispatcher_by_integration
+        source_code_settings = dispatcher.configuration.get("deployment_settings", {}).get(source_key)
         assert source_code_settings == dispatcher_source_release_2
         # Check the command output
         assert f"Updating dispatcher for {integration.name} with env_vars: None, deployment_settings {{'{source_key}': '{dispatcher_source_release_2}'}}..." in captured.out
         assert f"Update triggered for {integration.name}" in captured.out
 
     for integration in sorted_integrations[2:]:
-        # Check that configuration was not updated
+        # Check that configuration of other integrations was not updated
         integration.refresh_from_db()
-        source_code_settings = integration.dispatcher_by_outbound.configuration.get("deployment_settings", {}).get(source_key)
+        dispatcher = integration.dispatcher_by_outbound if gundi_version == "v1" else integration.dispatcher_by_integration
+        source_code_settings = dispatcher.configuration.get("deployment_settings", {}).get(source_key)
         assert source_code_settings == dispatcher_source_release_1
 
     # Check that the deploy task was called for the two ER integrations being updated

--- a/cdip_admin/integrations/models/v1/models.py
+++ b/cdip_admin/integrations/models/v1/models.py
@@ -223,9 +223,8 @@ class OutboundIntegrationConfiguration(TimestampedModel):
         return f"{self.owner.name} - {self.name} - {self.type.name}"
 
     def _pre_save(self, *args, **kwargs):
-        # Use pubsub for ER, SMART, WPS Watch and MoveBank Sites
-        # ToDo. We will use PubSub for all the sites in the future, once me migrate SMART and WPSWatch dispatchers
-        if self._state.adding and any([self.is_er_site, self.is_smart_site, self.is_mb_site, self.is_wpswatch_site]):
+        # Setup topic and broker for destination sites
+        if self._state.adding:
             if "topic" not in self.additional:
                 self.additional.update({"topic": get_dispatcher_topic_default_name(integration=self, gundi_version="v1")})
             if "broker" not in self.additional:

--- a/cdip_admin/integrations/models/v2/models.py
+++ b/cdip_admin/integrations/models/v2/models.py
@@ -163,8 +163,13 @@ class Integration(ChangeLogMixin, UUIDAbstractModel, TimestampedModel):
     def _post_save(self, *args, **kwargs):
         created = kwargs.get("created", False)
         # Deploy serverless dispatcher for ER Sites only
-        if created and settings.GCP_ENVIRONMENT_ENABLED and any([self.is_er_site, self.is_smart_site, self.is_mb_site, self.is_wpswatch_site]):
-            secret_id = settings.DISPATCHER_DEFAULTS_SECRET if self.is_er_site else settings.DISPATCHER_DEFAULTS_SECRET_SMART
+        if created and settings.GCP_ENVIRONMENT_ENABLED and any([self.is_er_site, self.is_smart_site, self.is_wpswatch_site]):
+            if self.is_smart_site:
+                secret_id = settings.DISPATCHER_DEFAULTS_SECRET_SMART
+            elif self.is_wpswatch_site:
+                secret_id = settings.DISPATCHER_DEFAULTS_SECRET_WPSWATCH
+            else:
+                secret_id = settings.DISPATCHER_DEFAULTS_SECRET
             DispatcherDeployment.objects.create(
                 name=get_default_dispatcher_name(integration=self),
                 integration=self,

--- a/cdip_admin/integrations/models/v2/models.py
+++ b/cdip_admin/integrations/models/v2/models.py
@@ -153,9 +153,8 @@ class Integration(ChangeLogMixin, UUIDAbstractModel, TimestampedModel):
         return f"{self.owner.name} - {self.name} - {self.type.name}"
 
     def _pre_save(self, *args, **kwargs):
-        # Use pubsub for ER, SMART and MoveBank Sites
-        # ToDo. We will use PubSub for all the sites in the future, once me migrate SMART and WPSWatch dispatchers
-        if self._state.adding and (self.is_er_site or self.is_smart_site or self.is_mb_site):
+        # Setup topic and broker for destination sites
+        if self._state.adding and any([self.is_er_site, self.is_smart_site, self.is_mb_site, self.is_wpswatch_site]):
             if "topic" not in self.additional:
                 self.additional.update({"topic": get_dispatcher_topic_default_name(integration=self)})
             if "broker" not in self.additional:
@@ -164,7 +163,7 @@ class Integration(ChangeLogMixin, UUIDAbstractModel, TimestampedModel):
     def _post_save(self, *args, **kwargs):
         created = kwargs.get("created", False)
         # Deploy serverless dispatcher for ER Sites only
-        if created and settings.GCP_ENVIRONMENT_ENABLED and (self.is_er_site or self.is_smart_site):
+        if created and settings.GCP_ENVIRONMENT_ENABLED and any([self.is_er_site, self.is_smart_site, self.is_mb_site, self.is_wpswatch_site]):
             secret_id = settings.DISPATCHER_DEFAULTS_SECRET if self.is_er_site else settings.DISPATCHER_DEFAULTS_SECRET_SMART
             DispatcherDeployment.objects.create(
                 name=get_default_dispatcher_name(integration=self),


### PR DESCRIPTION
### What does this PR do?
- Extends our `dispatchers` command to support updating the source, so that we can deploy new versions.
    - The command supports dispatchers v1 and v2 for ER, SMART and WPS Watch.
    - It also supports updating dispatchers in bulk by type, or updating a single one by id.
- Adds test coverage for the different usages of the command combined with different types and versions

    
### Command usage examples:
```
$ python3 manage.py dispatchers --v1 --type earth_ranger --max 2 --update-source er-dispatcher-src-release-202405091336-4a30801.zip
$ python3 manage.py dispatchers --v2 --type smart_connect --max 2 --update-source "gcr.io/cdip-78ca/gundi/smart-dispatcher:release-202405092019-2c1155b"

$ python3 manage.py dispatchers --v1 --integration c7ea23bf-ac1c-4f49-be44-5ae1eb2b0898 --update-source "gcr.io/cdip-78ca/gundi/wpswatch-dispatcher:release-202405092019-fbdc68c"
$ python3 manage.py dispatchers --v2 --integration b42c9205-5228-49e0-a75b-ebe5b6a9f78e --update-source "gcr.io/cdip-78ca/gundi/smart-dispatcher:release-202405092019-2c1155b"
```

### Relevant link(s)
[GUNDI-3096](https://allenai.atlassian.net/browse/GUNDI-3096)

[GUNDI-3096]: https://allenai.atlassian.net/browse/GUNDI-3096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ