### PR TITLE
Add django-silk for debugging

### DIFF
--- a/cdip_admin/cdip_admin/settings.py
+++ b/cdip_admin/cdip_admin/settings.py
@@ -163,6 +163,12 @@ MIDDLEWARE = [
     "crum.CurrentRequestUserMiddleware",
 ]
 
+# Debugging
+DJANGO_SILK_ENABLED = env.bool("DJANGO_SILK_ENABLED", False)
+if DJANGO_SILK_ENABLED:
+    INSTALLED_APPS.append("silk")
+    MIDDLEWARE.append("silk.middleware.SilkyMiddleware")
+
 ROOT_URLCONF = "cdip_admin.urls"
 
 TEMPLATES = [

--- a/cdip_admin/cdip_admin/urls.py
+++ b/cdip_admin/cdip_admin/urls.py
@@ -15,6 +15,7 @@ Including another URLconf
 """
 from django.conf.urls import url
 from django.contrib import admin
+from django.conf import settings
 from django.urls import path, include
 from website.views import welcome, date, about, index, login_view, logout_view
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
@@ -42,3 +43,5 @@ urlpatterns = [
 handler403 = "cdip_admin.views.custom_error_403"
 
 urlpatterns += staticfiles_urlpatterns()
+if settings.DJANGO_SILK_ENABLED:
+    urlpatterns.append(path("silk/", include("silk.urls", namespace="silk")))

--- a/dependencies/requirements.in
+++ b/dependencies/requirements.in
@@ -85,3 +85,4 @@ opentelemetry-sdk==1.14.0
 opentelemetry-exporter-gcp-trace==1.3.0
 opentelemetry-propagator-gcp==1.3.0
 opentelemetry-instrumentation-requests==0.35b0
+django-silk==5.1.0

--- a/dependencies/requirements.txt
+++ b/dependencies/requirements.txt
@@ -14,6 +14,8 @@ asgiref==3.7.2
     # via django
 attrs==23.1.0
     # via jsonschema
+autopep8==2.1.0
+    # via django-silk
 babel==2.8.0
     # via
     #   -r requirements.in
@@ -117,6 +119,7 @@ django==3.2.25
     #   django-model-utils
     #   django-phonenumber-field
     #   django-rest-swagger
+    #   django-silk
     #   django-storages
     #   django-tables2
     #   django-timezone-field
@@ -157,6 +160,8 @@ django-rest-swagger @ git+https://github.com/PADAS/django-rest-swagger.git@0d933
     # via -r requirements.in
 django-scopes==1.2.0
     # via -r requirements.in
+django-silk==5.1.0
+    # via -r requirements.in
 django-simple-history==3.1.1
     # via -r requirements.in
 django-storages==1.13.2
@@ -194,7 +199,6 @@ gevent==21.12.0
     # via -r requirements.in
 google-api-core[grpc]==2.11.1
     # via
-    #   google-api-core
     #   google-cloud-core
     #   google-cloud-eventarc
     #   google-cloud-functions
@@ -234,6 +238,8 @@ googleapis-common-protos[grpc]==1.59.1
     #   grpc-google-iam-v1
     #   grpcio-status
     #   opentelemetry-exporter-otlp-proto-http
+gprof2dot==2022.7.29
+    # via django-silk
 greenlet==1.1.3.post0
     # via gevent
 grpc-google-iam-v1==0.12.6
@@ -413,6 +419,8 @@ pyasn1==0.4.8
     #   rsa
 pyasn1-modules==0.3.0
     # via google-auth
+pycodestyle==2.11.1
+    # via autopep8
 pycparser==2.20
     # via
     #   -r requirements.in
@@ -540,10 +548,13 @@ sqlparse==0.3.1
     # via
     #   -r requirements.in
     #   django
+    #   django-silk
 statsd==3.3.0
     # via cdip-connector
 timezonefinder==5.2.0
     # via smartconnect-client
+tomli==2.0.1
+    # via autopep8
 typing-extensions==4.7.1
     # via
     #   asgiref


### PR DESCRIPTION
Adds django-silk for debugging slow requests and/or queries. 
This can be enabled by setting env var `DJANGO_SILK_ENABLED = True` (disabled by default)

Example of what we can get:
![silk_sql](https://github.com/PADAS/cdip/assets/9864478/5af1727c-e058-4592-b467-34462e340ba0)
