### PR TITLE
Sanitize URL if the integration is ER type

### DIFF
--- a/cdip_admin/integrations/models/v1/models.py
+++ b/cdip_admin/integrations/models/v1/models.py
@@ -1,4 +1,6 @@
 import uuid
+
+from urllib.parse import urlparse
 from django.db import models, transaction
 from django.db.models.signals import post_save
 from django.dispatch import receiver
@@ -229,6 +231,20 @@ class OutboundIntegrationConfiguration(TimestampedModel):
                 self.additional.update({"topic": get_dispatcher_topic_default_name(integration=self, gundi_version="v1")})
             if "broker" not in self.additional:
                 self.additional.update({"broker": "gcp_pubsub"})
+
+        if self.is_er_site:
+            # Cleanup
+            url_parse = urlparse(self.endpoint)
+
+            scheme = url_parse.scheme
+            if scheme == "http":
+                scheme = "https"
+
+            port = ""
+            if url_parse.port:
+                port = f":{url_parse.port}"
+
+            self.endpoint = f"{scheme}://{url_parse.hostname}{port}/"
 
     def _post_save(self, *args, **kwargs):
         created = kwargs.get("created", False)

--- a/cdip_admin/integrations/models/v1/models.py
+++ b/cdip_admin/integrations/models/v1/models.py
@@ -229,8 +229,7 @@ class OutboundIntegrationConfiguration(TimestampedModel):
         if self._state.adding:
             if "topic" not in self.additional:
                 self.additional.update({"topic": get_dispatcher_topic_default_name(integration=self, gundi_version="v1")})
-            if "broker" not in self.additional:
-                self.additional.update({"broker": "gcp_pubsub"})
+            self.additional.setdefault('broker', 'gcp_pubsub')
 
         if self.is_er_site:
             # Cleanup
@@ -240,11 +239,7 @@ class OutboundIntegrationConfiguration(TimestampedModel):
             if scheme == "http":
                 scheme = "https"
 
-            port = ""
-            if url_parse.port:
-                port = f":{url_parse.port}"
-
-            self.endpoint = f"{scheme}://{url_parse.hostname}{port}/"
+            self.endpoint = f"{scheme}://{url_parse.netloc}/"
 
     def _post_save(self, *args, **kwargs):
         created = kwargs.get("created", False)

--- a/cdip_admin/integrations/models/v2/models.py
+++ b/cdip_admin/integrations/models/v2/models.py
@@ -189,8 +189,7 @@ class Integration(ChangeLogMixin, UUIDAbstractModel, TimestampedModel):
         if self._state.adding and any([self.is_er_site, self.is_smart_site, self.is_mb_site, self.is_wpswatch_site]):
             if "topic" not in self.additional:
                 self.additional.update({"topic": get_dispatcher_topic_default_name(integration=self)})
-            if "broker" not in self.additional:
-                self.additional.update({"broker": "gcp_pubsub"})
+            self.additional.setdefault('broker', 'gcp_pubsub')
 
         if self.is_er_site:
             # Cleanup
@@ -200,11 +199,7 @@ class Integration(ChangeLogMixin, UUIDAbstractModel, TimestampedModel):
             if scheme == "http":
                 scheme = "https"
 
-            port = ""
-            if url_parse.port:
-                port = f":{url_parse.port}"
-
-            self.base_url = f"{scheme}://{url_parse.hostname}{port}/"
+            self.base_url = f"{scheme}://{url_parse.netloc}/"
 
     def _post_save(self, *args, **kwargs):
         created = kwargs.get("created", False)

--- a/cdip_admin/integrations/models/v2/models.py
+++ b/cdip_admin/integrations/models/v2/models.py
@@ -3,7 +3,7 @@ import uuid
 from functools import cached_property
 import jsonschema
 import requests
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 import google.oauth2.id_token
 from core.models import UUIDAbstractModel, TimestampedModel
 from django_celery_beat.models import IntervalSchedule, PeriodicTask
@@ -191,6 +191,20 @@ class Integration(ChangeLogMixin, UUIDAbstractModel, TimestampedModel):
                 self.additional.update({"topic": get_dispatcher_topic_default_name(integration=self)})
             if "broker" not in self.additional:
                 self.additional.update({"broker": "gcp_pubsub"})
+
+        if self.is_er_site:
+            # Cleanup
+            url_parse = urlparse(self.base_url)
+
+            scheme = url_parse.scheme
+            if scheme == "http":
+                scheme = "https"
+
+            port = ""
+            if url_parse.port:
+                port = f":{url_parse.port}"
+
+            self.base_url = f"{scheme}://{url_parse.hostname}{port}/"
 
     def _post_save(self, *args, **kwargs):
         created = kwargs.get("created", False)


### PR DESCRIPTION
- Change scheme from `http` to `https`
- Add port to base_url if present

If the site is ER, the `base_url` will only contain scheme,  hostname and port (to avoid any path present)