### PR TITLE
GUNDI-3234: Support actions execution with config overrides

### DIFF
--- a/cdip_admin/api/v2/serializers.py
+++ b/cdip_admin/api/v2/serializers.py
@@ -1126,7 +1126,7 @@ class ActivityLogRetrieveSerializer(serializers.Serializer):
 
 class ActionTriggerSerializer(serializers.Serializer):
     run_in_background = serializers.BooleanField(required=False, default=False)
-    config_overrides = serializers.JSONField(required=False, write_only=True)
+    config_overrides = serializers.JSONField(required=False)
 
 
 class UserAgreementSerializer(serializers.ModelSerializer):

--- a/cdip_admin/api/v2/tests/test_actions_execution_api.py
+++ b/cdip_admin/api/v2/tests/test_actions_execution_api.py
@@ -17,11 +17,11 @@ def _test_execute_action(
     mocker.patch("integrations.models.v2.models.google.oauth2.id_token.fetch_id_token", mocker.MagicMock(return_value="fake_id_token"))
     integration_service_url = integration.type.service_url
     actions_execute_url = urljoin(integration_service_url, "/v1/actions/execute")
-    requests_mock.post(actions_execute_url, json=action_response, status_code=status.HTTP_200_OK)
+    gcp_request_mock = requests_mock.post(actions_execute_url, json=action_response, status_code=status.HTTP_200_OK)
     api_url = reverse("actions-execute", kwargs={"integration_pk": integration.id, "value": action.value})
     request_data = {}
     if config_overrides:
-        request_data["configurations"] = config_overrides
+        request_data["config_overrides"] = config_overrides
     if run_in_background:
         request_data["run_in_background"] = True
     api_client.force_authenticate(user)
@@ -34,6 +34,8 @@ def _test_execute_action(
 
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == expected_response
+    if config_overrides:
+        assert gcp_request_mock.last_request.json().get("config_overrides") == config_overrides
 
 
 def _test_cannot_execute_action(
@@ -106,4 +108,21 @@ def test_cannot_execute_action_as_org_viewer(
         user=org_viewer_user,
         integration=cellstop_integration,
         action=cellstop_action_auth
+    )
+
+
+def test_execute_action_with_config_overrides(
+        api_client, mocker, requests_mock, org_admin_user, organization,
+        cellstop_integration, cellstop_action_auth, cellstop_action_auth_response
+):
+    _test_execute_action(
+        mocker=mocker,
+        api_client=api_client,
+        requests_mock=requests_mock,
+        user=org_admin_user,
+        integration=cellstop_integration,
+        action=cellstop_action_auth,
+        action_response=cellstop_action_auth_response,
+        expected_response=cellstop_action_auth_response,
+        config_overrides={"username": "test_user", "password": "test_password"}  # pragma: allowlist secret
     )

--- a/cdip_admin/api/v2/tests/test_actions_execution_api.py
+++ b/cdip_admin/api/v2/tests/test_actions_execution_api.py
@@ -111,15 +111,20 @@ def test_cannot_execute_action_as_org_viewer(
     )
 
 
+@pytest.mark.parametrize("user", [
+    ("superuser"),
+    ("org_admin_user"),
+])
 def test_execute_action_with_config_overrides(
-        api_client, mocker, requests_mock, org_admin_user, organization,
+        request, api_client, mocker, requests_mock, user, organization,
         cellstop_integration, cellstop_action_auth, cellstop_action_auth_response
 ):
+    user = request.getfixturevalue(user)
     _test_execute_action(
         mocker=mocker,
         api_client=api_client,
         requests_mock=requests_mock,
-        user=org_admin_user,
+        user=user,
         integration=cellstop_integration,
         action=cellstop_action_auth,
         action_response=cellstop_action_auth_response,

--- a/cdip_admin/api/v2/tests/utils.py
+++ b/cdip_admin/api/v2/tests/utils.py
@@ -44,4 +44,8 @@ def _test_activity_logs_on_instance_updated(activity_log, instance, user, expect
         assert changes.get(field) == value
     revert_data = activity_log.revert_data
     for field, value in expected_revert_data.items():
-        assert revert_data.get(field) == value
+        if isinstance(value, dict):
+            for key, val in value.items():
+                assert revert_data.get(field).get(key) == val
+        else:
+            assert revert_data.get(field) == value

--- a/cdip_admin/integrations/models/v2/models.py
+++ b/cdip_admin/integrations/models/v2/models.py
@@ -103,8 +103,7 @@ class IntegrationAction(UUIDAbstractModel, TimestampedModel):
                 "integration_id": str(integration.id),
                 "action_id": self.value,
                 "run_in_background": run_in_background,
-                # ToDo: Enable this once it's supported by integrations
-                #"config_overrides": config_overrides,
+                "config_overrides": config_overrides,
             }
         )
         response.raise_for_status()


### PR DESCRIPTION
### What does this PR do?
- Adds support for triggering integration actions with a new config provided in the request instead of using the config stored in the DB. This is for cases such as testing new credentials in a configuration before saving them.
- Adds test coverage

### Relevant link(s)
[GUNDI-3234](https://allenai.atlassian.net/browse/GUNDI-3234)

[GUNDI-3234]: https://allenai.atlassian.net/browse/GUNDI-3234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ