### PR TITLE
GUNDI-3339:  Improve traces queries with multple destinations

### DIFF
--- a/cdip_admin/conftest.py
+++ b/cdip_admin/conftest.py
@@ -1325,9 +1325,9 @@ def event_delivered_trace(provider_trap_tagger, integrations_list_er):
 
 
 @pytest.fixture
-def event_delivered_trace2(provider_trap_tagger, integrations_list_er):
+def event_delivered_trace2(provider_trap_tagger, event_delivered_trace, integrations_list_er):
     trace = GundiTrace(
-        # We save only IDs, no sensitive data is saved
+        object_id=event_delivered_trace.object_id,
         data_provider=provider_trap_tagger,
         related_to=None,
         object_type="ev",


### PR DESCRIPTION
### What does this PR do?
- Fixes an issue in queries related to attachments, for the case when a related event was delivered to more than one destination
- Add guardrails in other similar queries
- Adds test coverage for the bugfixes

### Relevant link(s)
[GUNDI-3339](https://allenai.atlassian.net/browse/GUNDI-3339)

[GUNDI-3339]: https://allenai.atlassian.net/browse/GUNDI-3339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ