### PR TITLE
GUNDI-3296: Ensure ordered event updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - 'release-**'
+      - 'gundi-3296-ordered-event-updates'
 
 jobs:
   vars:
@@ -28,7 +29,7 @@ jobs:
 
   deploy_dev:
     uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v2
-    if: startsWith(github.ref, 'refs/heads/main')
+    if: startsWith(github.ref, 'refs/heads/gundi-3296')
     needs: [vars, build]
     with:
       environment: dev

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
       - 'release-**'
-      - 'gundi-3296-ordered-event-updates'
 
 jobs:
   vars:
@@ -29,7 +28,7 @@ jobs:
 
   deploy_dev:
     uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v2
-    if: startsWith(github.ref, 'refs/heads/gundi-3296')
+    if: startsWith(github.ref, 'refs/heads/main')
     needs: [vars, build]
     with:
       environment: dev

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -118,7 +118,7 @@
         "filename": ".github/workflows/main.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 40
+        "line_number": 39
       }
     ],
     ".github/workflows/values/dev.yml": [
@@ -296,5 +296,5 @@
       }
     ]
   },
-  "generated_at": "2024-08-08T13:24:45Z"
+  "generated_at": "2024-08-12T11:52:16Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -118,7 +118,7 @@
         "filename": ".github/workflows/main.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 39
+        "line_number": 40
       }
     ],
     ".github/workflows/values/dev.yml": [
@@ -296,5 +296,5 @@
       }
     ]
   },
-  "generated_at": "2024-08-06T16:03:06Z"
+  "generated_at": "2024-08-08T13:24:45Z"
 }

--- a/cdip_admin/api/v2/tests/test_events_api.py
+++ b/cdip_admin/api/v2/tests/test_events_api.py
@@ -268,6 +268,8 @@ def test_update_event(api_client, mocker, trap_tagger_event_trace, mock_publishe
     payload = data_kwarg.get("payload", {})
     assert payload.get("changes") == data
     extra_arg = mock_publisher.publish.call_args.kwargs["extra"]
-    assert extra_arg.get("gundi_id") == str(trap_tagger_event_trace.object_id)
+    gundi_id = str(trap_tagger_event_trace.object_id)
+    assert extra_arg.get("gundi_id") == gundi_id
+    assert mock_publisher.publish.call_args.kwargs["ordering_key"] == gundi_id
     assert extra_arg.get("gundi_version") == "v2"
     assert extra_arg.get("observation_type") == StreamPrefixEnum.event_update.value

--- a/cdip_admin/api/v2/utils.py
+++ b/cdip_admin/api/v2/utils.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from hashlib import md5
 
 import backoff
@@ -14,6 +15,9 @@ from gundi_core.events import EventUpdateReceived, ObservationReceived, EventRec
 from core import tracing, cache
 from opentelemetry import trace
 from integrations.models import GundiTrace
+
+
+logger = logging.getLogger(__name__)
 
 
 deduplication_db = cache.get_deduplication_db()
@@ -174,8 +178,12 @@ def send_events_to_routing(events, gundi_ids):
                     default=str,
                 )
                 # Send message to routing services
+                observations_topic = settings.RAW_OBSERVATIONS_TOPIC
+                logger.debug(
+                    f"Publishing EventReceived(event_id={msg_for_routing.event_id}, gundi_id={gundi_id}) to PubSub topic {observations_topic}.."
+                )
                 publisher.publish(
-                    topic=settings.RAW_OBSERVATIONS_TOPIC,
+                    topic=observations_topic,
                     data=msg_for_routing.dict(exclude_none=True),
                     extra={
                         "observation_type": StreamPrefixEnum.event.value,
@@ -222,8 +230,12 @@ def send_event_update_to_routing(event_trace, event_changes):
                 default=str,
             )
             # Send message to routing services
+            observations_topic = settings.RAW_OBSERVATIONS_TOPIC
+            logger.debug(
+                f"Publishing EventUpdateReceived(event_id={msg_for_routing.event_id}, gundi_id={gundi_id}) to PubSub topic {observations_topic}.."
+            )
             publisher.publish(
-                topic=settings.RAW_OBSERVATIONS_TOPIC,
+                topic=observations_topic,
                 data=msg_for_routing.dict(exclude_none=True),
                 ordering_key=str(gundi_id),  # Order is important in case there are consecutive updates
                 extra={
@@ -307,8 +319,12 @@ def send_attachments_to_routing(attachments_data, gundi_ids):
                     default=str,
                 )
                 # Send message to routing services
+                observations_topic = settings.RAW_OBSERVATIONS_TOPIC
+                logger.debug(
+                    f"Publishing AttachmentReceived(event_id={msg_for_routing.event_id}, gundi_id={gundi_id}) to PubSub topic {observations_topic}.."
+                )
                 publisher.publish(
-                    topic=settings.RAW_OBSERVATIONS_TOPIC,
+                    topic=observations_topic,
                     data=msg_for_routing.dict(exclude_none=True),
                     extra={
                         "observation_type": StreamPrefixEnum.attachment.value,
@@ -392,8 +408,12 @@ def send_observations_to_routing(observations, gundi_ids):
                     default=str,
                 )
                 # Send message to routing services
+                observations_topic = settings.RAW_OBSERVATIONS_TOPIC
+                logger.debug(
+                    f"Publishing ObservationReceived(event_id={msg_for_routing.event_id}, gundi_id={gundi_id}) to PubSub topic {observations_topic}.."
+                )
                 publisher.publish(
-                    topic=settings.RAW_OBSERVATIONS_TOPIC,
+                    topic=observations_topic,
                     data=msg_for_routing.dict(exclude_none=True),
                     extra={
                         "observation_type": StreamPrefixEnum.observation.value,

--- a/cdip_admin/api/v2/utils.py
+++ b/cdip_admin/api/v2/utils.py
@@ -177,7 +177,6 @@ def send_events_to_routing(events, gundi_ids):
                 publisher.publish(
                     topic=settings.RAW_OBSERVATIONS_TOPIC,
                     data=msg_for_routing.dict(exclude_none=True),
-                    ordering_key=str(gundi_id),  # Order is important in case there are consecutive updates
                     extra={
                         "observation_type": StreamPrefixEnum.event.value,
                         "gundi_version": "v2",  # Add the version so routing knows how to handle it
@@ -311,7 +310,6 @@ def send_attachments_to_routing(attachments_data, gundi_ids):
                 publisher.publish(
                     topic=settings.RAW_OBSERVATIONS_TOPIC,
                     data=msg_for_routing.dict(exclude_none=True),
-                    ordering_key=attachment.get("related_to"),  # Attachment will be delivered after the related event
                     extra={
                         "observation_type": StreamPrefixEnum.attachment.value,
                         "gundi_version": "v2",  # Add the version so routing knows how to handle it


### PR DESCRIPTION
### What does this PR do?
- Sets an ordering key in event updates published to Pubsub to ensure they are delivered to routing in order
- Extends test coverage to check that the ordering key is set
- Fixes an issue that was generating duplicate event updates when having multiple destinations

### Relevant link(s)
[GUNDI-3296](https://allenai.atlassian.net/browse/GUNDI-3296)