### PR TITLE
Update cdip-connector version.

### DIFF
--- a/dependencies/requirements-dev.txt
+++ b/dependencies/requirements-dev.txt
@@ -40,7 +40,7 @@ cached-property==1.5.1
     # via -r requirements.in
 cachetools==5.3.1
     # via google-auth
-cdip-connector @ https://github.com/PADAS/smart-integrate-sdk/releases/download/v1.5.1/cdip_connector-1.5.1-py3-none-any.whl
+cdip-connector @ https://github.com/PADAS/smart-integrate-sdk/releases/download/v1.5.3/cdip_connector-1.5.3-py3-none-any.whl
     # via -r requirements.in
 celery==5.2.3
     # via

--- a/dependencies/requirements.in
+++ b/dependencies/requirements.in
@@ -79,7 +79,7 @@ django-model-utils==4.3.1
 django-crum==0.7.9
 https://github.com/PADAS/das-clients/releases/download/v.1.0.40/dasclient-1.0.40-py3-none-any.whl
 https://github.com/PADAS/smartconnect-client/releases/download/v1.6.0/smartconnect_client-1.6.0-py3-none-any.whl
-https://github.com/PADAS/smart-integrate-sdk/releases/download/v1.5.1/cdip_connector-1.5.1-py3-none-any.whl
+https://github.com/PADAS/smart-integrate-sdk/releases/download/v1.5.3/cdip_connector-1.5.3-py3-none-any.whl
 opentelemetry-api==1.14.0
 opentelemetry-sdk==1.14.0
 opentelemetry-exporter-gcp-trace==1.3.0

--- a/dependencies/requirements.txt
+++ b/dependencies/requirements.txt
@@ -38,7 +38,7 @@ cached-property==1.5.1
     # via -r requirements.in
 cachetools==5.3.1
     # via google-auth
-cdip-connector @ https://github.com/PADAS/smart-integrate-sdk/releases/download/v1.5.1/cdip_connector-1.5.1-py3-none-any.whl
+cdip-connector @ https://github.com/PADAS/smart-integrate-sdk/releases/download/v1.5.3/cdip_connector-1.5.3-py3-none-any.whl
     # via -r requirements.in
 celery==5.2.3
     # via


### PR DESCRIPTION
This is an update to the cdip-connector dependency. The latest having the feature to allow disabling tracing as well as the latest edits for job-partitioning (job-partitioning is only relevant for Gundi V1 functions).

[GUNDI-3125](https://allenai.atlassian.net/browse/GUNDI-3125)

[GUNDI-3125]: https://allenai.atlassian.net/browse/GUNDI-3125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ