### PR TITLE
Add extra "BUCKET_NAME" variable for legacy cdip-connector

### DIFF
--- a/.github/workflows/values/dev.yml
+++ b/.github/workflows/values/dev.yml
@@ -27,6 +27,7 @@ admin_portal:
     DISPATCHER_EVENTS_SUB_ID: cdip-dispatcher-events-sub-dev
     REDIS_HOST: "10.3.176.132"
     GS_BUCKET_NAME: "cdip-files-dev"
+    BUCKET_NAME: "cdip-files-dev"
     DISPATCHER_DEFAULTS_SECRET: "er-dispatcher-defaults-dev"
     MOVEBANK_DISPATCHER_DEFAULT_TOPIC: "destination-movebank-dev"
     DISPATCHER_DEFAULTS_SECRET_SMART: "sm-dispatcher-defaults-dev"

--- a/.github/workflows/values/prod.yml
+++ b/.github/workflows/values/prod.yml
@@ -32,6 +32,7 @@ admin_portal:
     DISPATCHER_EVENTS_SUB_ID: cdip-dispatcher-events-sub-prod
     REDIS_HOST: "10.208.106.172"
     GS_BUCKET_NAME: "cdip-files-prod"
+    BUCKET_NAME: "cdip-files-prod"
     DISPATCHER_DEFAULTS_SECRET: "er-dispatcher-defaults-prod"
     MOVEBANK_DISPATCHER_DEFAULT_TOPIC: "destination-movebank-prod"
     DISPATCHER_DEFAULTS_SECRET_SMART: "sm-dispatcher-defaults-prod"

--- a/.github/workflows/values/stage.yml
+++ b/.github/workflows/values/stage.yml
@@ -27,6 +27,7 @@ admin_portal:
     DISPATCHER_EVENTS_SUB_ID: cdip-dispatcher-events-sub-stage
     REDIS_HOST: "10.243.180.36"
     GS_BUCKET_NAME: "cdip-files-stage"
+    BUCKET_NAME: "cdip-files-stage"
     DISPATCHER_DEFAULTS_SECRET: "er-dispatcher-defaults-stage"
     MOVEBANK_DISPATCHER_DEFAULT_TOPIC: "destination-movebank-stage"
     DISPATCHER_DEFAULTS_SECRET_SMART: "sm-dispatcher-defaults-stage"


### PR DESCRIPTION
Add an extra environment variable called `BUCKET_NAME` and have it be the same as `GS_BUCKET_NAME`.

This will allow code using GoogleCloudStorage within the legacy cdip-connector library to find the appropriate storage bucket for storing attachments.