### PR TITLE
GUNDI-3334: Add status field in API v2

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -258,7 +258,7 @@
         "filename": "cdip_admin/conftest.py",
         "hashed_secret": "27d933b78d3ea4a51a3ff26aef5831c92d43925c",
         "is_verified": false,
-        "line_number": 2397
+        "line_number": 2412
       }
     ],
     "cdip_admin/integrations/migrations/0047_init_erinreach_config_schema.py": [
@@ -296,5 +296,5 @@
       }
     ]
   },
-  "generated_at": "2024-08-06T16:03:06Z"
+  "generated_at": "2024-08-22T18:12:15Z"
 }

--- a/cdip_admin/api/serializers.py
+++ b/cdip_admin/api/serializers.py
@@ -1,8 +1,6 @@
 from django.urls import reverse
 from core.utils import add_base_url
 from rest_framework import serializers
-
-from organizations.models import Organization
 from integrations.models import *
 
 

--- a/cdip_admin/api/v2/serializers.py
+++ b/cdip_admin/api/v2/serializers.py
@@ -891,6 +891,7 @@ class EventCreateUpdateSerializer(GundiTraceSerializer):
     event_type = serializers.CharField(write_only=True, required=False)
     event_details = serializers.JSONField(write_only=True, required=False)
     annotations = serializers.JSONField(write_only=True, required=False)
+    status = serializers.CharField(write_only=True, required=False)
 
     class Meta:
         list_serializer_class = EventBulkCreateUpdateSerializer

--- a/cdip_admin/api/v2/utils.py
+++ b/cdip_admin/api/v2/utils.py
@@ -158,7 +158,8 @@ def send_events_to_routing(events, gundi_ids):
                         event_type=event.get("event_type"),
                         event_details=event.get("event_details", {}),
                         geometry=event.get("geometry", None),
-                        observation_type=StreamPrefixEnum.event.value
+                        observation_type=StreamPrefixEnum.event.value,
+                        status=event.get("status")
                     )
                 )
                 tracing.instrumentation.enrich_span_from_event(

--- a/cdip_admin/conftest.py
+++ b/cdip_admin/conftest.py
@@ -1558,6 +1558,21 @@ def mock_get_api_key():
     return PropertyMock(return_value="TestAp1k3y1234")
 
 
+@pytest.fixture
+def species_update_request_data():
+    return {
+        "event_details": {
+          "species": "Puma"
+        }
+    }
+
+
+@pytest.fixture
+def status_update_request_data():
+    return {
+        "status": "resolved"
+    }
+
 ########################################################################################################################
 # GUNDI 1.0
 ########################################################################################################################

--- a/dependencies/requirements-dev.txt
+++ b/dependencies/requirements-dev.txt
@@ -275,13 +275,13 @@ grpcio-status==1.57.0
     # via
     #   google-api-core
     #   google-cloud-pubsub
-gundi-client==1.0.2
+gundi-client==1.0.4
     # via
     #   -r requirements.in
     #   cdip-connector
-gundi-client-v2==2.3.3
+gundi-client-v2==2.3.5
     # via -r requirements.in
-gundi-core==1.5.8
+gundi-core==1.6.2
     # via
     #   -r requirements.in
     #   cdip-connector

--- a/dependencies/requirements.in
+++ b/dependencies/requirements.in
@@ -68,9 +68,9 @@ jsonschema==4.17.3
 django-celery-beat==2.5.0
 django-storages==1.13.2
 walrus==0.8.1
-gundi-core==1.5.8
-gundi-client==1.0.2
-gundi-client-v2==2.3.3
+gundi-core==1.6.2
+gundi-client==1.0.4
+gundi-client-v2==2.3.5
 google-cloud-functions==1.13.1
 google-cloud-run==0.10.1
 google-cloud-eventarc==1.10.0

--- a/dependencies/requirements.txt
+++ b/dependencies/requirements.txt
@@ -260,13 +260,13 @@ grpcio-status==1.56.0
     # via
     #   google-api-core
     #   google-cloud-pubsub
-gundi-client==1.0.2
+gundi-client==1.0.4
     # via
     #   -r requirements.in
     #   cdip-connector
-gundi-client-v2==2.3.3
+gundi-client-v2==2.3.5
     # via -r requirements.in
-gundi-core==1.5.8
+gundi-core==1.6.2
     # via
     #   -r requirements.in
     #   cdip-connector


### PR DESCRIPTION
### What does this PR do?
- Adds a `status` field in API v2 for events and event updates
- Updates gundi-core and gundi-client versions
- Test coverage

### Relevant link(s)
[GUNDI-3334](https://allenai.atlassian.net/browse/GUNDI-3334)

[GUNDI-3334]: https://allenai.atlassian.net/browse/GUNDI-3334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ