### PR TITLE
GUNDI-3249: Consume wpswatch dispatcher custom logs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -258,7 +258,7 @@
         "filename": "cdip_admin/conftest.py",
         "hashed_secret": "27d933b78d3ea4a51a3ff26aef5831c92d43925c",
         "is_verified": false,
-        "line_number": 2412
+        "line_number": 2437
       }
     ],
     "cdip_admin/integrations/migrations/0047_init_erinreach_config_schema.py": [
@@ -296,5 +296,5 @@
       }
     ]
   },
-  "generated_at": "2024-08-22T18:12:15Z"
+  "generated_at": "2024-08-26T13:12:59Z"
 }

--- a/cdip_admin/conftest.py
+++ b/cdip_admin/conftest.py
@@ -8,6 +8,7 @@ from typing import NamedTuple, Any
 from django.contrib.auth.models import User, Group
 from rest_framework.utils import json
 from rest_framework.test import APIClient
+from gundi_core.schemas import v2 as gundi_schemas_v2
 from accounts.models import AccountProfile, AccountProfileOrganization
 from activity_log.models import ActivityLog
 from core.enums import DjangoGroups, RoleChoices
@@ -1546,6 +1547,30 @@ def trap_tagger_observation_update_failed_event(
             "data_provider_id": str(trap_tagger_event_update_trace.data_provider.id),
             "destination_id": str(integrations_list_er[0].id),
             "updated_at": "2024-07-25 12:25:44.442696+00:00",
+        },
+    }
+    data_bytes = json.dumps(event_dict).encode("utf-8")
+    message.data = data_bytes
+    return message
+
+@pytest.fixture
+def wpswatch_dispatcher_log_event(
+        mocker, trap_tagger_event_trace, integrations_list_wpswatch
+):
+    message = mocker.MagicMock()
+    gundi_id = str(trap_tagger_event_trace.object_id)
+    event_dict = {
+        "event_id": "505535df-1b9b-412b-9fd5-e29b09582901",
+        "timestamp": "2023-07-11 18:19:19.215459+00:00",
+        "schema_version": "v1",
+        "event_type": "DispatcherCustomLog",
+        "payload": {
+            "gundi_id": gundi_id,
+            "related_to": None,
+            "data_provider_id": str(trap_tagger_event_trace.data_provider.id),
+            "destination_id": str(integrations_list_wpswatch[0].id),
+            "title": f"Observation {gundi_id} buffered in wait for attachment",
+            "level": gundi_schemas_v2.LogLevel.INFO.value,
         },
     }
     data_bytes = json.dumps(event_dict).encode("utf-8")

--- a/cdip_admin/event_consumers/tests/test_dispatcher_events_consumer.py
+++ b/cdip_admin/event_consumers/tests/test_dispatcher_events_consumer.py
@@ -309,3 +309,20 @@ def test_process_observation_update_failed_event(
     assert activity_log.value == "observation_update_failed"
     assert activity_log.title == f"Error Updating observation {trap_tagger_event_update_trace.object_id} in '{trap_tagger_event_update_trace.destination.base_url}'"
     assert activity_log.details == event_data
+
+
+def test_process_dispatcher_log_event(
+        trap_tagger_event_trace, wpswatch_dispatcher_log_event
+):
+    # Test the case when a dispatcher logs a message
+    process_event(wpswatch_dispatcher_log_event)
+    event_data = json.loads(wpswatch_dispatcher_log_event.data)["payload"]
+    # Check that the event was recorded in the activity log
+    activity_log = ActivityLog.objects.filter(integration_id=event_data["destination_id"]).first()
+    assert activity_log
+    assert activity_log.log_type == ActivityLog.LogTypes.EVENT
+    assert activity_log.log_level == event_data["level"]
+    assert activity_log.origin == ActivityLog.Origin.DISPATCHER
+    assert activity_log.value == "custom_dispatcher_log"
+    assert activity_log.title == event_data['title']
+    assert not activity_log.is_reversible


### PR DESCRIPTION
### What does this PR do?
- Extends the dispatcher events consumer to show a message in activity logs when the WPS Watch dispatcher buffers an event in wait for an attachment.
- Extends the test coverage accordingly

### Relevant link(s)
[GUNDI-3249](https://allenai.atlassian.net/browse/GUNDI-3249)

[GUNDI-3249]: https://allenai.atlassian.net/browse/GUNDI-3249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ