### PR TITLE
GUNDI-2571: Filter connections by destiantion id

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -258,7 +258,7 @@
         "filename": "cdip_admin/conftest.py",
         "hashed_secret": "27d933b78d3ea4a51a3ff26aef5831c92d43925c",
         "is_verified": false,
-        "line_number": 2437
+        "line_number": 2491
       }
     ],
     "cdip_admin/integrations/migrations/0047_init_erinreach_config_schema.py": [
@@ -296,5 +296,5 @@
       }
     ]
   },
-  "generated_at": "2024-08-26T13:12:59Z"
+  "generated_at": "2024-08-29T13:34:29Z"
 }

--- a/cdip_admin/api/v2/tests/test_connections_api.py
+++ b/cdip_admin/api/v2/tests/test_connections_api.py
@@ -203,6 +203,27 @@ def test_filter_connections_by_destination_type_as_org_viewer(
     )
 
 
+def test_filter_connections_by_destination_id_as_superuser(
+        api_client, superuser, other_organization,
+        provider_movebank_ewt, provider_trap_tagger,
+        smart_destination_1, smart_destination_2_same_url_as_1,
+):
+    assert smart_destination_1.base_url == smart_destination_2_same_url_as_1.base_url
+    # Connection 1: Movebank -> Smart Destination 1 (url: "https://smarttest.smart.wps.org")
+    provider_movebank_ewt.default_route.destinations.add(smart_destination_1)
+    # Connection 1: Trap Tagger -> Smart Destination 2 (same url: "https://smarttest.smart.wps.org")
+    provider_trap_tagger.default_route.destinations.add(smart_destination_2_same_url_as_1)
+
+    _test_filter_connections(
+        api_client=api_client,
+        user=superuser,
+        filters={
+            "destination_id": str(smart_destination_1.id)
+        },
+        expected_integrations=[provider_movebank_ewt]  # Connections are not mixed when filtering by destination ID
+    )
+
+
 def test_filter_connections_by_multiple_destination_urls_as_superuser(
         api_client, superuser, organization, provider_lotek_panthera, provider_movebank_ewt,
         integrations_list_er, route_1, route_2, integration_type_er

--- a/cdip_admin/conftest.py
+++ b/cdip_admin/conftest.py
@@ -36,7 +36,7 @@ from integrations.models import (
     SourceConfiguration,
     ensure_default_route,
     RouteConfiguration,
-    GundiTrace, IntegrationWebhook, WebhookConfiguration,
+    GundiTrace, IntegrationWebhook, WebhookConfiguration, RouteProvider, RouteDestination,
 )
 from organizations.models import Organization
 from pathlib import Path
@@ -508,6 +508,60 @@ def smart_integration(
         },
     )
     ensure_default_route(integration=integration)
+    return integration
+
+
+@pytest.fixture
+def smart_destination_1(
+        other_organization,
+        integration_type_smart,
+        get_random_id,
+        smart_action_auth,
+        smart_action_push_events,
+):
+    # Create the integration
+    site_url = "smarttest.smart.wps.org"
+    integration, _ = Integration.objects.get_or_create(
+        type=integration_type_smart,
+        name=f"SMART Site {get_random_id()}",
+        owner=other_organization,
+        base_url=site_url,
+    )
+    # Configure actions
+    IntegrationConfiguration.objects.create(
+        integration=integration,
+        action=smart_action_auth,
+        data={
+            "api_key": f"SMART-{get_random_id()}-KEY",
+        },
+    )
+    return integration
+
+
+@pytest.fixture
+def smart_destination_2_same_url_as_1(
+        other_organization,
+        integration_type_smart,
+        get_random_id,
+        smart_action_auth,
+        smart_action_push_events,
+        smart_destination_1
+):
+    # Create the integration
+    integration, _ = Integration.objects.get_or_create(
+        type=integration_type_smart,
+        name=f"SMART Site {get_random_id()}",
+        owner=other_organization,
+        base_url=smart_destination_1.base_url,
+    )
+    # Configure actions
+    IntegrationConfiguration.objects.create(
+        integration=integration,
+        action=smart_action_auth,
+        data={
+            "api_key": f"SMART-{get_random_id()}-KEY",
+        },
+    )
     return integration
 
 

--- a/cdip_admin/integrations/filters.py
+++ b/cdip_admin/integrations/filters.py
@@ -389,6 +389,7 @@ class ConnectionFilter(django_filters_rest.FilterSet):
     destination_type__in = CharInFilter(method='filter_by_destination_type', lookup_expr="in")
     destination_url = django_filters_rest.CharFilter(method='filter_by_destination_url')
     destination_url__in = CharInFilter(method='filter_by_destination_url', lookup_expr="in")
+    destination_id = django_filters_rest.CharFilter(method='filter_by_destination_id')
 
     class Meta:
         model = Integration
@@ -419,6 +420,12 @@ class ConnectionFilter(django_filters_rest.FilterSet):
         )
         # Filter integrations having at least one destination with an url matching at least one of the provided values
         return qs_with_destination_urls.filter(destination_urls__overlap=destination_urls)
+
+    def filter_by_destination_id(self, queryset, name, value):
+        # Filter integrations having at destination with id matching the provided value
+        return queryset.filter(
+            routing_rules_by_provider__destinations__id=str(value)
+        )
 
 
 class IntegrationTypeFilter(django_filters_rest.FilterSet):


### PR DESCRIPTION
### What does this PR do?
- Extends filters in the `/connections/` endpoint to support filtering by `destination_id`
- Extends the test coverage accordingly

### Relevant link(s)
[GUNDI-2571](https://allenai.atlassian.net/browse/GUNDI-2571)


[GUNDI-2571]: https://allenai.atlassian.net/browse/GUNDI-2571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ