### PR TITLE
GUNDI-3454: Validate uuid in destination_id filter

### DIFF
--- a/cdip_admin/api/v2/tests/test_connections_api.py
+++ b/cdip_admin/api/v2/tests/test_connections_api.py
@@ -224,6 +224,28 @@ def test_filter_connections_by_destination_id_as_superuser(
     )
 
 
+def test_filter_connections_validates_destination_id(
+        api_client, superuser, other_organization,
+        provider_movebank_ewt, provider_trap_tagger,
+        smart_destination_1, smart_destination_2_same_url_as_1,
+):
+    assert smart_destination_1.base_url == smart_destination_2_same_url_as_1.base_url
+    # Connection 1: Movebank -> Smart Destination 1 (url: "https://smarttest.smart.wps.org")
+    provider_movebank_ewt.default_route.destinations.add(smart_destination_1)
+    # Connection 1: Trap Tagger -> Smart Destination 2 (same url: "https://smarttest.smart.wps.org")
+    provider_trap_tagger.default_route.destinations.add(smart_destination_2_same_url_as_1)
+
+    api_client.force_authenticate(superuser)
+    response = api_client.get(
+        reverse("connections-list"),
+        data={
+            "destination_id": 1  # invalid UUID
+        }
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+
 def test_filter_connections_by_multiple_destination_urls_as_superuser(
         api_client, superuser, organization, provider_lotek_panthera, provider_movebank_ewt,
         integrations_list_er, route_1, route_2, integration_type_er

--- a/cdip_admin/integrations/filters.py
+++ b/cdip_admin/integrations/filters.py
@@ -389,7 +389,7 @@ class ConnectionFilter(django_filters_rest.FilterSet):
     destination_type__in = CharInFilter(method='filter_by_destination_type', lookup_expr="in")
     destination_url = django_filters_rest.CharFilter(method='filter_by_destination_url')
     destination_url__in = CharInFilter(method='filter_by_destination_url', lookup_expr="in")
-    destination_id = django_filters_rest.CharFilter(method='filter_by_destination_id')
+    destination_id = django_filters_rest.UUIDFilter(method='filter_by_destination_id')
 
     class Meta:
         model = Integration


### PR DESCRIPTION
### What does this PR do?
- Changes the filter type of `destination_id` to `UUIDFilter` to get the value validated as a proper uuid.
- Extends the test coverage accordingly

### Relevant link(s)
[GUNDI-3454](https://allenai.atlassian.net/browse/GUNDI-3454)