### PR TITLE
GUNDI-3376: Dispatchers re-create command

### DIFF
--- a/cdip_admin/deployments/admin.py
+++ b/cdip_admin/deployments/admin.py
@@ -36,8 +36,16 @@ class DispatcherDeploymentAdmin(admin.ModelAdmin):
     )
     list_filter = (
         "status",
+        "integration__type",
+        "legacy_integration__type",
     )
     actions = [restart_deployments, recreate_dispatchers]
+    search_fields = (
+        "id",
+        "name",
+        "integration__name",
+        "legacy_integration__name",
+    )
 
     def delete_queryset(self, request, queryset):
         for deployment in queryset:

--- a/cdip_admin/deployments/management/commands/dispatchers.py
+++ b/cdip_admin/deployments/management/commands/dispatchers.py
@@ -119,6 +119,7 @@ class Command(BaseCommand):
             else:
                 self.stdout.write("Please specify an integration ID or a type")
                 return
+
             self.update_dispatchers(
                 integrations=integrations_to_update,
                 deployment_settings=new_settings

--- a/cdip_admin/deployments/models.py
+++ b/cdip_admin/deployments/models.py
@@ -70,7 +70,7 @@ class DispatcherDeployment(UUIDAbstractModel, TimestampedModel):
         # Trigger the deployment of a dispatcher.
         # https://django-model-utils.readthedocs.io/en/latest/utilities.html#field-tracker
         config_changed = self.tracker.has_changed("configuration")
-        if self.status == DispatcherDeployment.Status.SCHEDULED or config_changed:
+        if self.status == DispatcherDeployment.Status.SCHEDULED or (config_changed and self.status != DispatcherDeployment.Status.IN_PROGRESS):
             transaction.on_commit(
                 lambda: deploy_serverless_dispatcher.delay(deployment_id=self.id)
             )

--- a/cdip_admin/deployments/tasks.py
+++ b/cdip_admin/deployments/tasks.py
@@ -30,8 +30,7 @@ if settings.GCP_ENVIRONMENT_ENABLED:
     )
 else:
     pubsub_client = utils.PubSubDummyClient()
-    # ToDo: Implement dummy client for subscriptions
-    #subscriptions_client = utils.SubscriberDummyClient()
+    subscriptions_client = utils.SubscriberDummyClient()
     functions_client = utils.FunctionsDummyClient()
     cloudrun_client = utils.CloudRunDummyClient()
     eventarc_client = utils.EventarcDummyClient()

--- a/cdip_admin/deployments/utils.py
+++ b/cdip_admin/deployments/utils.py
@@ -136,6 +136,34 @@ class EventarcDummyClient:
         return None
 
 
+class SubscriberDummyClient:
+
+    def create_subscription(
+            self,
+            request=None,
+            *,
+            name=None,
+            subscription=None,
+            retry=None,
+            timeout=None,
+            metadata=(),
+    ) -> None:
+        logger.warning(f"Using SubscriberDummyClient. Subscription creation ignored.")
+        return None
+
+    def delete_subscription(
+            self,
+            request=None,
+            *,
+            subscription=None,
+            retry=None,
+            timeout=None,
+            metadata=(),
+    ) -> None:
+        logger.warning(f"Using SubscriberDummyClient. Subscription deletion ignored.")
+        return None
+
+
 def get_dispatcher_defaults_from_gcp_secrets(secret_id=settings.DISPATCHER_DEFAULTS_SECRET):
     # Load default settings for serverless dispatchers from GCP secrets
     client = secretmanager.SecretManagerServiceClient()


### PR DESCRIPTION
### What does this PR do?
- Updates the deployment code to avoid using eventarc triggers for ER, SMART and WPS Watch
- Adds commands to re-create dispatchers for ER, SMART and WPS Watch
- Adds support for re-creating dispatchers from the admin
- Adds support for searching and filtering dispatchers in the admin
- Extends test coverage for dispatcher commands
- Fixes an issue deleting dispatchers

### Relevant link(s)
[GUNDI-3376](https://allenai.atlassian.net/browse/GUNDI-3376)

[GUNDI-3376]: https://allenai.atlassian.net/browse/GUNDI-3376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ