### PR TITLE
GUNDI-3558: Show stream type in activity logs title

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -258,7 +258,7 @@
         "filename": "cdip_admin/conftest.py",
         "hashed_secret": "27d933b78d3ea4a51a3ff26aef5831c92d43925c",
         "is_verified": false,
-        "line_number": 2989
+        "line_number": 3013
       }
     ],
     "cdip_admin/integrations/migrations/0047_init_erinreach_config_schema.py": [
@@ -296,5 +296,5 @@
       }
     ]
   },
-  "generated_at": "2024-11-01T21:11:21Z"
+  "generated_at": "2024-11-04T14:36:30Z"
 }

--- a/cdip_admin/conftest.py
+++ b/cdip_admin/conftest.py
@@ -1767,7 +1767,7 @@ def attachment_delivered_trace(
         # We save only IDs, no sensitive data is saved
         data_provider=provider_trap_tagger,
         related_to=event_delivered_trace.object_id,
-        object_type="ev",
+        object_type="att",
         destination=integrations_list_er[0],
         delivered_at="2023-07-10T19:37:48.425974Z",
         external_id="c258f9f7-1a2e-4932-8d60-3acd2f59a1b2",
@@ -1796,6 +1796,30 @@ def trap_tagger_to_er_observation_delivered_event(
         "payload": {
             "gundi_id": str(trap_tagger_event_trace.object_id),
             "related_to": None,
+            "external_id": "35983ced-1216-4d43-81da-01ee90ba9b80",
+            "data_provider_id": str(trap_tagger_event_trace.data_provider.id),
+            "destination_id": str(integrations_list_er[0].id),
+            "delivered_at": "2023-07-11 18:19:19.215015+00:00",
+        },
+    }
+    data_bytes = json.dumps(event_dict).encode("utf-8")
+    message.data = data_bytes
+    return message
+
+
+@pytest.fixture
+def trap_tagger_to_er_attachment_delivered_event(
+        mocker, trap_tagger_event_trace, attachment_delivered_trace, integrations_list_er
+):
+    message = mocker.MagicMock()
+    event_dict = {
+        "event_id": "605535df-1b9b-412b-9fd5-e29b09582999",
+        "timestamp": "2023-07-11 18:19:19.215459+00:00",
+        "schema_version": "v1",
+        "event_type": "ObservationDelivered",
+        "payload": {
+            "gundi_id": str(attachment_delivered_trace.object_id),
+            "related_to": str(trap_tagger_event_trace.object_id),
             "external_id": "35983ced-1216-4d43-81da-01ee90ba9b80",
             "data_provider_id": str(trap_tagger_event_trace.data_provider.id),
             "destination_id": str(integrations_list_er[0].id),

--- a/cdip_admin/event_consumers/dispatcher_events_consumer.py
+++ b/cdip_admin/event_consumers/dispatcher_events_consumer.py
@@ -14,6 +14,13 @@ from activity_log.models import ActivityLog
 logger = logging.getLogger(__name__)
 
 
+data_type_str_map = {
+    "obv": "Observation",
+    "ev": "Event",
+    "att": "Attachment"
+}
+
+
 def handle_observation_delivered_event(event_dict: dict):
     event = system_events.ObservationDelivered.parse_obj(event_dict)
     # Update the status and save the external id
@@ -74,7 +81,8 @@ def handle_observation_delivered_event(event_dict: dict):
         f"Recording delivery event in the activity log for gundi_id {event_data.gundi_id}, new destination_id: {event_data.destination_id}",
         extra={"event": event_dict}
     )
-    title = f"Observation Delivered to '{trace.destination.base_url}'"
+    data_type = data_type_str_map.get(trace.object_type, "Data")
+    title = f"{data_type} Delivered to '{trace.destination.base_url}'"
     log_data = {
         **event_dict["payload"],
         "source_external_id": str(trace.source.external_id) if trace.source else None,
@@ -143,7 +151,8 @@ def handle_observation_delivery_failed_event(event_dict: dict):
         f"Recording delivery error event in the activity log for gundi_id {event_data.gundi_id}, new destination_id: {event_data.destination_id}",
         extra={"event": event_dict}
     )
-    title = f"Error Delivering observation {trace.object_id} to '{trace.destination.base_url}'"
+    data_type = data_type_str_map.get(trace.object_type, "Data")
+    title = f"Error Delivering {data_type} {trace.object_id} to '{trace.destination.base_url}'"
     log_data = {
         **event_dict["payload"],
         "source_external_id": str(trace.source.external_id) if trace.source else None,
@@ -184,7 +193,8 @@ def handle_observation_updated_event(event_dict: dict):
         f"Recording update event in the activity log for gundi_id {event_data.gundi_id}, new destination_id: {event_data.destination_id}",
         extra={"event": event_dict}
     )
-    title = f"Observation {gundi_id} updated in '{trace.destination.base_url}'"
+    data_type = data_type_str_map.get(trace.object_type, "Data")
+    title = f"{data_type} {gundi_id} updated in '{trace.destination.base_url}'"
     log_data = {
         **event_dict["payload"],
         "source_external_id": str(trace.source.external_id) if trace.source else None,
@@ -225,7 +235,8 @@ def handle_observation_update_failed_event(event_dict: dict):
         f"Recording update error event in the activity log for gundi_id {gundi_id}, destination_id: {destination_id}",
         extra={"event": event_dict}
     )
-    title = f"Error Updating observation {gundi_id} in '{trace.destination.base_url}'"
+    data_type = data_type_str_map.get(trace.object_type, "Data")
+    title = f"Error Updating {data_type} {gundi_id} in '{trace.destination.base_url}'"
     log_data = {
         **event_dict["payload"],
         "source_external_id": str(trace.source.external_id) if trace.source else None,

--- a/cdip_admin/event_consumers/tests/test_dispatcher_events_consumer.py
+++ b/cdip_admin/event_consumers/tests/test_dispatcher_events_consumer.py
@@ -27,7 +27,7 @@ def test_process_observation_delivered_event_with_er_destination(
     assert activity_log.log_level == ActivityLog.LogLevels.DEBUG
     assert activity_log.origin == ActivityLog.Origin.DISPATCHER
     assert activity_log.value == "observation_delivery_succeeded"
-    assert activity_log.title == f"Observation Delivered to '{trap_tagger_event_trace.destination.base_url}'"
+    assert activity_log.title == f"Event Delivered to '{trap_tagger_event_trace.destination.base_url}'"
     assert activity_log.details == event_data
 
 
@@ -49,7 +49,7 @@ def test_process_observation_delivered_event_with_smart_destination(
     assert activity_log.log_level == ActivityLog.LogLevels.DEBUG
     assert activity_log.origin == ActivityLog.Origin.DISPATCHER
     assert activity_log.value == "observation_delivery_succeeded"
-    assert activity_log.title == f"Observation Delivered to '{trap_tagger_event_trace.destination.base_url}'"
+    assert activity_log.title == f"Event Delivered to '{trap_tagger_event_trace.destination.base_url}'"
     assert activity_log.details == event_data
 
 
@@ -76,7 +76,7 @@ def test_process_observation_delivered_event_with_two_er_destinations(
     assert activity_log.log_level == ActivityLog.LogLevels.DEBUG
     assert activity_log.origin == ActivityLog.Origin.DISPATCHER
     assert activity_log.value == "observation_delivery_succeeded"
-    assert activity_log.title == f"Observation Delivered to '{trace_one.destination.base_url}'"
+    assert activity_log.title == f"Event Delivered to '{trace_one.destination.base_url}'"
     assert activity_log.details == event_data
 
     process_event(trap_tagger_observation_delivered_event_two)  # A second event for the other destination
@@ -96,8 +96,9 @@ def test_process_observation_delivered_event_with_two_er_destinations(
     assert activity_log.log_level == ActivityLog.LogLevels.DEBUG
     assert activity_log.origin == ActivityLog.Origin.DISPATCHER
     assert activity_log.value == "observation_delivery_succeeded"
-    assert activity_log.title == f"Observation Delivered to '{trace_two.destination.base_url}'"
+    assert activity_log.title == f"Event Delivered to '{trace_two.destination.base_url}'"
     assert activity_log.details == event_data
+
 
 def test_process_observation_delivered_event_with_er_and_smart_destinations(
         trap_tagger_event_trace, trap_tagger_to_er_observation_delivered_event, trap_tagger_to_smart_observation_delivered_event
@@ -122,7 +123,7 @@ def test_process_observation_delivered_event_with_er_and_smart_destinations(
     assert activity_log.log_level == ActivityLog.LogLevels.DEBUG
     assert activity_log.origin == ActivityLog.Origin.DISPATCHER
     assert activity_log.value == "observation_delivery_succeeded"
-    assert activity_log.title == f"Observation Delivered to '{trace_one.destination.base_url}'"
+    assert activity_log.title == f"Event Delivered to '{trace_one.destination.base_url}'"
     assert activity_log.details == event_data
 
     process_event(trap_tagger_to_smart_observation_delivered_event)  # A second event for the other destination
@@ -142,7 +143,7 @@ def test_process_observation_delivered_event_with_er_and_smart_destinations(
     assert activity_log.log_level == ActivityLog.LogLevels.DEBUG
     assert activity_log.origin == ActivityLog.Origin.DISPATCHER
     assert activity_log.value == "observation_delivery_succeeded"
-    assert activity_log.title == f"Observation Delivered to '{trace_two.destination.base_url}'"
+    assert activity_log.title == f"Event Delivered to '{trace_two.destination.base_url}'"
     assert activity_log.details == event_data
 
 
@@ -168,7 +169,7 @@ def test_process_observation_delivery_failed_event(
     assert activity_log.log_level == ActivityLog.LogLevels.ERROR
     assert activity_log.origin == ActivityLog.Origin.DISPATCHER
     assert activity_log.value == "observation_delivery_failed"
-    assert activity_log.title == f"Error Delivering observation {trap_tagger_event_trace.object_id} to '{trap_tagger_event_trace.destination.base_url}'"
+    assert activity_log.title == f"Error Delivering Event {trap_tagger_event_trace.object_id} to '{trap_tagger_event_trace.destination.base_url}'"
     assert activity_log.details == event_data
 
 
@@ -204,7 +205,7 @@ def test_process_observation_delivered_event_after_retry_with_single_destination
     assert activity_log.log_level == ActivityLog.LogLevels.ERROR
     assert activity_log.origin == ActivityLog.Origin.DISPATCHER
     assert activity_log.value == "observation_delivery_failed"
-    assert activity_log.title == f"Error Delivering observation {trap_tagger_event_trace.object_id} to '{trap_tagger_event_trace.destination.base_url}'"
+    assert activity_log.title == f"Error Delivering Event {trap_tagger_event_trace.object_id} to '{trap_tagger_event_trace.destination.base_url}'"
     assert activity_log.details == event_data
 
     # Process the second event. The observation was delivered with success now
@@ -224,7 +225,7 @@ def test_process_observation_delivered_event_after_retry_with_single_destination
     assert activity_log.log_level == ActivityLog.LogLevels.DEBUG
     assert activity_log.origin == ActivityLog.Origin.DISPATCHER
     assert activity_log.value == "observation_delivery_succeeded"
-    assert activity_log.title == f"Observation Delivered to '{trap_tagger_event_trace.destination.base_url}'"
+    assert activity_log.title == f"Event Delivered to '{trap_tagger_event_trace.destination.base_url}'"
     assert activity_log.details == event_data
 
 
@@ -285,7 +286,7 @@ def test_process_observation_updated_event(
     assert activity_log.log_level == ActivityLog.LogLevels.DEBUG
     assert activity_log.origin == ActivityLog.Origin.DISPATCHER
     assert activity_log.value == "observation_update_succeeded"
-    assert activity_log.title == f"Observation {trap_tagger_event_update_trace.object_id} updated in '{trap_tagger_event_update_trace.destination.base_url}'"
+    assert activity_log.title == f"Event {trap_tagger_event_update_trace.object_id} updated in '{trap_tagger_event_update_trace.destination.base_url}'"
     assert activity_log.details == event_data
 
 
@@ -307,7 +308,7 @@ def test_process_observation_update_failed_event(
     assert activity_log.log_level == ActivityLog.LogLevels.ERROR
     assert activity_log.origin == ActivityLog.Origin.DISPATCHER
     assert activity_log.value == "observation_update_failed"
-    assert activity_log.title == f"Error Updating observation {trap_tagger_event_update_trace.object_id} in '{trap_tagger_event_update_trace.destination.base_url}'"
+    assert activity_log.title == f"Error Updating Event {trap_tagger_event_update_trace.object_id} in '{trap_tagger_event_update_trace.destination.base_url}'"
     assert activity_log.details == event_data
 
 

--- a/cdip_admin/event_consumers/tests/test_dispatcher_events_consumer.py
+++ b/cdip_admin/event_consumers/tests/test_dispatcher_events_consumer.py
@@ -329,13 +329,13 @@ def test_process_dispatcher_log_event(
     assert not activity_log.is_reversible
 
 
-@pytest.mark.parametrize("trace,delivery_event", [
-    ("trap_tagger_event_trace", "trap_tagger_to_er_observation_delivered_event"),
-    ("attachment_delivered_trace", "trap_tagger_to_er_attachment_delivered_event"),
-    ("trap_tagger_to_movebank_observation_trace", "trap_tagger_to_movebank_observation_delivered_event"),
+@pytest.mark.parametrize("trace,delivery_event,stream_type", [
+    ("trap_tagger_event_trace", "trap_tagger_to_er_observation_delivered_event", "Event"),
+    ("attachment_delivered_trace", "trap_tagger_to_er_attachment_delivered_event", "Attachment"),
+    ("trap_tagger_to_movebank_observation_trace", "trap_tagger_to_movebank_observation_delivered_event", "Observation"),
 ])
 def test_show_stream_type_in_activity_log_title_on_observation_delivery(
-        request, trace, delivery_event
+        request, trace, delivery_event, stream_type
 ):
     trace = request.getfixturevalue(trace)
     delivery_event = request.getfixturevalue(delivery_event)
@@ -344,5 +344,4 @@ def test_show_stream_type_in_activity_log_title_on_observation_delivery(
     event_data = json.loads(delivery_event.data)["payload"]
     # Check that the event was recorded with hte right title in the activity logs
     activity_log = ActivityLog.objects.filter(integration_id=event_data["data_provider_id"]).first()
-    data_type = data_type_str_map.get(trace.object_type, "Data")
-    assert activity_log.title == f"{data_type} Delivered to '{trace.destination.base_url}'"
+    assert activity_log.title == f"{stream_type} Delivered to '{trace.destination.base_url}'"


### PR DESCRIPTION
### What does this PR do?
- Modify activity log titles to differentiate delivery events by stream type (events, observations, attachments)
- Test coverage

### Relevant link(s)
[GUNDI-3558](https://allenai.atlassian.net/browse/GUNDI-3558)

[GUNDI-3558]: https://allenai.atlassian.net/browse/GUNDI-3558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ