### PR TITLE
GUNDI-3560: Show source id in activity logs

### DIFF
--- a/cdip_admin/activity_log/mixins.py
+++ b/cdip_admin/activity_log/mixins.py
@@ -148,7 +148,8 @@ class ChangeLogMixin:
 
     def get_id_display(self):
         if hasattr(self, "logs_id_field"):
-            return str(self.logs_id_field)
+            id_to_display = getattr(self, self.logs_id_field)
+            return str(id_to_display) if id_to_display else None
         return None
 
     def get_user(self):

--- a/cdip_admin/activity_log/mixins.py
+++ b/cdip_admin/activity_log/mixins.py
@@ -62,10 +62,12 @@ class ChangeLogMixin:
                     changes[field_name] = serialized_value
         return changes
 
-    def log_activity(self, integration, action, changes, is_reversible, revert_data=None, user=None):
+    def log_activity(self, integration, action, changes, is_reversible, revert_data=None, user=None, id_display=None):
         model_name = self.__class__.__name__
         value = f"{model_name.lower()}_{action.lower()}"
         title = f"{model_name} {action}"
+        if id_display:
+            title += f" ({id_display})"
         if user and not user.is_anonymous:
             title += f" by {user}"
         ActivityLog.objects.create(
@@ -99,7 +101,8 @@ class ChangeLogMixin:
                     changes=changes or self._original_values,  # FixMe: Some times on creation the changes are empty
                     is_reversible=True,
                     revert_data=self.get_revert_data(action=action, fields=changes.keys()),
-                    user=self.get_user()
+                    user=self.get_user(),
+                    id_display=self.get_id_display()
                 )
         except Exception as e:
             logger.warning(f"Activity Log > Error recording activity for {self}: '{e}'.")
@@ -111,7 +114,8 @@ class ChangeLogMixin:
                 action=ActivityActions.DELETED.value,
                 changes=self._original_values,
                 is_reversible=False,
-                user=self.get_user()
+                user=self.get_user(),
+                id_display=self.get_id_display()
             )
         except Exception as e:
             logger.warning(f"Activity Log > Error recording activity for {self}: '{e}'.")
@@ -141,6 +145,11 @@ class ChangeLogMixin:
             logger.warning(f"Activity Log: '{integration}' isn't an instance of Integration. Integration left empty.")
             integration = None
         return integration
+
+    def get_id_display(self):
+        if hasattr(self, "logs_id_field"):
+            return str(self.logs_id_field)
+        return None
 
     def get_user(self):
         return get_current_user()

--- a/cdip_admin/api/v2/tests/utils.py
+++ b/cdip_admin/api/v2/tests/utils.py
@@ -3,22 +3,25 @@ from activity_log.models import ActivityLog
 
 
 def _test_activity_logs_on_instance_created(activity_log, instance, user):
-    model = str(instance._meta.model.__name__)
+    Model = instance._meta.model
+    model_name = str(Model.__name__)
     details = activity_log.details
     assert activity_log
     assert activity_log.log_type == ActivityLog.LogTypes.DATA_CHANGE
     assert activity_log.log_level == ActivityLog.LogLevels.INFO
     assert activity_log.origin == ActivityLog.Origin.PORTAL
-    expected_title = f"{model} {ActivityActions.CREATED.value}"
+    expected_title = f"{model_name} {ActivityActions.CREATED.value}"
+    if hasattr(Model, "logs_id_field"):
+        expected_title += f" ({getattr(instance, Model.logs_id_field)})"
     if user and not user.is_anonymous:
         expected_title += f" by {user}"
     assert activity_log.title == expected_title
-    assert details.get("model_name") == model
+    assert details.get("model_name") == model_name
     assert details.get("instance_pk") == str(instance.pk)
     assert details.get("action") == ActivityActions.CREATED.value
     assert activity_log.is_reversible
     assert activity_log.revert_data == {
-        "model_name": model,
+        "model_name": model_name,
         "instance_pk": str(instance.pk)
     }
 

--- a/cdip_admin/integrations/models/v2/models.py
+++ b/cdip_admin/integrations/models/v2/models.py
@@ -610,6 +610,8 @@ class Source(ChangeLogMixin, UUIDAbstractModel, TimestampedModel):
         verbose_name="Additional JSON Configuration",
     )
 
+    logs_id_field = "external_id"
+
     def __str__(self):
         return f"{self.external_id} - {self.integration.type.name}"
 


### PR DESCRIPTION
### What does this PR do?
- Adds support for specifying a field to display as ID in activity logs of creation type.
- Shows the external ID in activity logs on source creation
- Test coverage

### Log title example
`Source CREATED (Z9Y8X7W6V5U4)`

### Relevant link(s)
[GUNDI-3560](https://allenai.atlassian.net/browse/GUNDI-3560)

[GUNDI-3560]: https://allenai.atlassian.net/browse/GUNDI-3560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ