### PR TITLE
GUNDI-3801: Update health status on integration enable/disable

### DIFF
--- a/cdip_admin/integrations/models/v2/models.py
+++ b/cdip_admin/integrations/models/v2/models.py
@@ -239,7 +239,7 @@ class Integration(ChangeLogMixin, UUIDAbstractModel, TimestampedModel):
             HealthCheckSettings.objects.get_or_create(integration=self)
         else:  # Updated
             if self.tracker.has_changed("enabled"):
-                # Update the integration status
+                # Reflect the enabled status in the health status asap
                 calculate_integration_statuses([str(self.id)])
                 # Disable/Enable related periodic tasks for pull actions
                 for config in self.configurations.filter(action__type=IntegrationAction.ActionTypes.PULL_DATA):

--- a/cdip_admin/integrations/tests/test_calc_integration_status.py
+++ b/cdip_admin/integrations/tests/test_calc_integration_status.py
@@ -85,3 +85,18 @@ def test_calculate_destination_integration_status_with_custom_threshold(
     calculate_integration_status(integration_id=destination_movebank.id)
     destination_movebank.status.refresh_from_db()
     assert destination_movebank.status.status == IntegrationStatus.Status.UNHEALTHY
+
+
+@pytest.mark.parametrize('enabled', [False, True,])
+def test_update_health_status_on_integration_enabled_change(
+        request,
+        enabled,
+        provider_lotek_panthera,
+):
+    provider_enabled = request.getfixturevalue('enabled')
+    provider_lotek_panthera.enabled = provider_enabled
+    provider_lotek_panthera.save()
+    provider_lotek_panthera.status.refresh_from_db()
+    health_status = provider_lotek_panthera.status.status
+    expected_status = IntegrationStatus.Status.HEALTHY if provider_enabled else IntegrationStatus.Status.DISABLED
+    assert health_status == expected_status.value

--- a/cdip_admin/integrations/tests/test_calc_integration_status.py
+++ b/cdip_admin/integrations/tests/test_calc_integration_status.py
@@ -1,5 +1,5 @@
 import pytest
-from integrations.models import IntegrationStatus
+from integrations.models import IntegrationStatus, Integration
 from ..models.v2 import calculate_integration_status
 
 
@@ -96,7 +96,17 @@ def test_update_health_status_on_integration_enabled_change(
     provider_enabled = request.getfixturevalue('enabled')
     provider_lotek_panthera.enabled = provider_enabled
     provider_lotek_panthera.save()
-    provider_lotek_panthera.status.refresh_from_db()
     health_status = provider_lotek_panthera.status.status
     expected_status = IntegrationStatus.Status.HEALTHY if provider_enabled else IntegrationStatus.Status.DISABLED
     assert health_status == expected_status.value
+
+
+def test_health_status_matches_integration_disabled_on_creation(integration_type_lotek, organization):
+    integration = Integration.objects.create(
+        type=integration_type_lotek,
+        name=f"Lotek Provider Disabled",
+        owner=organization,
+        base_url=f"api.test.lotek.com",
+        enabled=False
+    )
+    assert integration.status.status == IntegrationStatus.Status.DISABLED.value


### PR DESCRIPTION
### What does this PR do?
- Updates the health status immediately after enabling/disabling integrations and when they are created as disabled.
- Test coverage

### Relevant link(s)
[GUNDI-3801](https://allenai.atlassian.net/browse/GUNDI-3801)

[GUNDI-3801]: https://allenai.atlassian.net/browse/GUNDI-3801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ