### PR TITLE
GUNDI-3781: Fix connection status filter

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -258,7 +258,7 @@
         "filename": "cdip_admin/conftest.py",
         "hashed_secret": "27d933b78d3ea4a51a3ff26aef5831c92d43925c",
         "is_verified": false,
-        "line_number": 3013
+        "line_number": 3050
       }
     ],
     "cdip_admin/integrations/migrations/0047_init_erinreach_config_schema.py": [
@@ -296,5 +296,5 @@
       }
     ]
   },
-  "generated_at": "2024-11-04T14:36:30Z"
+  "generated_at": "2024-12-12T21:51:54Z"
 }

--- a/cdip_admin/api/v2/tests/test_connections_api.py
+++ b/cdip_admin/api/v2/tests/test_connections_api.py
@@ -460,6 +460,7 @@ def test_global_search_connections_as_org_viewer(
 def test_filter_connections_by_status_healthy_as_superuser(
         api_client, superuser, organization, connection_with_healthy_provider_and_destination,
         connection_with_unhealthy_provider, connection_with_unhealthy_destination, connection_with_disabled_destination,
+        connection_with_disabled_provider_and_unhealthy_destination,
 ):
     _test_filter_connections(
         api_client=api_client,
@@ -474,6 +475,7 @@ def test_filter_connections_by_status_healthy_as_superuser(
 def test_filter_connections_by_status_unhealthy_as_superuser(
         api_client, superuser, organization, connection_with_healthy_provider_and_destination,
         connection_with_unhealthy_provider, connection_with_unhealthy_destination, connection_with_disabled_destination,
+        connection_with_disabled_provider_and_unhealthy_destination,
 ):
     _test_filter_connections(
         api_client=api_client,
@@ -488,6 +490,7 @@ def test_filter_connections_by_status_unhealthy_as_superuser(
 def test_filter_connections_by_status_needs_review_as_superuser(
         api_client, superuser, organization, connection_with_healthy_provider_and_destination,
         connection_with_unhealthy_provider, connection_with_unhealthy_destination, connection_with_disabled_destination,
+        connection_with_disabled_provider_and_unhealthy_destination,
 ):
     _test_filter_connections(
         api_client=api_client,

--- a/cdip_admin/conftest.py
+++ b/cdip_admin/conftest.py
@@ -1370,6 +1370,43 @@ def connection_with_healthy_provider_and_destination(
 
 
 @pytest.fixture
+def connection_with_disabled_provider_and_unhealthy_destination(
+        organization,
+        integration_type_cellstop,
+        get_random_id,
+        cellstop_action_auth,
+        cellstop_action_fetch_samples,
+        er_destination_unhealthy
+):
+    # Create the integration
+    site_url = f"fake-{get_random_id()}.cellstop.com"
+    integration, _ = Integration.objects.get_or_create(
+        type=integration_type_cellstop,
+        name=f"Healthy Connection {get_random_id()}",
+        owner=organization,
+        base_url=site_url,
+        enabled=False
+    )
+    # Configure actions
+    IntegrationConfiguration.objects.create(
+        integration=integration,
+        action=cellstop_action_auth,
+        data={
+            "username": f"fake-username",
+            "password": f"fake-passwd",
+        },
+    )
+    IntegrationConfiguration.objects.create(
+        integration=integration,
+        action=cellstop_action_fetch_samples,
+        data={},
+    )
+    ensure_default_route(integration=integration)
+    RouteDestination.objects.create(integration=er_destination_unhealthy, route=integration.default_route)
+    return integration
+
+
+@pytest.fixture
 def connection_with_unhealthy_provider(
         organization,
         integration_type_cellstop,


### PR DESCRIPTION
### What does this PR do?
- Fixes an issue where `disabled` connections were wrongly returned when filtering by `unhealthy` (due to `unhealthy` destinations)
- Test coverage

### Relevant link(s)
[GUNDI-3781](https://allenai.atlassian.net/browse/GUNDI-3781)
[Connection Status Calc](https://allenai.atlassian.net/wiki/spaces/CDIP/pages/30428528641/Health+Indicators+WIP#Connection-status-aggregation-matrix)

[GUNDI-3781]: https://allenai.atlassian.net/browse/GUNDI-3781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ