### PR TITLE
GUNDI-3901: Update chart version to get env vars for config-events

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
     with:
       environment: dev
       chart_name: admin-portal
-      chart_version: '1.3.0'
+      chart_version: '1.3.1'
       repository: ${{ needs.vars.outputs.repository }}
       tag: ${{ needs.vars.outputs.tag }}
     secrets: inherit
@@ -48,7 +48,7 @@ jobs:
     with:
       environment: stage
       chart_name: admin-portal
-      chart_version: '1.3.0'
+      chart_version: '1.3.1'
       repository: ${{ needs.vars.outputs.repository }}
       tag: ${{ needs.vars.outputs.tag }}
     secrets: inherit


### PR DESCRIPTION
This pull request includes minor updates to the `chart_version` in the `.github/workflows/main.yml` file.

* Updated `chart_version` for `dev` environment from '1.3.0' to '1.3.1'.
* Updated `chart_version` for `stage` environment from '1.3.0' to '1.3.1'.