### PR TITLE
GUNDI-3559: Improve activity logs on dispatcher errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
       - 'release-**'
-      - 'gundi-3559-improve-delivery-error-logs'
 env:
   TRACING_ENABLED: ${{secrets.TRACING_ENABLED}}
   PUBSUB_ENABLED: ${{secrets.PUBSUB_ENABLED}}
@@ -32,7 +31,7 @@ jobs:
 
   deploy_dev:
     uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v2
-    if: startsWith(github.ref, 'refs/heads/gundi-3559-improve-delivery-error-logs')
+    if: startsWith(github.ref, 'refs/heads/main')
     needs: [vars, build]
     with:
       environment: dev

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - 'release-**'
+      - 'gundi-3559-improve-delivery-error-logs'
 env:
   TRACING_ENABLED: ${{secrets.TRACING_ENABLED}}
   PUBSUB_ENABLED: ${{secrets.PUBSUB_ENABLED}}
@@ -31,7 +32,7 @@ jobs:
 
   deploy_dev:
     uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v2
-    if: startsWith(github.ref, 'refs/heads/main')
+    if: startsWith(github.ref, 'refs/heads/gundi-3559-improve-delivery-error-logs')
     needs: [vars, build]
     with:
       environment: dev

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -258,7 +258,7 @@
         "filename": "cdip_admin/conftest.py",
         "hashed_secret": "27d933b78d3ea4a51a3ff26aef5831c92d43925c",
         "is_verified": false,
-        "line_number": 3442
+        "line_number": 3455
       }
     ],
     "cdip_admin/integrations/migrations/0047_init_erinreach_config_schema.py": [
@@ -296,5 +296,5 @@
       }
     ]
   },
-  "generated_at": "2025-01-23T20:03:55Z"
+  "generated_at": "2025-01-23T20:27:47Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -118,7 +118,7 @@
         "filename": ".github/workflows/main.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 42
+        "line_number": 43
       }
     ],
     ".github/workflows/values/dev.yml": [
@@ -296,5 +296,5 @@
       }
     ]
   },
-  "generated_at": "2025-01-13T23:26:12Z"
+  "generated_at": "2025-01-21T14:21:19Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -258,7 +258,7 @@
         "filename": "cdip_admin/conftest.py",
         "hashed_secret": "27d933b78d3ea4a51a3ff26aef5831c92d43925c",
         "is_verified": false,
-        "line_number": 3374
+        "line_number": 3442
       }
     ],
     "cdip_admin/integrations/migrations/0047_init_erinreach_config_schema.py": [
@@ -296,5 +296,5 @@
       }
     ]
   },
-  "generated_at": "2025-01-21T14:21:19Z"
+  "generated_at": "2025-01-23T20:03:55Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -118,7 +118,7 @@
         "filename": ".github/workflows/main.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 43
+        "line_number": 42
       }
     ],
     ".github/workflows/values/dev.yml": [
@@ -296,5 +296,5 @@
       }
     ]
   },
-  "generated_at": "2025-01-23T20:27:47Z"
+  "generated_at": "2025-01-23T20:45:25Z"
 }

--- a/cdip_admin/conftest.py
+++ b/cdip_admin/conftest.py
@@ -2290,7 +2290,7 @@ def trap_tagger_observation_delivered_event_two(
 
 
 @pytest.fixture
-def trap_tagger_observation_delivery_failed_event(
+def trap_tagger_observation_delivery_failed_schema_v1_event_one(
         mocker, trap_tagger_event_trace, integrations_list_er
 ):
     message = mocker.MagicMock()
@@ -2313,7 +2313,36 @@ def trap_tagger_observation_delivery_failed_event(
 
 
 @pytest.fixture
-def trap_tagger_observation_delivery_failed_event_two(
+def trap_tagger_observation_delivery_failed_schema_v2_event_one(
+        mocker, trap_tagger_event_trace, integrations_list_er
+):
+    message = mocker.MagicMock()
+    event_dict = {
+        "event_id": "605535df-1b9b-412b-9fd5-e29b09582999",
+        "timestamp": "2023-07-11 18:19:19.215459+00:00",
+        "schema_version": "v2",
+        "event_type": "ObservationDeliveryFailed",
+        "payload": {
+            'error': 'ERClientBadRequest: ER Bad Request ON POST https://fake-site.pamdas.org/api/v1.0/sensors/generic/1234/status (status_code=400) (response_body={"data": [[{"event_type": {"event_type": "Value \'animal_detection_alert_rep\' does not exist."}}]], "status": {"code": 400, "message": "Bad Request"}})',
+            'error_traceback': 'Traceback (most recent call last):\n  File "/home/dev/earthranger/gundi-dispatcher-er/core/event_handlers.py", line 124, in dispatch_transformed_observation_v2\n    result = await dispatcher.send(observation, **kwargs)\n  File "/home/dev/earthranger/gundi-dispatcher-er/core/dispatchers.py", line 214, in send\n    raise ex\n  File "/home/dev/earthranger/gundi-dispatcher-er/core/dispatchers.py", line 209, in send\n    return await client.post_report(\n  File "/usr/lib/python3.8/unittest/mock.py", line 1081, in __call__\n    return self._mock_call(*args, **kwargs)\n  File "/usr/lib/python3.8/unittest/mock.py", line 1085, in _mock_call\n    return self._execute_mock_call(*args, **kwargs)\n  File "/usr/lib/python3.8/unittest/mock.py", line 1140, in _execute_mock_call\n    raise effect\nerclient.er_errors.ERClientBadRequest: ER Bad Request ON POST https://fake-site.pamdas.org/api/v1.0/sensors/generic/1234/status (status_code=400) (response_body={"data": [[{"event_type": {"event_type": "Value \'detection_alert_rep\' does not exist."}}]], "status": {"code": 400, "message": "Bad Request"}})\n',
+            'server_response_status': 400,
+            'server_response_body': '{"data": [[{"event_type": {"event_type": "Value \'animal_detection_alert_rep\' does not exist."}}]], "status": {"code": 400, "message": "Bad Request"}}',
+            'observation': {
+                "gundi_id": str(trap_tagger_event_trace.object_id),
+                "related_to": None,
+                "data_provider_id": str(trap_tagger_event_trace.data_provider.id),
+                "destination_id": str(integrations_list_er[0].id),
+                "delivered_at": "2025-01-23 16:54:19.215015+00:00",
+            },
+        }
+    }
+    data_bytes = json.dumps(event_dict).encode("utf-8")
+    message.data = data_bytes
+    return message
+
+
+@pytest.fixture
+def trap_tagger_observation_delivery_failed_schema_v1_event_two(
         mocker, trap_tagger_event_trace, integrations_list_er
 ):
     message = mocker.MagicMock()
@@ -2336,7 +2365,7 @@ def trap_tagger_observation_delivery_failed_event_two(
 
 
 @pytest.fixture
-def trap_tagger_observation_update_failed_event(
+def trap_tagger_observation_update_failed_schema_v1_event(
         mocker, trap_tagger_event_update_trace, integrations_list_er
 ):
     message = mocker.MagicMock()
@@ -2356,6 +2385,45 @@ def trap_tagger_observation_update_failed_event(
     data_bytes = json.dumps(event_dict).encode("utf-8")
     message.data = data_bytes
     return message
+
+
+@pytest.fixture
+def trap_tagger_observation_update_failed_schema_v2_event(
+        mocker, trap_tagger_event_update_trace, integrations_list_er
+):
+    message = mocker.MagicMock()
+    event_dict = {
+        "event_id": "605535df-1b9b-412b-9fd5-e29b09582999",
+        "timestamp": "2023-07-11 18:19:19.215459+00:00",
+        "schema_version": "v2",
+        "event_type": "ObservationUpdateFailed",
+        "payload": {
+            # ToDo: get a real example
+            "observation": {
+                "gundi_id": str(trap_tagger_event_update_trace.object_id),
+                "related_to": None,
+                "data_provider_id": str(trap_tagger_event_update_trace.data_provider.id),
+                "destination_id": str(integrations_list_er[0].id),
+                "updated_at": "2024-07-25 12:25:44.442696+00:00",
+            }
+        },
+    }
+    data_bytes = json.dumps(event_dict).encode("utf-8")
+    message.data = data_bytes
+    return message
+
+
+@pytest.fixture
+def observation_delivery_failed_event(
+        request,
+        trap_tagger_observation_delivery_failed_schema_v1_event_one,
+        trap_tagger_observation_delivery_failed_schema_v2_event_one
+):
+    if request.param == "schema_v1":
+        return trap_tagger_observation_delivery_failed_schema_v1_event_one
+    else:  # Default to the latest version
+        return trap_tagger_observation_delivery_failed_schema_v2_event_one
+
 
 @pytest.fixture
 def wpswatch_dispatcher_log_event(

--- a/cdip_admin/conftest.py
+++ b/cdip_admin/conftest.py
@@ -2398,7 +2398,10 @@ def trap_tagger_observation_update_failed_schema_v2_event(
         "schema_version": "v2",
         "event_type": "ObservationUpdateFailed",
         "payload": {
-            # ToDo: get a real example
+            "error": "Event 69afe55f-24a5-40c6-8320-24c244bc4e4e wasn't delivered yet. Will retry later.",
+            "error_traceback": "",
+            "server_response_status": None,
+            "server_response_body": "",
             "observation": {
                 "gundi_id": str(trap_tagger_event_update_trace.object_id),
                 "related_to": None,
@@ -2424,6 +2427,16 @@ def observation_delivery_failed_event(
     else:  # Default to the latest version
         return trap_tagger_observation_delivery_failed_schema_v2_event_one
 
+@pytest.fixture
+def observation_update_failed_event(
+        request,
+        trap_tagger_observation_update_failed_schema_v1_event,
+        trap_tagger_observation_update_failed_schema_v2_event
+):
+    if request.param == "schema_v1":
+        return trap_tagger_observation_update_failed_schema_v1_event
+    else:
+        return trap_tagger_observation_update_failed_schema_v2_event
 
 @pytest.fixture
 def wpswatch_dispatcher_log_event(

--- a/cdip_admin/event_consumers/dispatcher_events_consumer.py
+++ b/cdip_admin/event_consumers/dispatcher_events_consumer.py
@@ -113,6 +113,10 @@ def handle_observation_delivery_failed_event(event_dict: dict):
     schema_version = event_dict.get("schema_version")
     if schema_version == "v1":
         event = build_delivery_failed_event_v2_from_v1_data(event_dict)
+        destination_id = event.payload.observation.destination_id
+        logger.warning(
+            f"Event schema version v1 is deprecated. Please update the dispatcher of destination {destination_id}."
+        )
     else:
         event = system_events.ObservationDeliveryFailed.parse_obj(event_dict)
     # Update the status and save the external id
@@ -240,6 +244,10 @@ def handle_observation_update_failed_event(event_dict: dict):
     schema_version = event_dict.get("schema_version")
     if schema_version == "v1":
         event = build_update_failed_event_v2_from_v1_data(event_dict)
+        destination_id = event.payload.observation.destination_id
+        logger.warning(
+            f"Event schema version v1 is deprecated. Please update the dispatcher of destination {destination_id}."
+        )
     else:
         event = system_events.ObservationUpdateFailed.parse_obj(event_dict)
     event_data = event.payload

--- a/cdip_admin/event_consumers/dispatcher_events_consumer.py
+++ b/cdip_admin/event_consumers/dispatcher_events_consumer.py
@@ -82,7 +82,7 @@ def handle_observation_delivered_event(event_dict: dict):
         extra={"event": event_dict}
     )
     data_type = data_type_str_map.get(trace.object_type, "Data")
-    title = f"{data_type} Delivered to '{trace.destination.base_url}'"
+    title = f"{data_type} {trace.object_id} Delivered to '{trace.destination.base_url}'"
     log_data = {
         **event_dict["payload"],
         "source_external_id": str(trace.source.external_id) if trace.source else None,

--- a/cdip_admin/event_consumers/dispatcher_events_consumer.py
+++ b/cdip_admin/event_consumers/dispatcher_events_consumer.py
@@ -176,6 +176,8 @@ def handle_observation_delivery_failed_event(event_dict: dict):
         **event.payload.dict(),
         "source_external_id": str(trace.source.external_id) if trace.source else None,
     }
+    # Workaround to serialize complex types until upgrading to pydantic v2
+    log_data_cleaned = json.loads(json.dumps(log_data, default=str)),
     ActivityLog.objects.create(
         log_level=ActivityLog.LogLevels.ERROR,
         log_type=ActivityLog.LogTypes.EVENT,
@@ -183,7 +185,7 @@ def handle_observation_delivery_failed_event(event_dict: dict):
         integration=trace.data_provider,
         value="observation_delivery_failed",
         title=title,
-        details=log_data,
+        details=log_data_cleaned,
         is_reversible=False
     )
 
@@ -279,6 +281,8 @@ def handle_observation_update_failed_event(event_dict: dict):
         **event.payload.dict(),
         "source_external_id": str(trace.source.external_id) if trace.source else None,
     }
+    # Workaround to serialize complex types until upgrading to pydantic v2
+    log_data_cleaned = json.loads(json.dumps(log_data, default=str)),
     ActivityLog.objects.create(
         log_level=ActivityLog.LogLevels.ERROR,
         log_type=ActivityLog.LogTypes.EVENT,
@@ -286,7 +290,7 @@ def handle_observation_update_failed_event(event_dict: dict):
         integration=trace.data_provider,
         value="observation_update_failed",
         title=title,
-        details=log_data,
+        details=log_data_cleaned,
         is_reversible=False
     )
 

--- a/cdip_admin/event_consumers/dispatcher_events_consumer.py
+++ b/cdip_admin/event_consumers/dispatcher_events_consumer.py
@@ -177,7 +177,7 @@ def handle_observation_delivery_failed_event(event_dict: dict):
         "source_external_id": str(trace.source.external_id) if trace.source else None,
     }
     # Workaround to serialize complex types until upgrading to pydantic v2
-    log_data_cleaned = json.loads(json.dumps(log_data, default=str)),
+    log_data_cleaned = json.loads(json.dumps(log_data, default=str))
     ActivityLog.objects.create(
         log_level=ActivityLog.LogLevels.ERROR,
         log_type=ActivityLog.LogTypes.EVENT,
@@ -282,7 +282,7 @@ def handle_observation_update_failed_event(event_dict: dict):
         "source_external_id": str(trace.source.external_id) if trace.source else None,
     }
     # Workaround to serialize complex types until upgrading to pydantic v2
-    log_data_cleaned = json.loads(json.dumps(log_data, default=str)),
+    log_data_cleaned = json.loads(json.dumps(log_data, default=str))
     ActivityLog.objects.create(
         log_level=ActivityLog.LogLevels.ERROR,
         log_type=ActivityLog.LogTypes.EVENT,

--- a/cdip_admin/event_consumers/dispatcher_events_consumer.py
+++ b/cdip_admin/event_consumers/dispatcher_events_consumer.py
@@ -143,7 +143,7 @@ def handle_observation_delivery_failed_event(event_dict: dict):
             f"Creating trace with error for gundi_id {observation.gundi_id}, new destination_id: {observation.destination_id}",
             extra={"event": event_dict}
         )
-        GundiTrace.objects.create(
+        trace = GundiTrace.objects.create(
             object_id=trace.object_id,
             object_type=trace.object_type,
             source=trace.source,

--- a/cdip_admin/event_consumers/dispatcher_events_consumer.py
+++ b/cdip_admin/event_consumers/dispatcher_events_consumer.py
@@ -103,7 +103,7 @@ def build_delivery_failed_event_v2_from_v1_data(event_dict: dict) -> system_even
     v1_payload = event_dict.get("payload")
     return system_events.ObservationDeliveryFailed(
         payload=system_events.DeliveryErrorDetails(
-            error="Delivery Failed at the Dispatcher. Check the server logs for more details.",
+            error="Delivery Failed at the Dispatcher. Please update this dispatcher to see more details here.",
             observation=system_events.DispatchedObservation.parse_obj(v1_payload)
         )
     )
@@ -173,7 +173,7 @@ def handle_observation_delivery_failed_event(event_dict: dict):
     data_type = data_type_str_map.get(trace.object_type, "Data")
     title = f"Error Delivering {data_type} {trace.object_id} to '{trace.destination.base_url}'"
     log_data = {
-        **event_dict["payload"],
+        **event.payload.dict(),
         "source_external_id": str(trace.source.external_id) if trace.source else None,
     }
     ActivityLog.objects.create(
@@ -234,7 +234,7 @@ def build_update_failed_event_v2_from_v1_data(event_dict: dict) -> system_events
     v1_payload = event_dict.get("payload")
     return system_events.ObservationUpdateFailed(
         payload=system_events.UpdateErrorDetails(
-            error="Update Failed at the Dispatcher. Check the server logs for more details.",
+            error="Update Failed at the Dispatcher. Please update this dispatcher to see more details here.",
             observation=system_events.UpdatedObservation.parse_obj(v1_payload)
         )
     )
@@ -276,7 +276,7 @@ def handle_observation_update_failed_event(event_dict: dict):
     data_type = data_type_str_map.get(trace.object_type, "Data")
     title = f"Error Updating {data_type} {gundi_id} in '{trace.destination.base_url}'"
     log_data = {
-        **event_dict["payload"],
+        **event.payload.dict(),
         "source_external_id": str(trace.source.external_id) if trace.source else None,
     }
     ActivityLog.objects.create(

--- a/cdip_admin/event_consumers/tests/test_dispatcher_events_consumer.py
+++ b/cdip_admin/event_consumers/tests/test_dispatcher_events_consumer.py
@@ -27,7 +27,7 @@ def test_process_observation_delivered_event_with_er_destination(
     assert activity_log.log_level == ActivityLog.LogLevels.DEBUG
     assert activity_log.origin == ActivityLog.Origin.DISPATCHER
     assert activity_log.value == "observation_delivery_succeeded"
-    assert activity_log.title == f"Event Delivered to '{trap_tagger_event_trace.destination.base_url}'"
+    assert activity_log.title == f"Event {trap_tagger_event_trace.object_id} Delivered to '{trap_tagger_event_trace.destination.base_url}'"
     assert activity_log.details == event_data
 
 
@@ -49,7 +49,7 @@ def test_process_observation_delivered_event_with_smart_destination(
     assert activity_log.log_level == ActivityLog.LogLevels.DEBUG
     assert activity_log.origin == ActivityLog.Origin.DISPATCHER
     assert activity_log.value == "observation_delivery_succeeded"
-    assert activity_log.title == f"Event Delivered to '{trap_tagger_event_trace.destination.base_url}'"
+    assert activity_log.title == f"Event {trap_tagger_event_trace.object_id} Delivered to '{trap_tagger_event_trace.destination.base_url}'"
     assert activity_log.details == event_data
 
 
@@ -76,7 +76,7 @@ def test_process_observation_delivered_event_with_two_er_destinations(
     assert activity_log.log_level == ActivityLog.LogLevels.DEBUG
     assert activity_log.origin == ActivityLog.Origin.DISPATCHER
     assert activity_log.value == "observation_delivery_succeeded"
-    assert activity_log.title == f"Event Delivered to '{trace_one.destination.base_url}'"
+    assert activity_log.title == f"Event {trace_one.object_id} Delivered to '{trace_one.destination.base_url}'"
     assert activity_log.details == event_data
 
     process_event(trap_tagger_observation_delivered_event_two)  # A second event for the other destination
@@ -96,7 +96,7 @@ def test_process_observation_delivered_event_with_two_er_destinations(
     assert activity_log.log_level == ActivityLog.LogLevels.DEBUG
     assert activity_log.origin == ActivityLog.Origin.DISPATCHER
     assert activity_log.value == "observation_delivery_succeeded"
-    assert activity_log.title == f"Event Delivered to '{trace_two.destination.base_url}'"
+    assert activity_log.title == f"Event {trace_two.object_id} Delivered to '{trace_two.destination.base_url}'"
     assert activity_log.details == event_data
 
 
@@ -123,7 +123,7 @@ def test_process_observation_delivered_event_with_er_and_smart_destinations(
     assert activity_log.log_level == ActivityLog.LogLevels.DEBUG
     assert activity_log.origin == ActivityLog.Origin.DISPATCHER
     assert activity_log.value == "observation_delivery_succeeded"
-    assert activity_log.title == f"Event Delivered to '{trace_one.destination.base_url}'"
+    assert activity_log.title == f"Event {trace_one.object_id} Delivered to '{trace_one.destination.base_url}'"
     assert activity_log.details == event_data
 
     process_event(trap_tagger_to_smart_observation_delivered_event)  # A second event for the other destination
@@ -143,7 +143,7 @@ def test_process_observation_delivered_event_with_er_and_smart_destinations(
     assert activity_log.log_level == ActivityLog.LogLevels.DEBUG
     assert activity_log.origin == ActivityLog.Origin.DISPATCHER
     assert activity_log.value == "observation_delivery_succeeded"
-    assert activity_log.title == f"Event Delivered to '{trace_two.destination.base_url}'"
+    assert activity_log.title == f"Event {trace_two.object_id} Delivered to '{trace_two.destination.base_url}'"
     assert activity_log.details == event_data
 
 
@@ -225,7 +225,7 @@ def test_process_observation_delivered_event_after_retry_with_single_destination
     assert activity_log.log_level == ActivityLog.LogLevels.DEBUG
     assert activity_log.origin == ActivityLog.Origin.DISPATCHER
     assert activity_log.value == "observation_delivery_succeeded"
-    assert activity_log.title == f"Event Delivered to '{trap_tagger_event_trace.destination.base_url}'"
+    assert activity_log.title == f"Event {trap_tagger_event_trace.object_id} Delivered to '{trap_tagger_event_trace.destination.base_url}'"
     assert activity_log.details == event_data
 
 
@@ -344,4 +344,4 @@ def test_show_stream_type_in_activity_log_title_on_observation_delivery(
     event_data = json.loads(delivery_event.data)["payload"]
     # Check that the event was recorded with hte right title in the activity logs
     activity_log = ActivityLog.objects.filter(integration_id=event_data["data_provider_id"]).first()
-    assert activity_log.title == f"{stream_type} Delivered to '{trace.destination.base_url}'"
+    assert activity_log.title == f"{stream_type} {trace.object_id} Delivered to '{trace.destination.base_url}'"

--- a/dependencies/requirements-dev.txt
+++ b/dependencies/requirements-dev.txt
@@ -281,7 +281,7 @@ gundi-client==1.0.4
     #   cdip-connector
 gundi-client-v2==2.3.8
     # via -r requirements.in
-gundi-core==1.8.1
+gundi-core==1.9.0
     # via
     #   -r requirements.in
     #   cdip-connector

--- a/dependencies/requirements.in
+++ b/dependencies/requirements.in
@@ -68,7 +68,7 @@ jsonschema==4.17.3
 django-celery-beat==2.5.0
 django-storages==1.13.2
 walrus==0.8.1
-gundi-core==1.8.1
+gundi-core==1.9.0
 gundi-client==1.0.4
 gundi-client-v2==2.3.8
 google-cloud-functions==1.13.1

--- a/dependencies/requirements.txt
+++ b/dependencies/requirements.txt
@@ -266,7 +266,7 @@ gundi-client==1.0.4
     #   cdip-connector
 gundi-client-v2==2.3.8
     # via -r requirements.in
-gundi-core==1.8.1
+gundi-core==1.9.0
     # via
     #   -r requirements.in
     #   cdip-connector


### PR DESCRIPTION
### What does this PR do?
- Updates gundi-core and modified the dispatcher events consumer to process the latest events published by dispatchers which contain more info on errors including the traceback, server response status, and the response body. This extra info is now stored in activity logs under "details" so that we can see it in the portal and use it for troubleshooting
- Contemplates that dispatchers running an older version of the code may be publishing events with an older schema. Both schema versions are supported. v1 schema events, which don't carry extra error details, are converted to v2 schema events setting a default error message like "Delivery Failed at the Dispatcher. Please update this dispatcher to see more details here." 
- Test coverage

### How this looks in activity logs
![activity_logs_with_details](https://github.com/user-attachments/assets/81829eac-ece9-4c73-9add-479e7ddecf78)

### Relevant link(s)
[GUNDI-3559](https://allenai.atlassian.net/browse/GUNDI-3559)

[GUNDI-3559]: https://allenai.atlassian.net/browse/GUNDI-3559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ