### PR TITLE
GUNDI-3912: Save extra details on connector errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - 'release-**'
+      - gundi-3912-extra-details-on-connector-errors
 env:
   TRACING_ENABLED: ${{secrets.TRACING_ENABLED}}
   PUBSUB_ENABLED: ${{secrets.PUBSUB_ENABLED}}
@@ -31,7 +32,7 @@ jobs:
 
   deploy_dev:
     uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v2
-    if: startsWith(github.ref, 'refs/heads/main')
+    if: startsWith(github.ref, 'refs/heads/gundi-3912-extra-details-on-connector-errors')
     needs: [vars, build]
     with:
       environment: dev

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
       - 'release-**'
-      - gundi-3912-extra-details-on-connector-errors
 env:
   TRACING_ENABLED: ${{secrets.TRACING_ENABLED}}
   PUBSUB_ENABLED: ${{secrets.PUBSUB_ENABLED}}
@@ -32,7 +31,7 @@ jobs:
 
   deploy_dev:
     uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v2
-    if: startsWith(github.ref, 'refs/heads/gundi-3912-extra-details-on-connector-errors')
+    if: startsWith(github.ref, 'refs/heads/main')
     needs: [vars, build]
     with:
       environment: dev

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -258,7 +258,7 @@
         "filename": "cdip_admin/conftest.py",
         "hashed_secret": "27d933b78d3ea4a51a3ff26aef5831c92d43925c",
         "is_verified": false,
-        "line_number": 3455
+        "line_number": 3461
       }
     ],
     "cdip_admin/integrations/migrations/0047_init_erinreach_config_schema.py": [
@@ -296,5 +296,5 @@
       }
     ]
   },
-  "generated_at": "2025-01-30T19:54:55Z"
+  "generated_at": "2025-01-31T15:45:49Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -118,7 +118,7 @@
         "filename": ".github/workflows/main.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 42
+        "line_number": 43
       }
     ],
     ".github/workflows/values/dev.yml": [
@@ -296,5 +296,5 @@
       }
     ]
   },
-  "generated_at": "2025-01-23T20:45:25Z"
+  "generated_at": "2025-01-30T18:10:30Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -118,7 +118,7 @@
         "filename": ".github/workflows/main.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 43
+        "line_number": 42
       }
     ],
     ".github/workflows/values/dev.yml": [
@@ -296,5 +296,5 @@
       }
     ]
   },
-  "generated_at": "2025-01-30T18:10:30Z"
+  "generated_at": "2025-01-30T19:54:55Z"
 }

--- a/cdip_admin/conftest.py
+++ b/cdip_admin/conftest.py
@@ -3320,6 +3320,12 @@ def pull_observations_action_failed_event(mocker, provider_lotek_panthera):
             "action_id": "pull_observations",
             "config_data": {"start_date": "2024-02-05"},
             "error": "Error connecting to provider.",
+            "request_url": "https://fake-api.lotek.com/observations",
+            "request_data": str(json.dumps({"start_date": "2024-02-05"})),
+            "request_verb": "POST",
+            "error_traceback": 'Traceback (most recent call last):\n  File "/code/path/file.py ..."',
+            "server_response_body": str(json.dumps({"status": "500", "error": "something went wrong"})),
+            "server_response_status": 500
         },
         "event_type": "IntegrationActionFailed",
     }

--- a/cdip_admin/event_consumers/integration_events_consumer.py
+++ b/cdip_admin/event_consumers/integration_events_consumer.py
@@ -66,7 +66,7 @@ def handle_integration_action_failed_event(event_dict: dict):
     action_id = event_data.action_id
     integration_id = event_data.integration_id
     integration = Integration.objects.get(id=integration_id)
-    error = event_data.payload.error
+    error = event_data.error
     message = f"Error running action '{action_id}': {error}"
     logger.info(message, extra={"event": event_dict})
     # Workaround to serialize complex types until upgrading to pydantic v2

--- a/cdip_admin/event_consumers/integration_events_consumer.py
+++ b/cdip_admin/event_consumers/integration_events_consumer.py
@@ -66,9 +66,11 @@ def handle_integration_action_failed_event(event_dict: dict):
     action_id = event_data.action_id
     integration_id = event_data.integration_id
     integration = Integration.objects.get(id=integration_id)
-    error = event_dict["payload"].get("error", "No details.")
+    error = event_data.payload.error
     message = f"Error running action '{action_id}': {error}"
     logger.info(message, extra={"event": event_dict})
+    # Workaround to serialize complex types until upgrading to pydantic v2
+    log_data_clean = json.loads(json.dumps(event_data.dict(), default=str))
     ActivityLog.objects.create(
         log_level=ActivityLog.LogLevels.ERROR,
         log_type=ActivityLog.LogTypes.EVENT,
@@ -76,7 +78,7 @@ def handle_integration_action_failed_event(event_dict: dict):
         integration=integration,
         value="integration_action_failed",
         title=_clean_event_title(message),
-        details=event_dict.get("payload", {}),
+        details=log_data_clean,
         is_reversible=False,
     )
 

--- a/cdip_admin/event_consumers/tests/test_integration_events_consumer.py
+++ b/cdip_admin/event_consumers/tests/test_integration_events_consumer.py
@@ -53,6 +53,10 @@ def test_process_action_failed_event(
     assert activity_log.origin == ActivityLog.Origin.INTEGRATION
     assert activity_log.value == "integration_action_failed"
     assert activity_log.is_reversible is False
+    # Check that error details have been recorded
+    event_error_details = json.loads(pull_observations_action_failed_event.data)["payload"]
+    log_details = activity_log.details
+    assert log_details == event_error_details
 
 
 def test_process_custom_activity_log_event(

--- a/dependencies/requirements-dev.txt
+++ b/dependencies/requirements-dev.txt
@@ -281,7 +281,7 @@ gundi-client==1.0.4
     #   cdip-connector
 gundi-client-v2==2.3.8
     # via -r requirements.in
-gundi-core==1.9.0
+gundi-core==1.9.1
     # via
     #   -r requirements.in
     #   cdip-connector

--- a/dependencies/requirements.in
+++ b/dependencies/requirements.in
@@ -68,7 +68,7 @@ jsonschema==4.17.3
 django-celery-beat==2.5.0
 django-storages==1.13.2
 walrus==0.8.1
-gundi-core==1.9.0
+gundi-core==1.9.1
 gundi-client==1.0.4
 gundi-client-v2==2.3.8
 google-cloud-functions==1.13.1

--- a/dependencies/requirements.txt
+++ b/dependencies/requirements.txt
@@ -266,7 +266,7 @@ gundi-client==1.0.4
     #   cdip-connector
 gundi-client-v2==2.3.8
     # via -r requirements.in
-gundi-core==1.9.0
+gundi-core==1.9.1
     # via
     #   -r requirements.in
     #   cdip-connector


### PR DESCRIPTION
### What does this PR do?
- Updates gundi-core and modified the integration events consumer to process the latest events published by connectors which contain more info on errors including the traceback, server response status, and the response body, when available. This extra info is now stored in activity logs under "details" so that we can see it in the portal and use it for troubleshooting
- Test coverage

### How this looks in activity logs
![connector_error_details](https://github.com/user-attachments/assets/f4f7f6aa-c0c6-406d-bfc8-4517709c4b8e)

### Relevant link(s)
[GUNDI-3912](https://allenai.atlassian.net/browse/GUNDI-3912)


[GUNDI-3912]: https://allenai.atlassian.net/browse/GUNDI-3912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ