### PR TITLE
GUNDI-3881: Exclude disabled in the unhealthy connections email

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -258,7 +258,7 @@
         "filename": "cdip_admin/conftest.py",
         "hashed_secret": "27d933b78d3ea4a51a3ff26aef5831c92d43925c",
         "is_verified": false,
-        "line_number": 3455
+        "line_number": 3492
       }
     ],
     "cdip_admin/integrations/migrations/0047_init_erinreach_config_schema.py": [
@@ -296,5 +296,5 @@
       }
     ]
   },
-  "generated_at": "2025-01-23T20:45:25Z"
+  "generated_at": "2025-01-31T18:52:47Z"
 }

--- a/cdip_admin/cdip_admin/settings.py
+++ b/cdip_admin/cdip_admin/settings.py
@@ -332,6 +332,7 @@ EMAIL_FROM_DISPLAY_DEFAULT = env.str("EMAIL_FROM_DISPLAY_DEFAULT", "Gundi Notifi
 EMAIL_REPLY_DEFAULT = env.str("EMAIL_REPLY_DEFAULT", "noreply@tempuri.org")
 EMAIL_INVITE_REDIRECT_URL = env.str("EMAIL_INVITE_REDIRECT_URL", "https://cdip-prod01.pamdas.org")
 EMAIL_ALERT_RECIPIENTS = env.list("EMAIL_ALERT_RECIPIENTS", default=["support@earthranger.com", "gundi@earthranger.com"])
+EMAIL_ALERT_INCLUDE_DISABLED = env.bool("EMAIL_ALERT_INCLUDE_DISABLED", False)
 PORTAL_BASE_URL = env.str("PORTAL_BASE_URL", "https://gundiservice.org")  # to render links to the portal in emails
 
 # Used for storing files such as report attachments

--- a/cdip_admin/conftest.py
+++ b/cdip_admin/conftest.py
@@ -1694,6 +1694,43 @@ def connection_with_healthy_provider_and_destination(
 
 
 @pytest.fixture
+def connection_with_disabled_provider(
+        organization,
+        integration_type_cellstop,
+        get_random_id,
+        cellstop_action_auth,
+        cellstop_action_fetch_samples,
+        er_destination_healthy
+):
+    # Create the integration
+    site_url = f"fake-{get_random_id()}.cellstop.com"
+    integration, _ = Integration.objects.get_or_create(
+        type=integration_type_cellstop,
+        name=f"Disabled Connection {get_random_id()}",
+        owner=organization,
+        base_url=site_url,
+        enabled=False
+    )
+    # Configure actions
+    IntegrationConfiguration.objects.create(
+        integration=integration,
+        action=cellstop_action_auth,
+        data={
+            "username": f"fake-username",
+            "password": f"fake-passwd",
+        },
+    )
+    IntegrationConfiguration.objects.create(
+        integration=integration,
+        action=cellstop_action_fetch_samples,
+        data={},
+    )
+    ensure_default_route(integration=integration)
+    RouteDestination.objects.create(integration=er_destination_healthy, route=integration.default_route)
+    return integration
+
+
+@pytest.fixture
 def connection_with_disabled_provider_and_unhealthy_destination(
         organization,
         integration_type_cellstop,

--- a/cdip_admin/emails/templates/unhealthy_connections_email.html
+++ b/cdip_admin/emails/templates/unhealthy_connections_email.html
@@ -83,15 +83,17 @@
                     <td>{{ connection.id }}</td>
                 </tr>
                 {% endfor %}
-                {% for connection in disabled_connections %}
-                <tr>
-                    <td class="status-disabled">disabled</td>
-                    <td>
-                        <a href="{{ portal_base_url }}/connections/{{ connection.id }}/logs" class="connection-link">{{ connection.name }}</a>
-                    </td>
-                    <td>{{ connection.id }}</td>
-                </tr>
-                {% endfor %}
+                {% if include_disabled %}
+                    {% for connection in disabled_connections %}
+                    <tr>
+                        <td class="status-disabled">disabled</td>
+                        <td>
+                            <a href="{{ portal_base_url }}/connections/{{ connection.id }}/logs" class="connection-link">{{ connection.name }}</a>
+                        </td>
+                        <td>{{ connection.id }}</td>
+                    </tr>
+                    {% endfor %}
+                {% endif %}
             </tbody>
         </table>
     </div>

--- a/cdip_admin/integrations/tasks.py
+++ b/cdip_admin/integrations/tasks.py
@@ -367,7 +367,7 @@ def calculate_integration_statuses_in_batches(batch_size=20):
 
 
 @shared_task
-def send_unhealthy_connections_email():
+def send_unhealthy_connections_email(include_disabled=settings.EMAIL_ALERT_INCLUDE_DISABLED):
     logger.info("Checking for unhealthy integrations to send email notification...")
     from integrations.models.v2 import Integration, ConnectionStatus, filter_connections_by_status
     providers = Integration.providers.all()
@@ -375,7 +375,7 @@ def send_unhealthy_connections_email():
     review_connections = filter_connections_by_status(queryset=providers, status=ConnectionStatus.NEEDS_REVIEW.value)
     disabled_connections = filter_connections_by_status(queryset=providers, status=ConnectionStatus.DISABLED.value)
 
-    if not unhealthy_connections.exists() and not review_connections.exists() and not disabled_connections.exists():
+    if not unhealthy_connections.exists() and not review_connections.exists() and (not include_disabled or not disabled_connections.exists()):
         logger.info("No connections needing attention found. Skipping email notification.")
         return
 
@@ -384,7 +384,8 @@ def send_unhealthy_connections_email():
         "unhealthy_connections": unhealthy_connections,
         "review_connections": review_connections,
         "disabled_connections": disabled_connections,
-        "portal_base_url": settings.PORTAL_BASE_URL
+        "portal_base_url": settings.PORTAL_BASE_URL,
+        "include_disabled": include_disabled
     }
     html_content = render_to_string("unhealthy_connections_email.html", context)
     email = EmailMultiAlternatives(

--- a/cdip_admin/integrations/tasks.py
+++ b/cdip_admin/integrations/tasks.py
@@ -367,8 +367,9 @@ def calculate_integration_statuses_in_batches(batch_size=20):
 
 
 @shared_task
-def send_unhealthy_connections_email(include_disabled=settings.EMAIL_ALERT_INCLUDE_DISABLED):
+def send_unhealthy_connections_email(include_disabled=None):
     logger.info("Checking for unhealthy integrations to send email notification...")
+    include_disabled = include_disabled or settings.EMAIL_ALERT_INCLUDE_DISABLED
     from integrations.models.v2 import Integration, ConnectionStatus, filter_connections_by_status
     providers = Integration.providers.all()
     unhealthy_connections = filter_connections_by_status(queryset=providers, status=ConnectionStatus.UNHEALTHY.value)

--- a/cdip_admin/integrations/tests/test_email_alerts.py
+++ b/cdip_admin/integrations/tests/test_email_alerts.py
@@ -12,8 +12,9 @@ def test_status_email_schedule_exists():
     assert PeriodicTask.objects.filter(task="integrations.tasks.send_unhealthy_connections_email").exists()
 
 
+@pytest.mark.parametrize("include_disabled", [True, False])
 def test_send_unhealthy_connections_email_task(
-        mocker, connection_with_healthy_provider_and_destination,
+        mocker, include_disabled, connection_with_healthy_provider_and_destination,
         connection_with_unhealthy_provider, connection_with_unhealthy_destination,
         connection_with_disabled_destination, connection_with_disabled_provider_and_unhealthy_destination
 ):
@@ -32,7 +33,7 @@ def test_send_unhealthy_connections_email_task(
         ]
     )
 
-    send_unhealthy_connections_email()
+    send_unhealthy_connections_email(include_disabled=include_disabled)
 
     providers = Integration.providers.all()
     unhealthy_connections = filter_connections_by_status(queryset=providers, status=ConnectionStatus.UNHEALTHY.value)
@@ -45,6 +46,40 @@ def test_send_unhealthy_connections_email_task(
     assert list(context["unhealthy_connections"]) == list(unhealthy_connections)
     assert list(context["review_connections"]) == list(review_connections)
     assert list(context["disabled_connections"]) == list(disabled_connections)
-
+    assert context["include_disabled"] == include_disabled
     mock_email = mock_email_backend.return_value
     mock_email.send.assert_called_once()
+
+
+def test_unhealthy_connections_email_not_sent_if_only_disabled(
+        mocker,
+        connection_with_disabled_provider,
+):
+    mock_email_backend = mocker.MagicMock()
+    mocker.patch("integrations.tasks.EmailMultiAlternatives", mock_email_backend)
+    mock_email_render = mocker.MagicMock()
+    mocker.patch("integrations.tasks.render_to_string", mock_email_render)
+
+    calculate_integration_statuses([connection_with_disabled_provider.id,])
+
+    send_unhealthy_connections_email(include_disabled=False)
+
+    mock_email = mock_email_backend.return_value
+    assert not mock_email.send.called
+
+
+@pytest.mark.parametrize("include_disabled", [True, False])
+def test_unhealthy_connections_email_not_sent_if_not_unhealthy_connections(
+        mocker, include_disabled, connection_with_healthy_provider_and_destination
+):
+    mock_email_backend = mocker.MagicMock()
+    mocker.patch("integrations.tasks.EmailMultiAlternatives", mock_email_backend)
+    mock_email_render = mocker.MagicMock()
+    mocker.patch("integrations.tasks.render_to_string", mock_email_render)
+
+    calculate_integration_statuses([connection_with_healthy_provider_and_destination.id])
+
+    send_unhealthy_connections_email(include_disabled=include_disabled)
+
+    mock_email = mock_email_backend.return_value
+    assert not mock_email.send.called

--- a/cdip_admin/integrations/tests/test_email_alerts.py
+++ b/cdip_admin/integrations/tests/test_email_alerts.py
@@ -68,6 +68,23 @@ def test_unhealthy_connections_email_not_sent_if_only_disabled(
     assert not mock_email.send.called
 
 
+def test_unhealthy_connections_email_excludes_disabled_by_default(
+        mocker,
+        connection_with_disabled_provider,
+):
+    mock_email_backend = mocker.MagicMock()
+    mocker.patch("integrations.tasks.EmailMultiAlternatives", mock_email_backend)
+    mock_email_render = mocker.MagicMock()
+    mocker.patch("integrations.tasks.render_to_string", mock_email_render)
+
+    calculate_integration_statuses([connection_with_disabled_provider.id,])
+
+    send_unhealthy_connections_email()
+
+    mock_email = mock_email_backend.return_value
+    assert not mock_email.send.called
+
+
 @pytest.mark.parametrize("include_disabled", [True, False])
 def test_unhealthy_connections_email_not_sent_if_not_unhealthy_connections(
         mocker, include_disabled, connection_with_healthy_provider_and_destination


### PR DESCRIPTION
### What does this PR do?
- Exclude disabled connections from the "unhealthy connections" email. If there are only disabled connections, the email isn't sent at all. There's also a setting to enable/disable this behavior.
- Test coverage


### Relevant link(s)
[GUNDI-3997](https://allenai.atlassian.net/browse/GUNDI-3997)


[GUNDI-3997]: https://allenai.atlassian.net/browse/GUNDI-3997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ