### PR TITLE
GUNDI-4129: Add filter 'is_used_as_provider' in integrations api

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -195,7 +195,7 @@
         "filename": "cdip_admin/conftest.py",
         "hashed_secret": "27d933b78d3ea4a51a3ff26aef5831c92d43925c",
         "is_verified": false,
-        "line_number": 3583
+        "line_number": 3581
       }
     ],
     "cdip_admin/integrations/migrations/0047_init_erinreach_config_schema.py": [
@@ -233,5 +233,5 @@
       }
     ]
   },
-  "generated_at": "2025-03-07T21:19:15Z"
+  "generated_at": "2025-03-13T21:15:38Z"
 }

--- a/cdip_admin/api/v2/tests/test_integrations_api.py
+++ b/cdip_admin/api/v2/tests/test_integrations_api.py
@@ -1613,3 +1613,27 @@ def test_get_integration_with_webhook_config(
         organization=organization,
         integration_id=str(provider_liquidtech_with_webhook_config.id)
     )
+
+
+@pytest.mark.parametrize("user", [
+    "superuser",
+    "org_admin_user",
+    "org_viewer_user",
+])
+@pytest.mark.parametrize("is_used_as_provider", [True, False])
+def test_filter_integrations_by_is_used_as_provider(
+        request, is_used_as_provider, user, api_client, organization, other_organization,
+        provider_lotek_panthera, provider_ats, provider_trap_tagger,
+        integrations_list_traptagger_dest, integrations_list_wpswatch
+):
+    user = request.getfixturevalue(user)
+    providers = [provider_lotek_panthera, provider_ats, provider_trap_tagger]
+    destinations = integrations_list_traptagger_dest + integrations_list_wpswatch
+    _test_filter_integrations(
+        api_client=api_client,
+        user=user,
+        filters={
+            "is_used_as_provider": is_used_as_provider
+        },
+        expected_integrations=providers if is_used_as_provider else destinations
+    )

--- a/cdip_admin/conftest.py
+++ b/cdip_admin/conftest.py
@@ -1477,7 +1477,6 @@ def integrations_list_wpswatch(
             integration=integration, action=wpswatch_action_push_events
         )
         integrations.append(integration)
-        ensure_default_route(integration=integration)
     return integrations
 
 
@@ -1507,10 +1506,10 @@ def integrations_list_traptagger_dest(
     integrations = []
     for i in range(5):
         # Create the integration
-        site_url = f"{get_random_id()}.wpswatch.fakewps.org"
+        site_url = f"{get_random_id()}.fake-traptagger.org"
         integration, _ = Integration.objects.get_or_create(
             type=integration_type_trap_tagger,
-            name=f"WPS Watch Site Test {i}",
+            name=f"TrapTagger Test site {i}",
             owner=organization,
             base_url=site_url,
         )
@@ -1518,7 +1517,6 @@ def integrations_list_traptagger_dest(
             integration=integration, action=traptagger_action_push_events
         )
         integrations.append(integration)
-        ensure_default_route(integration=integration)
     return integrations
 
 @pytest.fixture
@@ -2082,14 +2080,14 @@ def traptagger_action_push_events(integration_type_trap_tagger):
 def provider_trap_tagger(
         settings,
         get_random_id,
-        other_organization,
+        organization,
         integration_type_trap_tagger,
 ):
     settings.GCP_ENVIRONMENT_ENABLED = False
     provider, _ = Integration.objects.get_or_create(
         type=integration_type_trap_tagger,
         name=f"Trap Tagger Provider {get_random_id()}",
-        owner=other_organization,
+        owner=organization,
         base_url=f"https://api.test.traptagger.com",
     )
     ensure_default_route(integration=provider)

--- a/cdip_admin/integrations/filters.py
+++ b/cdip_admin/integrations/filters.py
@@ -361,6 +361,7 @@ class IntegrationFilter(django_filters_rest.FilterSet):
     action__in = CharInFilter(field_name="type__actions__value", lookup_expr="in", )
     status = django_filters_rest.CharFilter(field_name="status__status", lookup_expr="iexact", )
     status__in = CharInFilter(field_name="status__status", lookup_expr="in", )
+    is_used_as_provider = django_filters_rest.BooleanFilter(method="filter_is_used_as_provider")
 
     class Meta:
         model = Integration
@@ -371,6 +372,10 @@ class IntegrationFilter(django_filters_rest.FilterSet):
             'type': ['exact', 'in'],
             'owner': ['exact', 'in'],
         }
+
+    def filter_is_used_as_provider(self, queryset, name, value):
+        # Get integrations set as provider in any route
+        return queryset.filter(routing_rules_by_provider__isnull=(not value))
 
 
 class ConnectionFilter(django_filters_rest.FilterSet):


### PR DESCRIPTION
This PR adds a query param filter `is_used_as_provider=<true|false>` that will allow us to filter out integrations being used as data providers so that they don't show up in the destinations list in the portal. Test coverage is extended accordingly.

