### PR TITLE
GUNDI-4240: Return activity log details in separate endpoint

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -154,7 +154,7 @@
         "filename": "cdip_admin/api/v2/tests/test_activity_logs_api.py",
         "hashed_secret": "6c55803d6f1d7a177a0db3eb4b343b0d50f9c111",
         "is_verified": false,
-        "line_number": 373
+        "line_number": 374
       }
     ],
     "cdip_admin/api/v2/tests/test_integrations_api.py": [
@@ -233,5 +233,5 @@
       }
     ]
   },
-  "generated_at": "2025-04-24T13:44:45Z"
+  "generated_at": "2025-05-06T18:31:50Z"
 }

--- a/cdip_admin/api/v2/serializers.py
+++ b/cdip_admin/api/v2/serializers.py
@@ -1159,7 +1159,7 @@ class GundiTraceRetrieveSerializer(serializers.Serializer):
     has_error = serializers.BooleanField(read_only=True)
 
 
-class ActivityLogRetrieveSerializer(serializers.Serializer):
+class ActivityLogBaseSerializer(serializers.Serializer):
     id = serializers.UUIDField(read_only=True)
     created_at = serializers.DateTimeField(read_only=True)
     log_level = serializers.IntegerField(read_only=True)
@@ -1169,9 +1169,12 @@ class ActivityLogRetrieveSerializer(serializers.Serializer):
     value = serializers.CharField(read_only=True)
     title = serializers.CharField(read_only=True)
     created_by = UserDetailsRetrieveSerializer(read_only=True)
-    details = serializers.JSONField(read_only=True)
     is_reversible = serializers.BooleanField(read_only=True)
     revert_data = serializers.JSONField(read_only=True)
+
+
+class ActivityLogDetailsSerializer(ActivityLogBaseSerializer):
+    details = serializers.JSONField(read_only=True)
 
 
 class ActionTriggerSerializer(serializers.Serializer):

--- a/cdip_admin/api/v2/views.py
+++ b/cdip_admin/api/v2/views.py
@@ -486,7 +486,6 @@ class ActivityLogsViewSet(
     An endpoint retrieving and revert activity logs.
     """
     permission_classes = [permissions.IsSuperuser | permissions.IsOrgAdmin | permissions.IsOrgViewer]
-    serializer_class = v2_serializers.ActivityLogRetrieveSerializer
     filter_backends = [
         drf_filters.OrderingFilter,
         django_filters.rest_framework.DjangoFilterBackend,
@@ -507,6 +506,11 @@ class ActivityLogsViewSet(
         # Returns a list with the logs of integrations that the user is allowed to see
         user_integrations = get_user_integrations_qs(user=self.request.user)
         return ActivityLog.objects.filter(integration__in=Subquery(user_integrations.values("id")))
+
+    def get_serializer_class(self):
+        if self.action == "list":
+            return v2_serializers.ActivityLogBaseSerializer
+        return v2_serializers.ActivityLogDetailsSerializer
 
     @action(detail=True, methods=["post", "put"])
     def revert(self, request, pk=None):

--- a/cdip_admin/api/v2/views.py
+++ b/cdip_admin/api/v2/views.py
@@ -500,12 +500,15 @@ class ActivityLogsViewSet(
     ]
 
     def get_queryset(self):
+        queryset = ActivityLog.objects.all()
+        if self.action == "list":
+            queryset = queryset.defer("details")  # Exclude details field from the DB queries
         # Superusers can see all
         if self.request.user.is_superuser:
-            return ActivityLog.objects.all()
+            return queryset
         # Returns a list with the logs of integrations that the user is allowed to see
         user_integrations = get_user_integrations_qs(user=self.request.user)
-        return ActivityLog.objects.filter(integration__in=Subquery(user_integrations.values("id")))
+        return queryset.filter(integration__in=Subquery(user_integrations.values("id")))
 
     def get_serializer_class(self):
         if self.action == "list":


### PR DESCRIPTION
This pull request refactors the `ActivityLogs` feature to improve performance and modularity. It introduces a base serializer for activity logs, optimizes database queries by deferring unnecessary fields during list operations, and adds a new test for retrieving activity log details. Additionally, minor updates were made to `.secrets.baseline`.

### Refactoring and Performance Improvements:
* Renamed `ActivityLogRetrieveSerializer` to `ActivityLogBaseSerializer` and introduced a new `ActivityLogDetailsSerializer` to handle detailed log retrieval. (`cdip_admin/api/v2/serializers.py` - [[1]](diffhunk://#diff-46b71600be12187985851c9e97b3631f862fa709770df13e08d5238d63f3f087L1162-R1162) [[2]](diffhunk://#diff-46b71600be12187985851c9e97b3631f862fa709770df13e08d5238d63f3f087L1172-R1179)
* Updated `ActivityLogsViewSet` to use `ActivityLogBaseSerializer` for list operations and `ActivityLogDetailsSerializer` for detail views. Added logic to defer the `details` field in database queries for list operations to improve performance. (`cdip_admin/api/v2/views.py` - [[1]](diffhunk://#diff-bdcc211030969ea864c353a94e1508ef0411b44543099939dca2ac8eed555afbL489) [[2]](diffhunk://#diff-bdcc211030969ea864c353a94e1508ef0411b44543099939dca2ac8eed555afbR503-R516)

### Tests and Validation:
* Added a new test, `test_get_activity_log_details`, to validate the retrieval of detailed activity log information. (`cdip_admin/api/v2/tests/test_activity_logs_api.py` - [cdip_admin/api/v2/tests/test_activity_logs_api.pyR461-R488](diffhunk://#diff-1a91ac9e0a0ff1cb976e15e9d0ee0cc5039838243abb081c92642d2b253b721cR461-R488))
* Updated an existing test to ensure the `details` field is excluded from activity log list responses. (`cdip_admin/api/v2/tests/test_activity_logs_api.py` - [cdip_admin/api/v2/tests/test_activity_logs_api.pyR34](diffhunk://#diff-1a91ac9e0a0ff1cb976e15e9d0ee0cc5039838243abb081c92642d2b253b721cR34))

### Minor Changes:
* Updated `.secrets.baseline` to reflect a new line number and generation timestamp. (`.secrets.baseline` - [[1]](diffhunk://#diff-d8447df0cd384602c76086081f13f27ad0b45902297c42da35a6fc51fdf1cec3L157-R157) [[2]](diffhunk://#diff-d8447df0cd384602c76086081f13f27ad0b45902297c42da35a6fc51fdf1cec3L236-R236)

Tested locally with django-silk, to ensure that the details column isn't included in DB queries when listing logs now:

![silk_sql_logs_list](https://github.com/user-attachments/assets/ba7c80e5-dccf-4da1-89ee-98f28157fd66)
