### PR TITLE
Log ER 409s as warings in activity logs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -195,7 +195,7 @@
         "filename": "cdip_admin/conftest.py",
         "hashed_secret": "27d933b78d3ea4a51a3ff26aef5831c92d43925c",
         "is_verified": false,
-        "line_number": 3719
+        "line_number": 3763
       }
     ],
     "cdip_admin/integrations/migrations/0047_init_erinreach_config_schema.py": [
@@ -233,5 +233,5 @@
       }
     ]
   },
-  "generated_at": "2025-06-03T18:52:47Z"
+  "generated_at": "2025-06-09T12:40:11Z"
 }

--- a/cdip_admin/conftest.py
+++ b/cdip_admin/conftest.py
@@ -2605,7 +2605,7 @@ def er_observation_delivery_failed_with_conflict(
         "schema_version": "v2",
         "event_type": "ObservationDeliveryFailed",
         "payload": {
-            'error': 'ERClientBadRequest: ER Conflict ON POST https://fake-site.pamdas.org/api/v1.0//sensors/generic/gundi_hytera_smartdispatchplus_68a5b4b3-04e1-4516-b7c1-09ce80c4330b/status.',
+            'error': 'ERClientRateLimitExceeded: ER Conflict ON POST https://fake-site.pamdas.org/api/v1.0//sensors/generic/gundi_hytera_smartdispatchplus_68a5b4b3-04e1-4516-b7c1-09ce80c4330b/status.',
             'error_traceback': 'Traceback (most recent call last):\n  File "/home/dev/earthranger/gundi-dispatcher-er/core/event_handlers.py", line 124, in dispatch_transformed_observation_v2\n    result = await dispatcher.send(observation, **kwargs)\n  File "/home/dev/earthranger/gundi-dispatcher-er/core/dispatchers.py", line 214, in send\n    raise ex\n  File "/home/dev/earthranger/gundi-dispatcher-er/core/dispatchers.py", line 209, in send\n    return await client.post_report(\n  File "/usr/lib/python3.8/unittest/mock.py", line 1081, in __call__\n    return self._mock_call(*args, **kwargs)\n  File "/usr/lib/python3.8/unittest/mock.py", line 1085, in _mock_call\n    return self._execute_mock_call(*args, **kwargs)\n  File "/usr/lib/python3.8/unittest/mock.py", line 1140, in _execute_mock_call\n    raise effect\nerclient.er_errors.ERClientRateLimitExceeded: ER COnflict ON POST https://fake-site.pamdas.org/api/v1.0/sensors/generic/1234/status (status_code=409) (response_body={"data": [], "status": {"code": 409, "message": "Conflict"}})\n',
             'server_response_status': 409,
             'server_response_body': '{"data": [], "status": {"code": 409, "message": "Conflict"}}',

--- a/cdip_admin/conftest.py
+++ b/cdip_admin/conftest.py
@@ -2595,7 +2595,7 @@ def trap_tagger_observation_delivery_failed_schema_v1_event_two(
 
 
 @pytest.fixture
-def er_observation_delivery_failed_schema_v2(
+def er_observation_delivery_failed_with_conflict(
         mocker, lotek_observation_trace, integrations_list_er
 ):
     message = mocker.MagicMock()
@@ -2606,7 +2606,7 @@ def er_observation_delivery_failed_schema_v2(
         "event_type": "ObservationDeliveryFailed",
         "payload": {
             'error': 'ERClientBadRequest: ER Conflict ON POST https://fake-site.pamdas.org/api/v1.0//sensors/generic/gundi_hytera_smartdispatchplus_68a5b4b3-04e1-4516-b7c1-09ce80c4330b/status.',
-            'error_traceback': 'Traceback (most recent call last):\n  File "/home/dev/earthranger/gundi-dispatcher-er/core/event_handlers.py", line 124, in dispatch_transformed_observation_v2\n    result = await dispatcher.send(observation, **kwargs)\n  File "/home/dev/earthranger/gundi-dispatcher-er/core/dispatchers.py", line 214, in send\n    raise ex\n  File "/home/dev/earthranger/gundi-dispatcher-er/core/dispatchers.py", line 209, in send\n    return await client.post_report(\n  File "/usr/lib/python3.8/unittest/mock.py", line 1081, in __call__\n    return self._mock_call(*args, **kwargs)\n  File "/usr/lib/python3.8/unittest/mock.py", line 1085, in _mock_call\n    return self._execute_mock_call(*args, **kwargs)\n  File "/usr/lib/python3.8/unittest/mock.py", line 1140, in _execute_mock_call\n    raise effect\nerclient.er_errors.ERClientBadRequest: ER Bad Request ON POST https://fake-site.pamdas.org/api/v1.0/sensors/generic/1234/status (status_code=400) (response_body={"data": [[{"event_type": {"event_type": "Value \'detection_alert_rep\' does not exist."}}]], "status": {"code": 400, "message": "Bad Request"}})\n',
+            'error_traceback': 'Traceback (most recent call last):\n  File "/home/dev/earthranger/gundi-dispatcher-er/core/event_handlers.py", line 124, in dispatch_transformed_observation_v2\n    result = await dispatcher.send(observation, **kwargs)\n  File "/home/dev/earthranger/gundi-dispatcher-er/core/dispatchers.py", line 214, in send\n    raise ex\n  File "/home/dev/earthranger/gundi-dispatcher-er/core/dispatchers.py", line 209, in send\n    return await client.post_report(\n  File "/usr/lib/python3.8/unittest/mock.py", line 1081, in __call__\n    return self._mock_call(*args, **kwargs)\n  File "/usr/lib/python3.8/unittest/mock.py", line 1085, in _mock_call\n    return self._execute_mock_call(*args, **kwargs)\n  File "/usr/lib/python3.8/unittest/mock.py", line 1140, in _execute_mock_call\n    raise effect\nerclient.er_errors.ERClientRateLimitExceeded: ER COnflict ON POST https://fake-site.pamdas.org/api/v1.0/sensors/generic/1234/status (status_code=409) (response_body={"data": [], "status": {"code": 409, "message": "Conflict"}})\n',
             'server_response_status': 409,
             'server_response_body': '{"data": [], "status": {"code": 409, "message": "Conflict"}}',
             'observation': {

--- a/cdip_admin/conftest.py
+++ b/cdip_admin/conftest.py
@@ -2278,6 +2278,19 @@ def trap_tagger_to_movebank_observation_trace(provider_trap_tagger):
 
 
 @pytest.fixture
+def lotek_observation_trace(provider_lotek_panthera, lotek_sources):
+    trace = GundiTrace(
+        # We save only IDs, no sensitive data is saved
+        data_provider=provider_lotek_panthera,
+        object_type="obv",
+        source=lotek_sources[0],
+        # Other fields are filled in later by the routing services
+    )
+    trace.save()
+    return trace
+
+
+@pytest.fixture
 def observation_traces_spikes(provider_lotek_panthera, request):
     # Parametrize with a list of tuples (time_value, time_unit)
     time_deltas = request.param
@@ -2582,6 +2595,36 @@ def trap_tagger_observation_delivery_failed_schema_v1_event_two(
 
 
 @pytest.fixture
+def er_observation_delivery_failed_schema_v2(
+        mocker, lotek_observation_trace, integrations_list_er
+):
+    message = mocker.MagicMock()
+    event_dict = {
+        "event_id": "605535df-1b9b-412b-9fd5-e29b09582999",
+        "timestamp": "2023-07-11 18:19:19.215459+00:00",
+        "schema_version": "v2",
+        "event_type": "ObservationDeliveryFailed",
+        "payload": {
+            'error': 'ERClientBadRequest: ER Conflict ON POST https://fake-site.pamdas.org/api/v1.0//sensors/generic/gundi_hytera_smartdispatchplus_68a5b4b3-04e1-4516-b7c1-09ce80c4330b/status.',
+            'error_traceback': 'Traceback (most recent call last):\n  File "/home/dev/earthranger/gundi-dispatcher-er/core/event_handlers.py", line 124, in dispatch_transformed_observation_v2\n    result = await dispatcher.send(observation, **kwargs)\n  File "/home/dev/earthranger/gundi-dispatcher-er/core/dispatchers.py", line 214, in send\n    raise ex\n  File "/home/dev/earthranger/gundi-dispatcher-er/core/dispatchers.py", line 209, in send\n    return await client.post_report(\n  File "/usr/lib/python3.8/unittest/mock.py", line 1081, in __call__\n    return self._mock_call(*args, **kwargs)\n  File "/usr/lib/python3.8/unittest/mock.py", line 1085, in _mock_call\n    return self._execute_mock_call(*args, **kwargs)\n  File "/usr/lib/python3.8/unittest/mock.py", line 1140, in _execute_mock_call\n    raise effect\nerclient.er_errors.ERClientBadRequest: ER Bad Request ON POST https://fake-site.pamdas.org/api/v1.0/sensors/generic/1234/status (status_code=400) (response_body={"data": [[{"event_type": {"event_type": "Value \'detection_alert_rep\' does not exist."}}]], "status": {"code": 400, "message": "Bad Request"}})\n',
+            'server_response_status': 409,
+            'server_response_body': '{"data": [], "status": {"code": 409, "message": "Conflict"}}',
+            'observation': {
+                "gundi_id": str(lotek_observation_trace.object_id),
+                "related_to": None,
+                "data_provider_id": str(lotek_observation_trace.data_provider.id),
+                "destination_id": str(integrations_list_er[0].id),
+                "delivered_at": "2025-01-23 16:54:19.215015+00:00",
+            },
+        }
+    }
+    data_bytes = json.dumps(event_dict).encode("utf-8")
+    message.data = data_bytes
+    return message
+
+
+
+@pytest.fixture
 def trap_tagger_observation_update_failed_schema_v1_event(
         mocker, trap_tagger_event_update_trace, integrations_list_er
 ):
@@ -2643,6 +2686,7 @@ def observation_delivery_failed_event(
         return trap_tagger_observation_delivery_failed_schema_v1_event_one
     else:  # Default to the latest version
         return trap_tagger_observation_delivery_failed_schema_v2_event_one
+
 
 @pytest.fixture
 def observation_update_failed_event(

--- a/cdip_admin/event_consumers/dispatcher_events_consumer.py
+++ b/cdip_admin/event_consumers/dispatcher_events_consumer.py
@@ -178,7 +178,11 @@ def handle_observation_delivery_failed_event(event_dict: dict):
     }
     # Workaround to serialize complex types until upgrading to pydantic v2
     log_data_cleaned = json.loads(json.dumps(log_data, default=str))
-    level = ActivityLog.LogLevels.WARNING if event.payload.server_response_status == 409 else ActivityLog.LogLevels.ERROR
+    # Flag the error as a warning if ER returns a 409 conflict error. Those are retried.
+    if "pamdas.org" in event.payload.error and event.payload.server_response_status == 409:
+        level = ActivityLog.LogLevels.WARNING
+    else:
+        level = ActivityLog.LogLevels.ERROR
     ActivityLog.objects.create(
         log_level=level,
         log_type=ActivityLog.LogTypes.EVENT,

--- a/cdip_admin/event_consumers/dispatcher_events_consumer.py
+++ b/cdip_admin/event_consumers/dispatcher_events_consumer.py
@@ -178,8 +178,9 @@ def handle_observation_delivery_failed_event(event_dict: dict):
     }
     # Workaround to serialize complex types until upgrading to pydantic v2
     log_data_cleaned = json.loads(json.dumps(log_data, default=str))
+    level = ActivityLog.LogLevels.WARNING if event.payload.server_response_status == 409 else ActivityLog.LogLevels.ERROR
     ActivityLog.objects.create(
-        log_level=ActivityLog.LogLevels.ERROR,
+        log_level=level,
         log_type=ActivityLog.LogTypes.EVENT,
         origin=ActivityLog.Origin.DISPATCHER,
         integration=trace.data_provider,

--- a/cdip_admin/event_consumers/tests/test_dispatcher_events_consumer.py
+++ b/cdip_admin/event_consumers/tests/test_dispatcher_events_consumer.py
@@ -403,15 +403,15 @@ def test_show_stream_type_in_activity_log_title_on_observation_delivery(
 
 
 def test_409_delivery_errors_are_logged_as_warnings(
-        lotek_observation_trace, er_observation_delivery_failed_schema_v2,
+        lotek_observation_trace, er_observation_delivery_failed_with_conflict,
 ):
     # Test that delivery failures where ER responds with 409 status are logged as warnings
-    process_event(er_observation_delivery_failed_schema_v2)
+    process_event(er_observation_delivery_failed_with_conflict)
     lotek_observation_trace.refresh_from_db()
     assert lotek_observation_trace.has_error
     assert lotek_observation_trace.error == "Delivery Failed at the Dispatcher."
     # Check that the event was recorded in the activity log
-    event_dict = json.loads(er_observation_delivery_failed_schema_v2.data)
+    event_dict = json.loads(er_observation_delivery_failed_with_conflict.data)
     observation_data = event_dict["payload"]["observation"]
     observation_data["source_external_id"] = lotek_observation_trace.source.external_id
 


### PR DESCRIPTION
This PR changes the log level of delivery errors on ER 409s (conflict) to warning, so that connections bringing more than one observation pero second per source are not flagged as unhealthy (e.g. Hytera radios)