### PR TITLE
GUNDI-4618: Gundi v1 migration script MK1

### DIFF
--- a/cdip_admin/integrations/management/commands/awt_v1_migration_script.py
+++ b/cdip_admin/integrations/management/commands/awt_v1_migration_script.py
@@ -103,15 +103,17 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        self.stdout.write(" -- Starting AWT v1 migration script -- \n")
+        self.stdout.write(" -- Starting AWT v1 migration script -- \n\n")
         if inbounds_to_migrate := self._get_awt_inbounds(options=options):
             awt_integrations_created = 0
+            awt_integrations_skipped = 0
+            awt_integrations_with_error = 0
             awt_integration_configs_created = 0
             destination_integration_types_created = 0
             destination_owners_created = 0
             destination_integration_created = 0
 
-            self.stdout.write(f" -- Got {len(inbounds_to_migrate)} AWT inbounds to migrate -- \n")
+            self.stdout.write(f" -- Got {len(inbounds_to_migrate)} AWT inbounds to migrate -- \n\n")
 
             # Get or create AWT PUSH integration type
             awt_integration_type, _ = IntegrationType.objects.get_or_create(
@@ -251,14 +253,18 @@ class Command(BaseCommand):
                             integration.default_route.save()
                             integration.save()
                         else:
+                            awt_integrations_skipped += 1
                             self.stdout.write(f" -- Integration {integration.name} (ID: {integration.id}) already exists, skipping creation... -- \n")
 
                 except Exception as e:
+                    awt_integrations_with_error += 1
                     self.stderr.write(f" -- ERROR migrating {inbound.name} (ID: {inbound.id}): {e}")
 
-            self.stdout.write(f"\n -- Summary -- \n")
+            self.stdout.write(f"\n -- Summary -- \n\n")
+            self.stdout.write(f" -- AWT Integrations with error: {awt_integrations_with_error} -- ")
+            self.stdout.write(f" -- AWT Integrations skipped: {awt_integrations_skipped} -- ")
             self.stdout.write(f" -- AWT Integrations created: {awt_integrations_created} -- ")
-            self.stdout.write(f" -- AWT Integration Configurations created: {awt_integration_configs_created} -- ")
+            self.stdout.write(f" -- AWT Integration Configurations created: {awt_integration_configs_created} -- \n\n")
             self.stdout.write(f" -- Destination Integration Types created: {destination_integration_types_created} -- ")
             self.stdout.write(f" -- Destination Integration Owners created: {destination_owners_created} -- ")
             self.stdout.write(f" -- Destination Integrations created: {destination_integration_created} -- ")

--- a/cdip_admin/integrations/management/commands/awt_v1_migration_script.py
+++ b/cdip_admin/integrations/management/commands/awt_v1_migration_script.py
@@ -144,7 +144,7 @@ class Command(BaseCommand):
                         )
                         integration, created = Integration.objects.get_or_create(
                             type=awt_integration_type,
-                            name=f"[AWT DATA PUSH] - {inbound.name}",
+                            name=f"[V1 to V2] - {inbound.name} ({inbound.login})",
                             owner=inbound_owner,
                             defaults={
                                 "base_url": inbound.endpoint
@@ -212,9 +212,7 @@ class Command(BaseCommand):
                                     type=destination_integration_type,
                                     owner=destination_owner,
                                     base_url=destination.endpoint,
-                                    defaults={
-                                        "name": destination.name
-                                    }
+                                    name=destination.name
                                 )
                                 if created:
                                     destination_integration_created += 1
@@ -291,7 +289,7 @@ class Command(BaseCommand):
             self.stdout.write(" -- ERROR: AWT Inbound Integration Type not found -- \n")
             return []
 
-        inbounds = InboundIntegrationConfiguration.objects.filter(type=awt_inbound_type, enabled=True).all()
+        inbounds = InboundIntegrationConfiguration.objects.filter(type=awt_inbound_type).all()
 
         self.stdout.write(f" -- Found {inbounds.count()} AWT inbounds -- ")
 

--- a/cdip_admin/integrations/management/commands/awt_v1_migration_script.py
+++ b/cdip_admin/integrations/management/commands/awt_v1_migration_script.py
@@ -11,7 +11,6 @@ from integrations.models import (
     InboundIntegrationType,
     InboundIntegrationConfiguration
 )
-from integrations.utils import get_dispatcher_topic_default_name
 
 
 ER_DESTINATION_JSON_SCHEMA = {
@@ -104,6 +103,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
+        self.stdout.write(" -- Starting AWT v1 migration script -- \n")
         if inbounds_to_migrate := self._get_awt_inbounds(options=options):
             awt_integrations_created = 0
             awt_integration_configs_created = 0

--- a/cdip_admin/integrations/management/commands/awt_v1_migration_script.py
+++ b/cdip_admin/integrations/management/commands/awt_v1_migration_script.py
@@ -1,0 +1,229 @@
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.db.models import Q
+from django.conf import settings
+from deployments.models import DispatcherDeployment
+from deployments.utils import (
+    get_dispatcher_defaults_from_gcp_secrets,
+    get_default_dispatcher_name,
+)
+from deployments.tasks import deploy_serverless_dispatcher
+from integrations.models import (
+    Organization,
+    Integration,
+    IntegrationType,
+    IntegrationAction,
+    IntegrationConfiguration,
+    Route,
+    InboundIntegrationType,
+    InboundIntegrationConfiguration,
+    OutboundIntegrationConfiguration
+)
+from integrations.utils import get_dispatcher_topic_default_name
+
+
+class Command(BaseCommand):
+
+    help = "AWT v1 integrations migration script (to Gundi v2)"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--inbounds',
+            nargs='+',
+            type=str,
+            required=False,
+            help='List of AWT integration inbounds IDs to migrate'
+        )
+        parser.add_argument(
+            "--max",
+            type=int,
+            default=10,
+            required=False,
+            help="Specify the maximum number of inbounds to migrate",
+        )
+
+    def handle(self, *args, **options):
+        if inbounds_to_migrate := self._get_awt_inbounds(options=options):
+            awt_integrations_created = 0
+            awt_integration_configs_created = 0
+            destination_integration_types_created = 0
+            destination_owners_created = 0
+            destination_integration_created = 0
+
+            self.stdout.write(f" -- Found {len(inbounds_to_migrate)} AWT inbounds to migrate -- \n")
+
+            # Get or create AWT PUSH integration type
+            awt_integration_type, _ = IntegrationType.objects.get_or_create(
+                name="Africa Wildlife Tracking (Animal Tracker)  [Data Push]",
+                value="awt_push_v2"
+            )
+            # Get or create AWT PUSH action
+            awt_push_action, _ = IntegrationAction.objects.get_or_create(
+                type=IntegrationAction.ActionTypes.PUSH_DATA,
+                name="AWT Push",
+                value="awt_push_action",
+                integration_type=awt_integration_type
+            )
+
+            for inbound in inbounds_to_migrate:
+                try:
+                    with transaction.atomic():
+                        inbound_owner, _ = Organization.objects.get_or_create(
+                            name=inbound.owner.name
+                        )
+                        integration, created = Integration.objects.get_or_create(
+                            type=awt_integration_type,
+                            name=f"[AWT DATA PUSH] - {inbound.name}",
+                            owner=inbound_owner,
+                        )
+                        if created:
+                            # New integration created
+                            awt_integrations_created += 1
+                            self.stdout.write(f" -- Created new integration: {integration.name} (ID: {integration.id}) from v1 inbound -- ")
+
+                            integration.enabled = False # enabled by default for validation purposes
+
+                            # Get or create the AWT_PUSH action config for this integration
+                            action_config, created = IntegrationConfiguration.objects.get_or_create(
+                                integration=integration,
+                                action=awt_push_action
+                            )
+                            if created:
+                                awt_integration_configs_created += 1
+                                self.stdout.write(f" -- Created new configuration for action '{awt_push_action.name}' for integration: {integration.name} (ID: {integration.id})")
+
+                            # Get or create integration route
+                            route_name = f"{integration.name} - Default Route"
+                            routing_rule, _ = Route.objects.get_or_create(
+                                name=route_name,
+                                owner=inbound_owner
+                            )
+
+                            # Set routing rule for the integration and add provider
+                            integration.default_route = routing_rule
+                            integration.default_route.data_providers.add(integration)
+
+                            # Read inbound destinations and create integration for each
+                            for destination in inbound.destinations.all():
+                                # Check if outbound type exists as integration type
+                                destination_integration_type, created = IntegrationType.objects.get_or_create(
+                                    value=destination.type.slug
+                                )
+                                if created:
+                                    destination_integration_types_created += 1
+                                    self.stdout.write(f" -- Created new integration type: {destination_integration_type.value} for destination: {destination.name} (ID: {destination.id})")
+
+                                # Check if outbound owner exists as organization
+                                destination_owner, created = Organization.objects.get_or_create(
+                                    name=destination.owner.name
+                                )
+                                if created:
+                                    destination_owners_created += 1
+                                    self.stdout.write(f" -- Created new organization: {destination_owner.name} for destination: {destination.name} (ID: {destination.id})")
+
+                                # if outbound is an ER site, remove the /api/v1.0 part from the base URL
+                                if destination.is_er_site:
+                                    destination.endpoint = destination.endpoint.replace(
+                                        "/api/v1.0", ""
+                                    )
+
+                                destination_integration, created = Integration.objects.get_or_create(
+                                    type=destination_integration_type,
+                                    owner=destination_owner,
+                                    base_url=destination.endpoint,
+                                )
+                                if created:
+                                    destination_integration_created += 1
+                                    destination_integration.name = destination.name
+                                    destination_integration.save()
+
+                                    self.stdout.write(f" -- Created new integration: {destination_integration.name} (ID: {destination_integration.id}) for destination: {destination.name} (ID: {destination.id})")
+
+                                    self.deploy_dispatcher(integration=destination_integration)
+
+                                integration.default_route.destinations.add(destination_integration)
+
+                            integration.save()
+
+                except Exception as e:
+                    self.stderr.write(f" -- ERROR migrating {inbound.name} (ID: {inbound.id}): {e}")
+
+            self.stdout.write(f"\n -- Summary -- \n")
+            self.stdout.write(f" -- AWT Integrations created: {awt_integrations_created} -- ")
+            self.stdout.write(f" -- AWT Integration Configurations created: {awt_integration_configs_created} -- ")
+            self.stdout.write(f" -- Destination Integration Types created: {destination_integration_types_created} -- ")
+            self.stdout.write(f" -- Destination Integration Owners created: {destination_owners_created} -- ")
+            self.stdout.write(f" -- Destination Integrations created: {destination_integration_created} -- ")
+
+    def deploy_dispatcher(self, integration):
+        try:
+            # Skip if the integration is not an ER, SMART, WPS Watch or TrapTagger site
+            if not (integration.is_er_site or integration.is_smart_site or integration.is_wpswatch_site or integration.is_traptagger_site):
+                self.stdout.write(
+                    f" -- Integration {integration.name} is not an ER, SMART, WPS Watch or TrapTagger site. Skipped... -- "
+                )
+                return
+
+            self.stdout.write(f" -- Deploying dispatcher for {integration.name}... -- ")
+
+            # Create the topic and the dispatcher
+            if integration.is_smart_site:
+                secret_id = settings.DISPATCHER_DEFAULTS_SECRET_SMART
+            elif integration.is_wpswatch_site:
+                secret_id = settings.DISPATCHER_DEFAULTS_SECRET_WPSWATCH
+            elif integration.is_traptagger_site:
+                secret_id = settings.DISPATCHER_DEFAULTS_SECRET_TRAPTAGGER
+            else:
+                secret_id = settings.DISPATCHER_DEFAULTS_SECRET
+
+            version = "v2"
+            with transaction.atomic():  # Update the integration and create the dispatcher, both or none
+                topic_name = get_dispatcher_topic_default_name(
+                    integration=integration, gundi_version=version
+                )
+                integration.additional.update(
+                    {"topic": topic_name, "broker": "gcp_pubsub"}
+                )
+                integration.save()
+                DispatcherDeployment.objects.create(
+                    name=get_default_dispatcher_name(
+                        integration=integration, gundi_version=version
+                    ),
+                    integration=integration,
+                    configuration=get_dispatcher_defaults_from_gcp_secrets(
+                        secret_id=secret_id
+                    ),
+                )
+        except Exception as e:
+            self.stdout.write(
+                f" -- Error deploying dispatcher for {integration.name}: {e} -- "
+            )
+        else:
+            self.stdout.write(
+                f" -- Deployment triggered for {integration.name} ({version}) -- "
+            )
+
+    def _get_awt_inbounds(self, options):
+        awt_inbound_type, _ = InboundIntegrationType.objects.get_or_create(
+            name="Africa Wildlife Tracking (AWT)",
+            description="Animal Collar	Hadrien Haupt	hadrien@awt.co.za",
+            slug="awt"
+        )
+
+        inbounds = InboundIntegrationConfiguration.objects.filter(type=awt_inbound_type, enabled=True).all()
+
+        self.stdout.write(f" -- Found {inbounds.count()} AWT inbounds -- ")
+
+        if options['inbounds']:
+            self.stdout.write(f" -- Filtering AWT inbounds by IDs: {options['inbounds']} -- ")
+            inbounds = inbounds.filter(id__in=options['inbounds'])
+
+        if not inbounds:
+            self.stdout.write(f" -- ERROR: AWT Integrations with IDs {options['inbounds']} not found -- \n")
+            return []
+
+        if options['max']:
+            self.stdout.write(f" -- Limiting to {options['max']} AWT inbounds as per --max option -- ")
+            inbounds = inbounds[:options['max']]
+
+        return inbounds

--- a/cdip_admin/integrations/management/commands/gundi_v1_migration_script.py
+++ b/cdip_admin/integrations/management/commands/gundi_v1_migration_script.py
@@ -16,68 +16,68 @@ from integrations.models import (
 
 
 ER_DESTINATION_JSON_SCHEMA = {
-	"if": {
-		"properties": {
-			"authentication_type": {
-				"const": "token"
-			}
-		}
-	},
-	"else": {
-		"required": ["username", "password"],
-		"properties": {
-			"password": {
-				"type": "string",
-				"title": "Password",
-				"format": "password",
-				"default": "",
-				"example": "mypasswd1234abc",
-				"writeOnly": True,
-				"description": "Password used to authenticate against Earth Ranger API"
-			},
-			"username": {
-				"type": "string",
-				"title": "Username",
-				"default": "",
-				"example": "myuser",
-				"description": "Username used to authenticate against Earth Ranger API"
-			}
-		}
-	},
-	"then": {
-		"required": ["token"],
-		"properties": {
-			"token": {
-				"type": "string",
-				"title": "Token",
-				"format": "password",
-				"default": "",
-				"example": "1b4c1e9c-5ee0-44db-c7f1-177ede2f854a",
-				"writeOnly": True,
-				"description": "Token used to authenticate against Earth Ranger API"
-			}
-		}
-	},
-	"type": "object",
-	"title": "AuthenticateConfig",
-	"properties": {
-		"authentication_type": {
-			"allOf": [{
-				"$ref": "#/definitions/ERAuthenticationType"
-			}],
-			"default": "token",
-			"description": "Type of authentication to use."
-		}
-	},
-	"definitions": {
-		"ERAuthenticationType": {
-			"enum": ["token", "username_password"],
-			"type": "string",
-			"title": "ERAuthenticationType",
-			"description": "An enumeration."
-		}
-	},
-	"is_executable": True
+    "if": {
+        "properties": {
+            "authentication_type": {
+                "const": "token"
+            }
+        }
+    },
+    "else": {
+        "required": ["username", "password"],
+        "properties": {
+            "password": {
+                "type": "string",
+                "title": "Password",
+                "format": "password",
+                "default": "",
+                "example": "mypasswd1234abc",
+                "writeOnly": True,
+                "description": "Password used to authenticate against Earth Ranger API"
+            },
+            "username": {
+                "type": "string",
+                "title": "Username",
+                "default": "",
+                "example": "myuser",
+                "description": "Username used to authenticate against Earth Ranger API"
+            }
+        }
+    },
+    "then": {
+        "required": ["token"],
+        "properties": {
+            "token": {
+                "type": "string",
+                "title": "Token",
+                "format": "password",
+                "default": "",
+                "example": "1b4c1e9c-5ee0-44db-c7f1-177ede2f854a",
+                "writeOnly": True,
+                "description": "Token used to authenticate against Earth Ranger API"
+            }
+        }
+    },
+    "type": "object",
+    "title": "AuthenticateConfig",
+    "properties": {
+        "authentication_type": {
+            "allOf": [{
+                "$ref": "#/definitions/ERAuthenticationType"
+            }],
+            "default": "token",
+            "description": "Type of authentication to use."
+        }
+    },
+    "definitions": {
+        "ERAuthenticationType": {
+            "enum": ["token", "username_password"],
+            "type": "string",
+            "title": "ERAuthenticationType",
+            "description": "An enumeration."
+        }
+    },
+    "is_executable": True
 }
 
 ER_DESTINATION_UI_SCHEMA = {"ui:order": ["authentication_type", "token", "username", "password"]}

--- a/cdip_admin/integrations/management/commands/gundi_v1_migration_script.py
+++ b/cdip_admin/integrations/management/commands/gundi_v1_migration_script.py
@@ -166,9 +166,8 @@ class Command(BaseCommand):
             for inbound in inbounds_to_migrate:
                 try:
                     with transaction.atomic():
-                        inbound_owner, _ = Organization.objects.get_or_create(
-                            name=inbound.owner.name
-                        )
+                        inbound_owner = inbound.owner
+
                         integration, created = Integration.objects.get_or_create(
                             type=v2_integration_type,
                             name=f"[V1 to V2] - {inbound.name} ({inbound.login})",

--- a/cdip_admin/integrations/management/commands/gundi_v1_migration_script.py
+++ b/cdip_admin/integrations/management/commands/gundi_v1_migration_script.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 
 from django.core.management.base import BaseCommand
 from django.db import transaction
@@ -129,6 +130,13 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
+
+        # TODO: FOR LOCAL EXECUTION ONLY! Remove if running in pod
+        logging.getLogger('django.db.backends').setLevel(logging.WARNING)
+        logging.getLogger('activity_log.mixins').setLevel(logging.ERROR)
+        logging.getLogger('integrations.tasks').setLevel(logging.WARNING)
+
+
         inbound_type = options["inbound_type"].capitalize()
         self.stdout.write(f" -- Starting {inbound_type} v1 migration script -- \n\n")
         if inbounds_to_migrate := self._get_v1_inbounds(options=options):
@@ -282,7 +290,7 @@ class Command(BaseCommand):
                                 "field_mappings": field_mappings
                             }
                             route_config, created = RouteConfiguration.objects.get_or_create(
-                                name=f"{integration.default_route.name} (Integration ID: {str(integration.id)}) - Default Configuration",
+                                name=f"{integration.default_route.name} (Integration ID: {str(integration.id)}) - Default Config",
                                 defaults={
                                     "data": field_mappings_result
                                 }

--- a/cdip_admin/integrations/management/commands/gundi_v1_migration_script.py
+++ b/cdip_admin/integrations/management/commands/gundi_v1_migration_script.py
@@ -282,12 +282,18 @@ class Command(BaseCommand):
                             field_mappings_result = {
                                 "field_mappings": field_mappings
                             }
-                            route_config, _ = RouteConfiguration.objects.get_or_create(
-                                name=integration.default_route.name + " - Default Configuration",
+                            route_config, created = RouteConfiguration.objects.get_or_create(
+                                name=f"{integration.default_route.name} (Integration ID: {str(integration.id)}) - Default Configuration",
                                 defaults={
                                     "data": field_mappings_result
                                 }
                             )
+
+                            if not created:
+                                # A route config already exists for this migration, we need to update it
+                                route_config.data = field_mappings_result
+                                route_config.save()
+
                             integration.default_route.configuration = route_config
                             integration.default_route.save()
                             integration.save()


### PR DESCRIPTION
### Relevant Link

https://allenai.atlassian.net/browse/GUNDI-4618

---

This pull request introduces a new Django management command in `gundi_v1_migration_script.py` to automate the migration of Gundi v1 inbound integrations to the Gundi v2 system. The script provides options for selecting specific inbounds, integration types, and actions, and handles the creation of necessary related objects (integrations, actions, organizations, routes, and configurations) during migration. It also includes custom JSON schema definitions for authentication and field mappings, and provides detailed output and error handling throughout the migration process.

Key additions and features:

**Migration Command Implementation**
* Added a new management command `gundi_v1_migration_script.py` that migrates inbound integrations from Gundi v1 to Gundi v2, with arguments for inbound type, integration type, action, specific inbounds, and migration limits.
* The command handles the creation or retrieval of related objects (organizations, integration types, integrations, actions, routes, configurations) as needed during the migration.
* Supports filtering and limiting which inbounds are migrated, and provides summary output for created, skipped, and errored migrations.

**Schema and Field Mapping Definitions**
* Introduced `ER_DESTINATION_JSON_SCHEMA` and `ER_DESTINATION_UI_SCHEMA` for defining authentication configuration structure for migrated integrations.
* Added a default field