### PR TITLE
GUNDI-4634: Add timeout in the default celery worker

### DIFF
--- a/cdip_admin/start_scripts/start_default_worker.sh
+++ b/cdip_admin/start_scripts/start_default_worker.sh
@@ -4,4 +4,4 @@
 
 WORKERS=5
 
-celery -A cdip_admin worker -Q default -l info -c $WORKERS -n default@%h 2>&1
+celery -A cdip_admin worker -Q default -l info -c $WORKERS -n default@%h --time-limit=120 --soft-time-limit=60 2>&1


### PR DESCRIPTION
This is a quick fix to mitigate issues with the default celery worker caused by slow smart integrations, while we work on a longer-term solution.