### PR TITLE
GUNDI-4636: Move smart integration tasks to separate worker

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
     with:
       environment: dev
       chart_name: admin-portal
-      chart_version: '1.3.5'
+      chart_version: '1.3.6'
       repository: ${{ needs.vars.outputs.repository }}
       tag: ${{ needs.vars.outputs.tag }}
     secrets: inherit
@@ -48,7 +48,7 @@ jobs:
     with:
       environment: stage
       chart_name: admin-portal
-      chart_version: '1.3.5'
+      chart_version: '1.3.6'
       repository: ${{ needs.vars.outputs.repository }}
       tag: ${{ needs.vars.outputs.tag }}
     secrets: inherit
@@ -81,7 +81,7 @@ jobs:
     with:
       environment: prod
       chart_name: admin-portal
-      chart_version: '1.3.5'
+      chart_version: '1.3.6'
       repository: ${{ needs.vars.outputs.repository }}
       tag: ${{ needs.vars.outputs.tag }}
     secrets: inherit

--- a/cdip_admin/cdip_admin/settings.py
+++ b/cdip_admin/cdip_admin/settings.py
@@ -283,6 +283,7 @@ CELERY_TASK_QUEUES = (
     Queue("healthchecks", Exchange("healthchecks"), routing_key="healthchecks"),
     Queue("systemevents", Exchange("systemevents"), routing_key="systemevents"),
     Queue("actiontriggers", Exchange("actiontriggers"), routing_key="actiontriggers"),
+    Queue("smartsyncs", Exchange("smartsyncs"), routing_key="smartsyncs"),
 )
 
 CELERY_TASK_ROUTES = {
@@ -318,7 +319,28 @@ CELERY_TASK_ROUTES = {
     },
     "integrations.tasks.run_integration": {
         "queue": "actiontriggers", "routing_key": "actiontriggers"
-    }
+    },
+    "sync_integrations.tasks.synchronize_smart_datamodels": {
+        "queue": "smartsyncs", "routing_key": "smartsyncs"
+    },
+    "sync_integrations.tasks.run_sync_integrations": {
+        "queue": "smartsyncs", "routing_key": "smartsyncs"
+    },
+    "sync_integrations.tasks.handle_outboundintegration_save": {
+        "queue": "smartsyncs", "routing_key": "smartsyncs"
+    },
+    "sync_integrations.tasks.run_er_smart_sync_integrations": {
+        "queue": "smartsyncs", "routing_key": "smartsyncs"
+    },
+    "sync_integrations.tasks.maintain_smart_integrations": {
+        "queue": "smartsyncs", "routing_key": "smartsyncs"
+    },
+    "sync_integrations.tasks._maintain_smart_integration": {
+        "queue": "smartsyncs", "routing_key": "smartsyncs"
+    },
+    "sync_integrations.tasks.run_er_smart_sync_integration": {
+        "queue": "smartsyncs", "routing_key": "smartsyncs"
+    },
 }
 
 CELERY_BROKER_TRANSPORT_OPTIONS = {"visibility_timeout": 3600, "fanout_prefix": True}

--- a/cdip_admin/start_scripts/start_smart_syncs_worker.sh
+++ b/cdip_admin/start_scripts/start_smart_syncs_worker.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+. $(dirname "$0")/django_common_startup.sh
+
+WORKERS=2
+
+celery -A cdip_admin worker -l info -c $WORKERS -Q smartsyncs -n smartsyncs@%h --time-limit=3660 --soft-time-limit=3600 2>&1


### PR DESCRIPTION
This PR moves the celery tasks related to smart sync integrations to a separate worker, to isolate any issues and avoid them affecting other tasks running in the default worker.