### PR TITLE
GUNDI-4650: Fix issue in config changes propagation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
       - 'release-**'
-      - 'gundi-4650-fix-config-events'
 env:
   TRACING_ENABLED: ${{secrets.TRACING_ENABLED}}
   PUBSUB_ENABLED: ${{secrets.PUBSUB_ENABLED}}
@@ -44,7 +43,7 @@ jobs:
 
   deploy_stage:
     uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v2
-    if: startsWith(github.ref, 'refs/heads/gundi-4650-fix-config-events')
+    if: startsWith(github.ref, 'refs/heads/release')
     needs: [vars, build]
     with:
       environment: stage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - 'release-**'
+      - 'gundi-4650-fix-config-events'
 env:
   TRACING_ENABLED: ${{secrets.TRACING_ENABLED}}
   PUBSUB_ENABLED: ${{secrets.PUBSUB_ENABLED}}
@@ -43,7 +44,7 @@ jobs:
 
   deploy_stage:
     uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v2
-    if: startsWith(github.ref, 'refs/heads/release')
+    if: startsWith(github.ref, 'refs/heads/gundi-4650-fix-config-events')
     needs: [vars, build]
     with:
       environment: stage

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -118,7 +118,7 @@
         "filename": ".github/workflows/main.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 42
+        "line_number": 43
       }
     ],
     ".github/workflows/values/dev.yml": [
@@ -233,5 +233,5 @@
       }
     ]
   },
-  "generated_at": "2025-08-13T12:27:31Z"
+  "generated_at": "2025-08-27T18:06:02Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -118,7 +118,7 @@
         "filename": ".github/workflows/main.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 43
+        "line_number": 42
       }
     ],
     ".github/workflows/values/dev.yml": [
@@ -233,5 +233,5 @@
       }
     ]
   },
-  "generated_at": "2025-08-27T18:06:02Z"
+  "generated_at": "2025-08-27T18:49:45Z"
 }

--- a/cdip_admin/activity_log/models.py
+++ b/cdip_admin/activity_log/models.py
@@ -254,12 +254,14 @@ class ActivityLog(UUIDAbstractModel, TimestampedModel):
     def _post_save(self, *args, **kwargs):
         # Publish events to notify other services about the config changes as needed
         if event := build_event_from_log(log=self):
+            # Cleanup to match subscription filters: earth_ranger -> earthranger
+            integration_type_filter = self.integration_type.value.replace("_", "").strip()
             publish_configuration_event.delay(
                 event_data=event.dict(),
                 attributes={  # Attributes can be used for filtering in subscriptions
                     "gundi_version": "v2",
                     "event_type": event.event_type,
-                    "integration_type": self.integration_type.value,
+                    "integration_type": integration_type_filter,
                 },
             )
 


### PR DESCRIPTION
This PR fixes an issue in configuration change events published by the portal. The integration_type attribute should contain the integration type value without underscores, e.g. `earthranger` instead of `earth_ranger`.