### PR TITLE
GUNDI-4666: Add command to add missing action configs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -195,7 +195,7 @@
         "filename": "cdip_admin/conftest.py",
         "hashed_secret": "27d933b78d3ea4a51a3ff26aef5831c92d43925c",
         "is_verified": false,
-        "line_number": 3775
+        "line_number": 3866
       }
     ],
     "cdip_admin/integrations/migrations/0047_init_erinreach_config_schema.py": [
@@ -233,5 +233,5 @@
       }
     ]
   },
-  "generated_at": "2025-08-27T18:49:45Z"
+  "generated_at": "2025-08-28T20:12:10Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -229,9 +229,9 @@
         "filename": "cdip_admin/integrations/tests/test_tasks.py",
         "hashed_secret": "d15e5a27160ace913d22871497c05a7e5bbbe2ef",
         "is_verified": false,
-        "line_number": 190
+        "line_number": 192
       }
     ]
   },
-  "generated_at": "2025-08-28T20:12:10Z"
+  "generated_at": "2025-08-28T20:28:26Z"
 }

--- a/cdip_admin/api/v2/tests/test_gunditrace_serializer.py
+++ b/cdip_admin/api/v2/tests/test_gunditrace_serializer.py
@@ -151,8 +151,8 @@ class TestGundiTraceSerializerValidation:
         # Create another integration
         other_integration = Integration.objects.create(
             name="Other Integration",
-            integration_type=provider_trap_tagger.integration_type,
-            organization=provider_trap_tagger.organization
+            type=provider_trap_tagger.type,
+            owner=provider_trap_tagger.owner
         )
         
         data = {
@@ -165,6 +165,7 @@ class TestGundiTraceSerializerValidation:
         
         assert "Your API Key is not authorized for the integration_id" in str(exc_info.value)
 
+    # FixMe: This test is failing
     def test_validate_invalid_integration_id_raises_error(self):
         """Test validation fails when integration ID is invalid"""
         factory = APIRequestFactory()
@@ -202,6 +203,7 @@ class TestGundiTraceSerializerValidation:
         
         assert "This API Key isn't associated with an integration" in str(exc_info.value)
 
+    # FixMe: This test is failing
     def test_validate_invalid_request_integration_id_raises_error(self):
         """Test validation fails when request.integration_id is invalid"""
         factory = APIRequestFactory()

--- a/cdip_admin/integrations/management/commands/set_action_configs.py
+++ b/cdip_admin/integrations/management/commands/set_action_configs.py
@@ -114,23 +114,5 @@ class Command(BaseCommand):
             else:
                 total_updated += 1
                 self.stdout.write(f"Updated config for action '{action_slug_id}' on integration '{integration.name}' ({integration.id})")
-            # try:
-            #     action_config = IntegrationConfiguration.objects.get(
-            #         integration=integration,
-            #         action=action
-            #     )
-            # except IntegrationConfiguration.DoesNotExist:
-            #     action_config = IntegrationConfiguration(
-            #         integration=integration,
-            #         action=action,
-            #         data=config_data
-            #     )
-            #     action_config.save()
-            #     total_created += 1
-            #     self.stdout.write(f"Created new config for action '{action_slug_id}' on integration '{integration.name}' ({integration.id})")
-            # else:
-            #     action_config.data = config_data
-            #     action_config.save()
-            #     total_updated += 1
-            #     self.stdout.write(f"Updated config for action '{action_slug_id}' on integration '{integration.name}' ({integration.id})")
+
         self.stdout.write(f"Total created: {total_created}, Total updated: {total_updated}")

--- a/cdip_admin/integrations/management/commands/set_action_configs.py
+++ b/cdip_admin/integrations/management/commands/set_action_configs.py
@@ -1,0 +1,136 @@
+import json
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.db.models import Q
+from django.conf import settings
+from deployments.models import DispatcherDeployment
+from deployments.utils import (
+    get_dispatcher_defaults_from_gcp_secrets,
+    get_default_dispatcher_name,
+)
+from deployments.tasks import deploy_serverless_dispatcher
+from integrations.models import Integration, OutboundIntegrationConfiguration, IntegrationAction, IntegrationType, \
+    IntegrationConfiguration
+from integrations.utils import get_dispatcher_topic_default_name
+
+
+class Command(BaseCommand):
+    help = "Create or update action configurations."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--integration",
+            required=False,
+            type=str,
+            help="Select a single integration by ID",
+        )
+        parser.add_argument(
+            "--integration-type",
+            required=False,
+            type=str,
+            help="Select integrations by type. e.g. inreach, earth_ranger.",
+        )
+        parser.add_argument(
+            "--action",
+            type=str,
+            help="Select an action by ID. e.g. pull_events, show_permissions",
+        )
+        parser.add_argument(
+            "--data",
+            type=str,
+            default="{}",
+            help="The JSON value to be set in the configuration data field.",
+        )
+        parser.add_argument(
+            "--max",
+            type=int,
+            default=10,
+            help="Specify the maximum number of integrations/configs to process.",
+        )
+
+    def handle(self, *args, **options):
+        integration_type_slug_id = options.get("integration_type")
+        integration_id = options.get("integration")
+        action_slug_id = options.get("action")
+        try:
+            config_data = json.loads(options.get("data"))
+        except json.JSONDecodeError:
+            self.stderr.write("The provided configuration data is not valid JSON.")
+            return
+        if not integration_type_slug_id and not integration_id:
+            self.stdout.write("Please specify an integration ID or type")
+            return
+        if integration_id:
+            try:
+                integration = Integration.objects.get(id=integration_id)
+            except Integration.DoesNotExist:
+                self.stderr.write(f"Integration '{integration_id}' not found.")
+                return
+        else:
+            integration = None
+        if integration_type_slug_id:
+            try:
+                integration_type = IntegrationType.objects.get(value=integration_type_slug_id)
+            except IntegrationType.DoesNotExist:
+                self.stderr.write(f"Integration type '{integration_type_slug_id}' not found.")
+                return
+        elif integration:  # Infer from the integration
+            integration_type = integration.type
+        else:
+            self.stderr.write("Integration type could not be determined.")
+            return
+
+        try:
+            action = IntegrationAction.objects.get(
+                integration_type=integration_type,
+                value=action_slug_id
+            )
+        except IntegrationAction.DoesNotExist:
+            self.stderr.write(f"Action '{action_slug_id}' for type {integration_type_slug_id} not found.")
+            return
+
+        # Get integrations to process
+        if integration_id:
+            integrations_to_process = [integration]
+        else:
+            integrations_to_process = Integration.objects.filter(
+                type=integration_type
+            )[: options.get("max")]
+
+        # Set configurations
+        total_created = 0
+        total_updated = 0
+        self.stdout.write(f"Processing {len(integrations_to_process)} integrations...")
+        for integration in integrations_to_process:
+            action_config, created = IntegrationConfiguration.objects.update_or_create(
+                integration=integration,
+                action=action,
+                defaults={"data": config_data}
+            )
+            if created:
+                total_created += 1
+                self.stdout.write(f"Created new config for action '{action_slug_id}' on integration '{integration.name}' ({integration.id})")
+            else:
+                total_updated += 1
+                self.stdout.write(f"Updated config for action '{action_slug_id}' on integration '{integration.name}' ({integration.id})")
+            # try:
+            #     action_config = IntegrationConfiguration.objects.get(
+            #         integration=integration,
+            #         action=action
+            #     )
+            # except IntegrationConfiguration.DoesNotExist:
+            #     action_config = IntegrationConfiguration(
+            #         integration=integration,
+            #         action=action,
+            #         data=config_data
+            #     )
+            #     action_config.save()
+            #     total_created += 1
+            #     self.stdout.write(f"Created new config for action '{action_slug_id}' on integration '{integration.name}' ({integration.id})")
+            # else:
+            #     action_config.data = config_data
+            #     action_config.save()
+            #     total_updated += 1
+            #     self.stdout.write(f"Updated config for action '{action_slug_id}' on integration '{integration.name}' ({integration.id})")
+        self.stdout.write(f"Total created: {total_created}, Total updated: {total_updated}")

--- a/cdip_admin/integrations/tests/test_commands.py
+++ b/cdip_admin/integrations/tests/test_commands.py
@@ -1,0 +1,49 @@
+import json
+import pytest
+from django.core.management import call_command
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_call_set_action_configs_command_with_integration_id(
+    er_destination_without_show_permissions_config, er_action_show_permissions
+):
+    integration_id = str(er_destination_without_show_permissions_config.id)
+    config_json = '{"include_subjects_from_subgroups_in_parent":true}'
+
+    call_command(
+        "set_action_configs",
+        "--integration", str(integration_id),
+        "--action", "show_permissions",
+        "--data", config_json
+    )
+
+    new_config = er_destination_without_show_permissions_config.configurations.filter(
+        integration=er_destination_without_show_permissions_config,
+        action=er_action_show_permissions
+    ).first()
+    assert new_config is not None
+    assert new_config.data == json.loads(config_json)
+
+
+def test_call_set_action_configs_command_with_integration_type(
+    er_destination_without_show_permissions_config, er_action_show_permissions
+):
+    integration_type = "earth_ranger"
+    config_json = '{"include_subjects_from_subgroups_in_parent":false}'
+
+    call_command(
+        "set_action_configs",
+        "--integration-type", integration_type,
+        "--max", "1",
+        "--action", "show_permissions",
+        "--data", config_json
+    )
+
+    new_config = er_destination_without_show_permissions_config.configurations.filter(
+        integration=er_destination_without_show_permissions_config,
+        action=er_action_show_permissions
+    ).first()
+    assert new_config is not None
+    assert new_config.data == json.loads(config_json)

--- a/cdip_admin/integrations/tests/test_tasks.py
+++ b/cdip_admin/integrations/tests/test_tasks.py
@@ -118,6 +118,7 @@ def test_movebank_permissions_set_is_updated_on_device_addition_v2(
     assert mocked_csv_task.delay.called
 
 
+# FixMe: This test is failing
 @pytest.mark.django_db
 def test_movebank_permissions_file_upload_task_creates_permissions_json(
         mocker,
@@ -178,6 +179,7 @@ def test_movebank_permissions_file_upload_task_no_configs(mocker, caplog, mock_m
     assert log_to_test in [r.message for r in caplog.records]
 
 
+# FixMe: This test is failing
 @pytest.mark.django_db
 def test_movebank_permissions_file_upload_task_with_configs(
         mocker,
@@ -245,6 +247,7 @@ def test_movebank_permissions_file_upload_task_with_configs(
         assert log in logs
 
 
+# FixMe: This test is failing
 @pytest.mark.django_db
 def test_movebank_permissions_file_upload_task_with_bad_configs(
         mocker,


### PR DESCRIPTION
This pull request introduces a new management command for creating or updating action configurations for integrations, along with supporting fixtures and tests. It also includes minor updates to test files and the secrets baseline. The most significant changes are the addition of the `set_action_configs` management command and its comprehensive test coverage.

**New management command and tests:**

* Added a new Django management command `set_action_configs` in `cdip_admin/integrations/management/commands/set_action_configs.py` to create or update `IntegrationConfiguration` objects for a given integration or integration type, action, and configuration data. The command supports filtering by integration, integration type, action, and limits the number of processed integrations.
* Added tests for the new management command in `cdip_admin/integrations/tests/test_commands.py`, covering both integration ID and integration type use cases to ensure configurations are created or updated as expected.

**Test fixtures and support:**

* Added the `er_action_show_permissions` fixture and the `er_destination_without_show_permissions_config` fixture in `cdip_admin/conftest.py` to support testing integrations without an existing show_permissions configuration. [[1]](diffhunk://#diff-ef120c645d9ac339bbac37720f451d79f84d67a40f6a07cfa149a8d973193a58R476-R500) [[2]](diffhunk://#diff-ef120c645d9ac339bbac37720f451d79f84d67a40f6a07cfa149a8d973193a58R1717-R1781)

**Test maintenance and minor updates:**

* Marked several failing tests in `cdip_admin/api/v2/tests/test_gunditrace_serializer.py` and `cdip_admin/integrations/tests/test_tasks.py` with `# FixMe: This test is failing` for future attention. [[1]](diffhunk://#diff-753beb2c378a3a593334b6f119668a9540dfaaaabc968e67f48dd16dd4eb69bdR168) [[2]](diffhunk://#diff-753beb2c378a3a593334b6f119668a9540dfaaaabc968e67f48dd16dd4eb69bdR206) [[3]](diffhunk://#diff-67bec5b50fc0a11f0758c09034b7f1fce33e5fc842c61e56179c22e61f965548R121) [[4]](diffhunk://#diff-67bec5b50fc0a11f0758c09034b7f1fce33e5fc842c61e56179c22e61f965548R182) [[5]](diffhunk://#diff-67bec5b50fc0a11f0758c09034b7f1fce33e5fc842c61e56179c22e61f965548R250)
* Updated test data and field names in `test_gunditrace_serializer.py` to match current models.

**Housekeeping:**

* Updated `.secrets.baseline` to reflect new line numbers and generation timestamp. [[1]](diffhunk://#diff-d8447df0cd384602c76086081f13f27ad0b45902297c42da35a6fc51fdf1cec3L198-R198) [[2]](diffhunk://#diff-d8447df0cd384602c76086081f13f27ad0b45902297c42da35a6fc51fdf1cec3L232-R236)