### PR TITLE
GUNDI-4670: Fix action topic names

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -163,21 +163,21 @@
         "filename": "cdip_admin/api/v2/tests/test_integrations_api.py",
         "hashed_secret": "f14d9df281fdecdb7b1c49ebb7a17f525c42ea48",
         "is_verified": false,
-        "line_number": 189
+        "line_number": 205
       },
       {
         "type": "Secret Keyword",
         "filename": "cdip_admin/api/v2/tests/test_integrations_api.py",
         "hashed_secret": "f424c840dadb52c20b6277fac4ca56ce729bc9b9",
         "is_verified": false,
-        "line_number": 1401
+        "line_number": 1417
       },
       {
         "type": "Secret Keyword",
         "filename": "cdip_admin/api/v2/tests/test_integrations_api.py",
         "hashed_secret": "12436f4d8e8d63b983d6b2a5184fa2ff83545d86",
         "is_verified": false,
-        "line_number": 1439
+        "line_number": 1455
       }
     ],
     "cdip_admin/cdip_admin/settings.py": [
@@ -195,7 +195,7 @@
         "filename": "cdip_admin/conftest.py",
         "hashed_secret": "27d933b78d3ea4a51a3ff26aef5831c92d43925c",
         "is_verified": false,
-        "line_number": 3866
+        "line_number": 3868
       }
     ],
     "cdip_admin/integrations/migrations/0047_init_erinreach_config_schema.py": [
@@ -233,5 +233,5 @@
       }
     ]
   },
-  "generated_at": "2025-08-28T20:28:26Z"
+  "generated_at": "2025-08-29T18:15:57Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -163,21 +163,21 @@
         "filename": "cdip_admin/api/v2/tests/test_integrations_api.py",
         "hashed_secret": "f14d9df281fdecdb7b1c49ebb7a17f525c42ea48",
         "is_verified": false,
-        "line_number": 205
+        "line_number": 207
       },
       {
         "type": "Secret Keyword",
         "filename": "cdip_admin/api/v2/tests/test_integrations_api.py",
         "hashed_secret": "f424c840dadb52c20b6277fac4ca56ce729bc9b9",
         "is_verified": false,
-        "line_number": 1417
+        "line_number": 1419
       },
       {
         "type": "Secret Keyword",
         "filename": "cdip_admin/api/v2/tests/test_integrations_api.py",
         "hashed_secret": "12436f4d8e8d63b983d6b2a5184fa2ff83545d86",
         "is_verified": false,
-        "line_number": 1455
+        "line_number": 1457
       }
     ],
     "cdip_admin/cdip_admin/settings.py": [
@@ -233,5 +233,5 @@
       }
     ]
   },
-  "generated_at": "2025-08-29T18:15:57Z"
+  "generated_at": "2025-08-29T18:57:24Z"
 }

--- a/cdip_admin/activity_log/models.py
+++ b/cdip_admin/activity_log/models.py
@@ -8,6 +8,7 @@ from core.models import UUIDAbstractModel, TimestampedModel
 import gundi_core.events as gundi_core_events
 import gundi_core.schemas.v2 as gundi_core_schemas
 
+from integrations.utils import get_topic_prefix_from_integration_type
 from .core import ActivityActions
 from .tasks import publish_configuration_event
 
@@ -255,7 +256,7 @@ class ActivityLog(UUIDAbstractModel, TimestampedModel):
         # Publish events to notify other services about the config changes as needed
         if event := build_event_from_log(log=self):
             # Cleanup to match subscription filters: earth_ranger -> earthranger
-            integration_type_filter = self.integration_type.value.replace("_", "").strip()
+            integration_type_filter = get_topic_prefix_from_integration_type(self.integration_type.value)
             publish_configuration_event.delay(
                 event_data=event.dict(),
                 attributes={  # Attributes can be used for filtering in subscriptions

--- a/cdip_admin/activity_log/models.py
+++ b/cdip_admin/activity_log/models.py
@@ -8,7 +8,7 @@ from core.models import UUIDAbstractModel, TimestampedModel
 import gundi_core.events as gundi_core_events
 import gundi_core.schemas.v2 as gundi_core_schemas
 
-from integrations.utils import get_topic_prefix_from_integration_type
+from integrations.utils import get_prefix_from_integration_type
 from .core import ActivityActions
 from .tasks import publish_configuration_event
 
@@ -256,7 +256,7 @@ class ActivityLog(UUIDAbstractModel, TimestampedModel):
         # Publish events to notify other services about the config changes as needed
         if event := build_event_from_log(log=self):
             # Cleanup to match subscription filters: earth_ranger -> earthranger
-            integration_type_filter = get_topic_prefix_from_integration_type(self.integration_type.value)
+            integration_type_filter = get_prefix_from_integration_type(self.integration_type.value)
             publish_configuration_event.delay(
                 event_data=event.dict(),
                 attributes={  # Attributes can be used for filtering in subscriptions

--- a/cdip_admin/api/v2/tests/test_integrations_api.py
+++ b/cdip_admin/api/v2/tests/test_integrations_api.py
@@ -12,7 +12,7 @@ from integrations.models import (
     IntegrationAction,
     IntegrationConfiguration, IntegrationType, IntegrationStatus,
 )
-from integrations.utils import get_topic_prefix_from_integration_type
+from integrations.utils import get_prefix_from_integration_type
 from .utils import _test_activity_logs_on_instance_created, _test_activity_logs_on_instance_updated
 
 
@@ -152,7 +152,7 @@ def _test_create_integration(
             assert task_kwargs.get("integration_id") == str(integration.id)
             assert task_kwargs.get("action_id") == str(configuration.action.value)
             # Check that the pubsub topic name is correct, without hyphens and underscores
-            prefix = get_topic_prefix_from_integration_type(integration.type.value)
+            prefix = get_prefix_from_integration_type(integration.type.value)
             expected_topic_name = f"{prefix}-actions-topic"
             assert task_kwargs.get("pubsub_topic") == expected_topic_name
 

--- a/cdip_admin/api/v2/tests/test_integrations_api.py
+++ b/cdip_admin/api/v2/tests/test_integrations_api.py
@@ -152,7 +152,7 @@ def _test_create_integration(
             assert task_kwargs.get("integration_id") == str(integration.id)
             assert task_kwargs.get("action_id") == str(configuration.action.value)
             # Check that the pubsub topic name is correct, without hyphens and underscores
-            prefix = get_topic_prefix_from_integration_type(value=integration.type.value)
+            prefix = get_topic_prefix_from_integration_type(integration.type.value)
             expected_topic_name = f"{prefix}-actions-topic"
             assert task_kwargs.get("pubsub_topic") == expected_topic_name
 

--- a/cdip_admin/api/v2/tests/test_integrations_api.py
+++ b/cdip_admin/api/v2/tests/test_integrations_api.py
@@ -12,6 +12,7 @@ from integrations.models import (
     IntegrationAction,
     IntegrationConfiguration, IntegrationType, IntegrationStatus,
 )
+from integrations.utils import get_topic_prefix_from_integration_type
 from .utils import _test_activity_logs_on_instance_created, _test_activity_logs_on_instance_updated
 
 
@@ -151,7 +152,8 @@ def _test_create_integration(
             assert task_kwargs.get("integration_id") == str(integration.id)
             assert task_kwargs.get("action_id") == str(configuration.action.value)
             # Check that the pubsub topic name is correct, without hyphens and underscores
-            expected_topic_name = f"{integration.type.value.lower().replace('_', '').replace('-', '').strip()}-actions-topic"
+            prefix = get_topic_prefix_from_integration_type(value=integration.type.value)
+            expected_topic_name = f"{prefix}-actions-topic"
             assert task_kwargs.get("pubsub_topic") == expected_topic_name
 
         # Check activity logs for each configuration

--- a/cdip_admin/api/v2/tests/test_integrations_api.py
+++ b/cdip_admin/api/v2/tests/test_integrations_api.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from django.urls import reverse
 from django_celery_beat.models import PeriodicTask
@@ -139,6 +141,19 @@ def _test_create_integration(
             assert configuration.data == next(c for c in configurations if c["action"] == str(configuration.action.id))["data"]
         elif str(configuration.action.id) in missing_configurations and create_configurations:
             assert configuration.data == {}  # Configuration was created automatically
+        if configuration.action.is_periodic_action:
+            # Check that a periodic task was created for periodic actions
+            assert configuration.periodic_task is not None
+            periodic_task = configuration.periodic_task
+            assert periodic_task.enabled is True
+            assert periodic_task.task == "integrations.tasks.run_integration"
+            task_kwargs = json.loads(periodic_task.kwargs)
+            assert task_kwargs.get("integration_id") == str(integration.id)
+            assert task_kwargs.get("action_id") == str(configuration.action.value)
+            # Check that the pubsub topic name is correct, without hyphens and underscores
+            expected_topic_name = f"{integration.type.value.replace('_', '').replace('-', '').strip()}-actions-topic"
+            assert task_kwargs.get("pubsub_topic") == expected_topic_name
+
         # Check activity logs for each configuration
         activity_log = activity_logs[i]
         _test_activity_logs_on_instance_created(
@@ -172,7 +187,8 @@ def _test_create_integration(
 
 def test_create_er_integration_as_superuser(
         api_client, superuser, organization, integration_type_er, get_random_id, er_action_auth,
-        er_action_push_events, er_action_push_positions, er_action_pull_events, er_action_pull_positions
+        er_action_push_events, er_action_push_positions, er_action_push_messages,
+        er_action_pull_events, er_action_pull_positions, er_action_show_permissions
 ):
     _test_create_integration(
         api_client=api_client,

--- a/cdip_admin/api/v2/tests/test_integrations_api.py
+++ b/cdip_admin/api/v2/tests/test_integrations_api.py
@@ -151,7 +151,7 @@ def _test_create_integration(
             assert task_kwargs.get("integration_id") == str(integration.id)
             assert task_kwargs.get("action_id") == str(configuration.action.value)
             # Check that the pubsub topic name is correct, without hyphens and underscores
-            expected_topic_name = f"{integration.type.value.replace('_', '').replace('-', '').strip()}-actions-topic"
+            expected_topic_name = f"{integration.type.value.lower().replace('_', '').replace('-', '').strip()}-actions-topic"
             assert task_kwargs.get("pubsub_topic") == expected_topic_name
 
         # Check activity logs for each configuration

--- a/cdip_admin/conftest.py
+++ b/cdip_admin/conftest.py
@@ -459,6 +459,7 @@ def er_action_pull_positions(integration_type_er):
         name="Pull Positions",
         value="pull_positions",
         description="Pull Tracking data from Earth Ranger API",
+        is_periodic_action=True,
     )
 
 
@@ -470,6 +471,7 @@ def er_action_pull_events(integration_type_er):
         name="Pull Events",
         value="pull_events",
         description="Pull Event data from Earth Ranger API",
+        is_periodic_action=True,
     )
 
 

--- a/cdip_admin/integrations/models/v2/models.py
+++ b/cdip_admin/integrations/models/v2/models.py
@@ -16,7 +16,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 
 from integrations.utils import get_api_key, does_movebank_permissions_config_changed, get_dispatcher_topic_default_name, \
-    get_topic_prefix_from_integration_type
+    get_prefix_from_integration_type
 from model_utils import FieldTracker
 from integrations.tasks import (
     update_mb_permissions_for_group,
@@ -434,7 +434,7 @@ class IntegrationConfiguration(ChangeLogMixin, UUIDAbstractModel, TimestampedMod
 
         if self.action.is_periodic_action and not self.periodic_task:
             task_name = f"Run '{self.action.name}' on '{self.integration.name}'"[:200]
-            integration_type_prefix = get_topic_prefix_from_integration_type(value=self.integration.type.value)
+            integration_type_prefix = get_prefix_from_integration_type(value=self.integration.type.value)
             topic_name = f"{integration_type_prefix}-actions-topic"
             periodic_task_params = {
                 "name": task_name,

--- a/cdip_admin/integrations/models/v2/models.py
+++ b/cdip_admin/integrations/models/v2/models.py
@@ -433,7 +433,7 @@ class IntegrationConfiguration(ChangeLogMixin, UUIDAbstractModel, TimestampedMod
 
         if self.action.is_periodic_action and not self.periodic_task:
             task_name = f"Run '{self.action.name}' on '{self.integration.name}'"[:200]
-            topic_name = f"{self.integration.type.value.replace('_', '').replace('-', '').strip()}-actions-topic"
+            topic_name = f"{self.integration.type.value.lower().replace('_', '').replace('-', '').strip()}-actions-topic"
             periodic_task_params = {
                 "name": task_name,
                 "task": "integrations.tasks.run_integration",

--- a/cdip_admin/integrations/models/v2/models.py
+++ b/cdip_admin/integrations/models/v2/models.py
@@ -15,7 +15,8 @@ from django.db.models import Subquery
 from django.conf import settings
 from django.contrib.auth import get_user_model
 
-from integrations.utils import get_api_key, does_movebank_permissions_config_changed, get_dispatcher_topic_default_name
+from integrations.utils import get_api_key, does_movebank_permissions_config_changed, get_dispatcher_topic_default_name, \
+    get_topic_prefix_from_integration_type
 from model_utils import FieldTracker
 from integrations.tasks import (
     update_mb_permissions_for_group,
@@ -433,7 +434,8 @@ class IntegrationConfiguration(ChangeLogMixin, UUIDAbstractModel, TimestampedMod
 
         if self.action.is_periodic_action and not self.periodic_task:
             task_name = f"Run '{self.action.name}' on '{self.integration.name}'"[:200]
-            topic_name = f"{self.integration.type.value.lower().replace('_', '').replace('-', '').strip()}-actions-topic"
+            integration_type_prefix = get_topic_prefix_from_integration_type(value=self.integration.type.value)
+            topic_name = f"{integration_type_prefix}-actions-topic"
             periodic_task_params = {
                 "name": task_name,
                 "task": "integrations.tasks.run_integration",

--- a/cdip_admin/integrations/models/v2/models.py
+++ b/cdip_admin/integrations/models/v2/models.py
@@ -433,13 +433,14 @@ class IntegrationConfiguration(ChangeLogMixin, UUIDAbstractModel, TimestampedMod
 
         if self.action.is_periodic_action and not self.periodic_task:
             task_name = f"Run '{self.action.name}' on '{self.integration.name}'"[:200]
+            topic_name = f"{self.integration.type.value.replace('_', '').replace('-', '').strip()}-actions-topic"
             periodic_task_params = {
                 "name": task_name,
                 "task": "integrations.tasks.run_integration",
                 "kwargs": json.dumps({
                     "integration_id": str(self.integration_id),
                     "action_id": self.action.value,
-                    "pubsub_topic": f"{self.integration.type.value}-actions-topic"
+                    "pubsub_topic": topic_name
                 })
             }
             # Check for custom crontab schedule

--- a/cdip_admin/integrations/tests/test_utils.py
+++ b/cdip_admin/integrations/tests/test_utils.py
@@ -3,7 +3,8 @@ import json
 
 import pytest
 
-from ..utils import create_api_consumer, KONG_PROXY_URL, CONSUMERS_PATH, get_api_consumer_info, patch_api_consumer_info
+from ..utils import create_api_consumer, KONG_PROXY_URL, CONSUMERS_PATH, get_api_consumer_info, patch_api_consumer_info, \
+    get_prefix_from_integration_type
 
 pytestmark = pytest.mark.django_db
 
@@ -67,3 +68,14 @@ def test_patch_api_consumer_info(mocker, provider_ats, mock_kong_consumers_api_r
     assert result == mock_kong_consumers_api_requests.patch.return_value
     expected_url = f"{KONG_PROXY_URL}{CONSUMERS_PATH}/integration:{str(provider_ats.id)}"
     mock_kong_consumers_api_requests.patch.assert_called_once_with(expected_url, data=data)
+
+
+@pytest.mark.parametrize("integration_type, expected_prefix", [
+    ("earth_ranger", "earthranger"),
+    ("MoveBank", "movebank"),
+    ("mella-tracking", "mellatracking"),
+    ("ats ", "ats"),
+    ("un_conventional-VAlue ", "unconventionalvalue"),
+])
+def test_get_topic_prefix_from_integration_type(integration_type, expected_prefix):
+    assert get_prefix_from_integration_type(integration_type) == expected_prefix

--- a/cdip_admin/integrations/utils.py
+++ b/cdip_admin/integrations/utils.py
@@ -152,7 +152,7 @@ def get_dispatcher_topic_default_name(integration, gundi_version="v2"):
         return settings.MOVEBANK_DISPATCHER_DEFAULT_TOPIC
     # Newer Connectors v2 with push data capabilities follow a naming convention
     if gundi_version == "v2":
-        integration_type_prefix = get_topic_prefix_from_integration_type(value=integration.type.value)
+        integration_type_prefix = get_topic_prefix_from_integration_type(integration.type.value)
         return f"{integration_type_prefix}-push-data-topic"
     # Fallback to legacy kafka dispatchers topic
     return f"sintegrate.observations.transformed"

--- a/cdip_admin/integrations/utils.py
+++ b/cdip_admin/integrations/utils.py
@@ -139,7 +139,7 @@ def send_message_to_gcp_pubsub(message, topic):
     logger.info(f"Published message ID: {future.result()}")
 
 
-def get_topic_prefix_from_integration_type(value: str):
+def get_prefix_from_integration_type(value: str):
     # e.g. stevens_connect -> stevensconnect
     return value.lower().replace("_", "").replace("-", "").strip()
 
@@ -152,7 +152,7 @@ def get_dispatcher_topic_default_name(integration, gundi_version="v2"):
         return settings.MOVEBANK_DISPATCHER_DEFAULT_TOPIC
     # Newer Connectors v2 with push data capabilities follow a naming convention
     if gundi_version == "v2":
-        integration_type_prefix = get_topic_prefix_from_integration_type(integration.type.value)
+        integration_type_prefix = get_prefix_from_integration_type(integration.type.value)
         return f"{integration_type_prefix}-push-data-topic"
     # Fallback to legacy kafka dispatchers topic
     return f"sintegrate.observations.transformed"

--- a/cdip_admin/integrations/utils.py
+++ b/cdip_admin/integrations/utils.py
@@ -139,6 +139,11 @@ def send_message_to_gcp_pubsub(message, topic):
     logger.info(f"Published message ID: {future.result()}")
 
 
+def get_topic_prefix_from_integration_type(value: str):
+    # e.g. stevens_connect -> stevensconnect
+    return value.lower().replace("_", "").replace("-", "").strip()
+
+
 def get_dispatcher_topic_default_name(integration, gundi_version="v2"):
 
     if integration.is_er_site or integration.is_smart_site or integration.is_wpswatch_site or integration.is_traptagger_site:
@@ -147,7 +152,7 @@ def get_dispatcher_topic_default_name(integration, gundi_version="v2"):
         return settings.MOVEBANK_DISPATCHER_DEFAULT_TOPIC
     # Newer Connectors v2 with push data capabilities follow a naming convention
     if gundi_version == "v2":
-        integration_type_prefix = integration.type.value.lower().replace("_", "").replace("-", "").strip()
+        integration_type_prefix = get_topic_prefix_from_integration_type(value=integration.type.value)
         return f"{integration_type_prefix}-push-data-topic"
     # Fallback to legacy kafka dispatchers topic
     return f"sintegrate.observations.transformed"

--- a/cdip_admin/integrations/utils.py
+++ b/cdip_admin/integrations/utils.py
@@ -147,7 +147,7 @@ def get_dispatcher_topic_default_name(integration, gundi_version="v2"):
         return settings.MOVEBANK_DISPATCHER_DEFAULT_TOPIC
     # Newer Connectors v2 with push data capabilities follow a naming convention
     if gundi_version == "v2":
-        integration_type_prefix = integration.type.value.lower().strip().replace("_", "")
+        integration_type_prefix = integration.type.value.lower().replace("_", "").replace("-", "").strip()
         return f"{integration_type_prefix}-push-data-topic"
     # Fallback to legacy kafka dispatchers topic
     return f"sintegrate.observations.transformed"


### PR DESCRIPTION
This pull request standardizes how integration type prefixes are generated and used throughout the codebase, particularly for pubsub topic names and periodic task creation. The main change introduces a new utility function, `get_prefix_from_integration_type`, which ensures consistent formatting (removing underscores, hyphens, and whitespace, and converting to lowercase). The function is now used in key locations where integration type prefixes are required, and corresponding tests have been added. Additionally, the pull request updates tests and baseline files to reflect these changes.

**Integration prefix standardization:**

* Added `get_prefix_from_integration_type` utility function in `cdip_admin/integrations/utils.py` to consistently generate integration type prefixes by removing underscores, hyphens, and whitespace, and converting to lowercase.
* Updated all usages of integration type prefixing for pubsub topic names and periodic tasks to use `get_prefix_from_integration_type`, including in `cdip_admin/activity_log/models.py`, `cdip_admin/integrations/models/v2/models.py`, and `cdip_admin/integrations/utils.py`. [[1]](diffhunk://#diff-cc7b63b90189360be4c2db54e3a28cac4beb6d929c517634614f547883e35132L258-R259) [[2]](diffhunk://#diff-2a79c2f708bae47679a48e0a37a8a885573ff7f5c01f648503bf574c5a758700R437-R445) [[3]](diffhunk://#diff-41bd00af6bee3d1de5790ca67a8644f8d0bc6549b192546a36088f5cfe925981L150-R155)

**Testing improvements:**

* Added parameterized tests for `get_prefix_from_integration_type` in `cdip_admin/integrations/tests/test_utils.py` to ensure correct prefix generation for various input formats.
* Enhanced integration creation tests in `cdip_admin/api/v2/tests/test_integrations_api.py` to verify that periodic tasks use the correct pubsub topic name and that the prefix is generated as expected.

**Test data and baseline updates:**

* Marked certain integration actions as periodic in test fixtures to support new test cases. [[1]](diffhunk://#diff-ef120c645d9ac339bbac37720f451d79f84d67a40f6a07cfa149a8d973193a58R462) [[2]](diffhunk://#diff-ef120c645d9ac339bbac37720f451d79f84d67a40f6a07cfa149a8d973193a58R474)
* Updated `.secrets.baseline` to reflect new line numbers after test changes. [[1]](diffhunk://#diff-d8447df0cd384602c76086081f13f27ad0b45902297c42da35a6fc51fdf1cec3L166-R180) [[2]](diffhunk://#diff-d8447df0cd384602c76086081f13f27ad0b45902297c42da35a6fc51fdf1cec3L198-R198) [[3]](diffhunk://#diff-d8447df0cd384602c76086081f13f27ad0b45902297c42da35a6fc51fdf1cec3L236-R236)