### PR TITLE
GUNDI-4676: Fix pull action tasks being triggered for ER destiantions

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -163,21 +163,21 @@
         "filename": "cdip_admin/api/v2/tests/test_integrations_api.py",
         "hashed_secret": "f14d9df281fdecdb7b1c49ebb7a17f525c42ea48",
         "is_verified": false,
-        "line_number": 207
+        "line_number": 210
       },
       {
         "type": "Secret Keyword",
         "filename": "cdip_admin/api/v2/tests/test_integrations_api.py",
         "hashed_secret": "f424c840dadb52c20b6277fac4ca56ce729bc9b9",
         "is_verified": false,
-        "line_number": 1419
+        "line_number": 1422
       },
       {
         "type": "Secret Keyword",
         "filename": "cdip_admin/api/v2/tests/test_integrations_api.py",
         "hashed_secret": "12436f4d8e8d63b983d6b2a5184fa2ff83545d86",
         "is_verified": false,
-        "line_number": 1457
+        "line_number": 1460
       }
     ],
     "cdip_admin/cdip_admin/settings.py": [
@@ -233,5 +233,5 @@
       }
     ]
   },
-  "generated_at": "2025-08-29T18:57:24Z"
+  "generated_at": "2025-09-02T21:02:08Z"
 }

--- a/cdip_admin/api/v2/tests/test_integrations_api.py
+++ b/cdip_admin/api/v2/tests/test_integrations_api.py
@@ -146,8 +146,11 @@ def _test_create_integration(
             # Check that a periodic task was created for periodic actions
             assert configuration.periodic_task is not None
             periodic_task = configuration.periodic_task
-            assert periodic_task.enabled is True
             assert periodic_task.task == "integrations.tasks.run_integration"
+            if integration.is_used_as_provider:
+                assert periodic_task.enabled is True
+            else:
+                assert periodic_task.enabled is False
             task_kwargs = json.loads(periodic_task.kwargs)
             assert task_kwargs.get("integration_id") == str(integration.id)
             assert task_kwargs.get("action_id") == str(configuration.action.value)

--- a/cdip_admin/integrations/models/v2/models.py
+++ b/cdip_admin/integrations/models/v2/models.py
@@ -274,7 +274,7 @@ class Integration(ChangeLogMixin, UUIDAbstractModel, TimestampedModel):
             if self.tracker.has_changed("enabled"):
                 if self.is_used_as_provider:
                     # Disable/Enable related periodic tasks for pull actions
-                    for config in self.configurations.filter(action__type=IntegrationAction.ActionTypes.PULL_DATA, action__is_periodic_action=True):
+                    for config in self.periodic_pull_action_configurations:
                         if config.periodic_task:
                             config.periodic_task.enabled = self.enabled
                             config.periodic_task.save()

--- a/cdip_admin/integrations/models/v2/services.py
+++ b/cdip_admin/integrations/models/v2/services.py
@@ -31,7 +31,8 @@ def ensure_default_route(integration):
         integration.save()
     # Add the integration a provider in its default routing rule
     if not integration.default_route.data_providers.filter(id=integration.id).exists():
-        integration.default_route.data_providers.add(integration)
+        RouteProvider = apps.get_model('integrations', 'RouteProvider')
+        RouteProvider.objects.create(integration=integration, route=integration.default_route)
 
 
 def get_user_integrations_qs(user):


### PR DESCRIPTION
This PR fixes the issue that caused false errors in activity logs and alerts due to pull actions being triggered for ER destinations.

Copilot:
This pull request introduces improvements to how periodic tasks are enabled or disabled for integrations, based on whether the integration is used as a provider. It adds new properties to the `Integration` model to clarify its usage context and refines the logic for managing periodic tasks, ensuring they are only active when appropriate. The changes also update related test cases and service logic for consistency.

**Integration model enhancements:**

* Added `is_used_as_provider` and `is_used_as_destination` properties to the `Integration` model to clearly indicate its role in routing rules.
* Introduced the `periodic_pull_action_configurations` property to simplify access to relevant configurations for periodic pull actions.

**Periodic task management:**

* Updated the logic in `_post_save` for `Integration` and `RouteProvider` to enable or disable periodic tasks for pull actions only if the integration is used as a provider and is enabled. [[1]](diffhunk://#diff-2a79c2f708bae47679a48e0a37a8a885573ff7f5c01f648503bf574c5a758700R275-R278) [[2]](diffhunk://#diff-2a79c2f708bae47679a48e0a37a8a885573ff7f5c01f648503bf574c5a758700R604-R618)
* Set the `enabled` field for periodic tasks at creation time based on whether the integration is used as a provider.

**Testing and service updates:**

* Modified tests in `test_integrations_api.py` to assert periodic task status based on provider usage.
* Updated the `ensure_default_route` service to use the new `RouteProvider` model creation logic for default routing.

**Other minor updates:**

* Adjusted secret baseline file line numbers and generation timestamp to reflect changes in test file lines. [[1]](diffhunk://#diff-d8447df0cd384602c76086081f13f27ad0b45902297c42da35a6fc51fdf1cec3L166-R180) [[2]](diffhunk://#diff-d8447df0cd384602c76086081f13f27ad0b45902297c42da35a6fc51fdf1cec3L236-R236)