### PR TITLE
Update gunicorn version for python 3.11

### DIFF
--- a/dependencies/requirements-dev.txt
+++ b/dependencies/requirements-dev.txt
@@ -277,7 +277,7 @@ gundi-core==1.11.0
     #   cdip-connector
     #   gundi-client
     #   gundi-client-v2
-gunicorn==19.9.0
+gunicorn==21.2.0
     # via -r dependencies/requirements.in
 h11==0.16.0
     # via httpcore
@@ -386,6 +386,7 @@ packaging==25.0
     # via
     #   -r dependencies/requirements.in
     #   drf-yasg
+    #   gunicorn
     #   kombu
     #   marshmallow
     #   pytest

--- a/dependencies/requirements.in
+++ b/dependencies/requirements.in
@@ -29,7 +29,7 @@ drf-yasg==1.21.7
 django-scopes==1.2.0
 django-tables2==2.3.1
 ecdsa==0.15
-gunicorn==19.9.0
+gunicorn==21.2.0
 idna==2.10
 importlib-metadata==1.6.1
 natsort==7.0.1

--- a/dependencies/requirements.txt
+++ b/dependencies/requirements.txt
@@ -260,7 +260,7 @@ gundi-core==1.11.0
     #   cdip-connector
     #   gundi-client
     #   gundi-client-v2
-gunicorn==19.9.0
+gunicorn==21.2.0
     # via -r dependencies/requirements.in
 h11==0.16.0
     # via httpcore
@@ -361,6 +361,7 @@ packaging==25.0
     # via
     #   -r dependencies/requirements.in
     #   drf-yasg
+    #   gunicorn
     #   kombu
     #   marshmallow
 phonenumbers==8.12.6


### PR DESCRIPTION
This PR upgrades the gunicorn version to fix a Python version compatibility issue detected while testing in dev