### PR TITLE
Gundi 4725 v1 devicegroup UI

### DIFF
--- a/cdip_admin/api/v2/serializers.py
+++ b/cdip_admin/api/v2/serializers.py
@@ -1347,7 +1347,7 @@ class UserAgreementSerializer(serializers.ModelSerializer):
         )
 
     def get_unique_together_validators(self):
-        # Overriden to disable unique together check as it's handled in the create method
+        # Overridden to disable unique together check as it's handled in the create method
         return []
 
     def create(self, validated_data):

--- a/cdip_admin/api/v2/views.py
+++ b/cdip_admin/api/v2/views.py
@@ -54,7 +54,7 @@ class EULAView(
     def get_object(self):
         return EULA.objects.get_active_eula()
 
-    # Overriden to return a single object (the active eula)
+    # Overridden to return a single object (the active eula)
     def list(self, request, *args, **kwargs):
         try:
             instance = self.get_object()

--- a/cdip_admin/integrations/forms.py
+++ b/cdip_admin/integrations/forms.py
@@ -22,6 +22,7 @@ from .models import (
     BridgeIntegration,
     Device
 )
+from .widgets import SearchableMultiSelectField
 from django.urls import reverse
 from django.core.exceptions import ValidationError
 import json
@@ -141,6 +142,13 @@ class InboundIntegrationConfigurationForm(forms.ModelForm):
 
 
 class DeviceGroupForm(forms.ModelForm):
+    # Override the destinations field to use our custom widget
+    destinations = SearchableMultiSelectField(
+        queryset=OutboundIntegrationConfiguration.objects.all(),
+        required=False,
+        label="Destinations"
+    )
+    
     class Meta:
         model = DeviceGroup
         exclude = [
@@ -179,9 +187,16 @@ class DeviceGroupForm(forms.ModelForm):
 
 
 class DeviceGroupManagementForm(forms.ModelForm):
+    # Override the destinations field to use our custom widget
+    destinations = SearchableMultiSelectField(
+        queryset=OutboundIntegrationConfiguration.objects.all(),
+        required=False,
+        label="Destinations"
+    )
+    
     class Meta:
         model = DeviceGroup
-        exclude = ["id", "name", "destinations", "owner"]
+        exclude = ["id", "name", "owner"]
 
     helper = FormHelper()
     helper.add_input(Submit("submit", "Save", css_class="btn-primary"))

--- a/cdip_admin/integrations/forms.py
+++ b/cdip_admin/integrations/forms.py
@@ -22,7 +22,7 @@ from .models import (
     BridgeIntegration,
     Device
 )
-from .widgets import SearchableMultiSelectField, SubjectTypeAutocompleteField, DeviceSearchableMultiSelectField, DeviceGroupSelectWithLinkField, DeviceGroupAutoCreateField
+from .widgets import SearchableMultiSelectField, SubjectTypeAutocompleteField, DeviceSearchableMultiSelectField, DeviceGroupSelectWithLinkField, DeviceGroupAutoCreateField, DeviceGroupDisplayWidget
 from django.urls import reverse
 from django.core.exceptions import ValidationError
 import json
@@ -105,6 +105,11 @@ class InboundIntegrationConfigurationForm(forms.ModelForm):
                     )
                 else:
                     self.fields["default_devicegroup"].queryset = device_group_qs
+                
+                # Replace default_devicegroup field with display widget for existing integrations
+                if self.instance.pk and self.instance.default_devicegroup:  # If this is an existing integration with a default device group
+                    self.fields["default_devicegroup"].widget = DeviceGroupDisplayWidget()
+                    self.fields["default_devicegroup"].help_text = "Default Device Group cannot be changed for existing integrations."
             # TODO: review how we trigger the warning modal
             self.fields['type'].widget.attrs['hx-get'] = reverse("inboundconfigurations/type_modal",
                                                                  kwargs={"integration_id": self.instance.id})
@@ -117,6 +122,18 @@ class InboundIntegrationConfigurationForm(forms.ModelForm):
                 if hasattr(request, 'session'):
                     request.session["integration_type"] = str(self.instance.type.id)
                 self.fields['state'].widget.instance = self.instance.type.id
+
+    def save(self, commit=True):
+        """Override save to preserve default_devicegroup value when using display widget."""
+        instance = super().save(commit=False)
+        
+        # If using DeviceGroupDisplayWidget, preserve the original value
+        if self.instance.pk and isinstance(self.fields['default_devicegroup'].widget, DeviceGroupDisplayWidget):
+            instance.default_devicegroup = self.instance.default_devicegroup
+        
+        if commit:
+            instance.save()
+        return instance
 
     helper = FormHelper()
     helper.add_input(Submit("submit", "Save", css_class="btn-primary"))

--- a/cdip_admin/integrations/forms.py
+++ b/cdip_admin/integrations/forms.py
@@ -382,6 +382,17 @@ class DeviceGroupManagementForm(forms.ModelForm):
                 )
             else:
                 self.fields["owner"].queryset = qs
+            
+            # Filter devices to only show devices from the inbound integration associated with this device group
+            try:
+                inbound_integration = self.instance.inbound_integration_configuration.get()
+                # Limit devices to only those from the associated inbound integration
+                self.fields["devices"].queryset = Device.objects.filter(
+                    inbound_configuration=inbound_integration
+                )
+            except (InboundIntegrationConfiguration.DoesNotExist, InboundIntegrationConfiguration.MultipleObjectsReturned):
+                # If no inbound integration is associated, show no devices
+                self.fields["devices"].queryset = Device.objects.none()
 
     field_order = [
         "name",

--- a/cdip_admin/integrations/forms.py
+++ b/cdip_admin/integrations/forms.py
@@ -22,7 +22,7 @@ from .models import (
     BridgeIntegration,
     Device
 )
-from .widgets import SearchableMultiSelectField, SubjectTypeAutocompleteField
+from .widgets import SearchableMultiSelectField, SubjectTypeAutocompleteField, DeviceSearchableMultiSelectField
 from django.urls import reverse
 from django.core.exceptions import ValidationError
 import json
@@ -194,6 +194,13 @@ class DeviceGroupManagementForm(forms.ModelForm):
         label="Destinations"
     )
     
+    # Override the devices field to use our custom widget
+    devices = DeviceSearchableMultiSelectField(
+        queryset=Device.objects.all(),
+        required=False,
+        label="Devices"
+    )
+    
     # Override the default_subject_type field to use our custom widget
     default_subject_type = SubjectTypeAutocompleteField(
         required=False,
@@ -203,7 +210,34 @@ class DeviceGroupManagementForm(forms.ModelForm):
     
     class Meta:
         model = DeviceGroup
-        exclude = ["id", "name", "owner"]
+        exclude = ["id"]
+
+    def __init__(self, *args, request=None, **kwargs):
+        super(DeviceGroupManagementForm, self).__init__(*args, **kwargs)
+        for field_name in self.fields:
+            if self.fields[field_name].help_text != "":
+                self.fields[
+                    field_name
+                ].label += tooltip_labels(self.fields[field_name].help_text)
+            self.fields[field_name].help_text = None
+        if self.instance and request:
+            qs = Organization.objects.all()
+            if not IsGlobalAdmin.has_permission(None, request, None):
+                self.fields[
+                    "owner"
+                ].queryset = IsOrganizationMember.filter_queryset_for_user(
+                    qs, request.user, "name"
+                )
+            else:
+                self.fields["owner"].queryset = qs
+
+    field_order = [
+        "name",
+        "owner",
+        "default_subject_type",
+        "destinations",
+        "devices",
+    ]
 
     helper = FormHelper()
     helper.add_input(Submit("submit", "Save", css_class="btn-primary"))

--- a/cdip_admin/integrations/forms.py
+++ b/cdip_admin/integrations/forms.py
@@ -22,7 +22,7 @@ from .models import (
     BridgeIntegration,
     Device
 )
-from .widgets import SearchableMultiSelectField, SubjectTypeAutocompleteField, DeviceSearchableMultiSelectField
+from .widgets import SearchableMultiSelectField, SubjectTypeAutocompleteField, DeviceSearchableMultiSelectField, DeviceGroupSelectWithLinkField, DeviceGroupAutoCreateField
 from django.urls import reverse
 from django.core.exceptions import ValidationError
 import json
@@ -35,6 +35,138 @@ def tooltip_labels(text):
 
 
 class InboundIntegrationConfigurationForm(forms.ModelForm):
+    # Override the default_devicegroup field to use our custom widget
+    default_devicegroup = DeviceGroupSelectWithLinkField(
+        queryset=DeviceGroup.objects.all(),
+        required=False,
+        label="Default Device Group"
+    )
+    
+    class Meta:
+        model = InboundIntegrationConfiguration
+        exclude = [
+            "id",
+        ]
+        fields = ("name", "owner", "type", "provider", "enabled",
+                  "default_devicegroup", "endpoint", "token",
+                  "login", "password", "state")
+        widgets = {
+            "password": PeekabooTextInput(),
+            "token": PeekabooTextInput(),
+            # "state": FormattedJsonFieldWidget(),
+            "apikey": PeekabooTextInput(),
+            "type": forms.Select(
+                attrs={
+                    'name': "type",
+                    'hx-trigger': 'change',
+                    'hx-target': 'body',
+                    'hx-swap': 'beforeend'
+                }),
+            "state": JSONFormWidget(
+                schema=InboundIntegrationType.objects.configuration_schema,
+            ),
+            "owner": forms.Select(
+                attrs={
+                    'name': "owner",
+                    'hx-trigger': 'load',
+                    'hx-target': '#div_id_state',
+                    'hx-swap': 'outerHTML'
+                },
+            )
+        }
+
+    def __init__(self, *args, request=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance:
+            for field_name in self.fields:
+                if self.fields[field_name].help_text != "":
+                    self.fields[
+                        field_name
+                    ].label += tooltip_labels(self.fields[field_name].help_text)
+                self.fields[field_name].help_text = None
+            if request:
+                qs = Organization.objects.all()
+                if not IsGlobalAdmin.has_permission(None, request, None):
+                    self.fields[
+                        "owner"
+                    ].queryset = IsOrganizationMember.filter_queryset_for_user(
+                        qs, request.user, "name", admin_only=True
+                    )
+                else:
+                    self.fields["owner"].queryset = qs
+                
+                # Filter device groups based on user permissions
+                device_group_qs = DeviceGroup.objects.all()
+                if not IsGlobalAdmin.has_permission(None, request, None):
+                    self.fields[
+                        "default_devicegroup"
+                    ].queryset = IsOrganizationMember.filter_queryset_for_user(
+                        device_group_qs, request.user, "owner__name"
+                    )
+                else:
+                    self.fields["default_devicegroup"].queryset = device_group_qs
+            # TODO: review how we trigger the warning modal
+            self.fields['type'].widget.attrs['hx-get'] = reverse("inboundconfigurations/type_modal",
+                                                                 kwargs={"integration_id": self.instance.id})
+            if hasattr(self.instance, 'type'):
+                # TODO: review how we trigger the schema view
+                self.fields['owner'].widget.attrs['hx-get'] = reverse("inboundconfigurations/schema",
+                                                                      kwargs={"integration_type": self.instance.type.id,
+                                                                              "integration_id": self.instance.id,
+                                                                              "update": "false"})
+                if hasattr(request, 'session'):
+                    request.session["integration_type"] = str(self.instance.type.id)
+                self.fields['state'].widget.instance = self.instance.type.id
+
+    helper = FormHelper()
+    helper.add_input(Submit("submit", "Save", css_class="btn-primary"))
+    helper.form_method = "POST"
+
+    helper.layout = Layout(
+        Row(
+            Column(Field("name", autocomplete="off"), css_class="form-group col-lg-3 mb-0"),
+            Column("owner", css_class="form-group col-lg-3 mb-0"),
+            css_class="form-row",
+        ),
+        Row(
+            Column("type", css_class="form-group col-lg-3 mb-0"),
+            Column(
+                Field("provider", autocomplete="off"), css_class="form-group col-lg-3 mb-0"
+            ),
+            css_class="form-row",
+        ),
+        "enabled",
+        Row(
+            Column("default_devicegroup", css_class="form-group col-lg-3 mb-0"),
+            css_class="form-row",
+        ),
+        Row(
+            Column(
+                Field("endpoint", autocomplete="off"),
+                css_class="form-group col-lg-3 mb-0",
+            ),
+            Column(Field("token", autocomplete="off"), css_class="form-group col-lg-3 mb-0"),
+            css_class="form-row",
+        ),
+        Row(
+            Column(Field("login", autocomplete="off"), css_class="form-group col-md-3"),
+            Column(
+                Field("password", autocomplete="off"), css_class="form-group col-md-3"
+            ),
+            css_class="form-row",
+        ),
+        Row(Column("state", css_class="form-group col-lg-6 mb-0")),
+    )
+
+
+class InboundIntegrationConfigurationAddForm(forms.ModelForm):
+    # Override the default_devicegroup field to show auto-create message
+    default_devicegroup = DeviceGroupAutoCreateField(
+        queryset=DeviceGroup.objects.none(),
+        required=False,
+        label="Default Device Group"
+    )
+    
     class Meta:
         model = InboundIntegrationConfiguration
         exclude = [

--- a/cdip_admin/integrations/forms.py
+++ b/cdip_admin/integrations/forms.py
@@ -22,7 +22,7 @@ from .models import (
     BridgeIntegration,
     Device
 )
-from .widgets import SearchableMultiSelectField
+from .widgets import SearchableMultiSelectField, SubjectTypeAutocompleteField
 from django.urls import reverse
 from django.core.exceptions import ValidationError
 import json
@@ -192,6 +192,13 @@ class DeviceGroupManagementForm(forms.ModelForm):
         queryset=OutboundIntegrationConfiguration.objects.all(),
         required=False,
         label="Destinations"
+    )
+    
+    # Override the default_subject_type field to use our custom widget
+    default_subject_type = SubjectTypeAutocompleteField(
+        required=False,
+        label="Default Subject Type",
+        empty_label="Select or create a subject type..."
     )
     
     class Meta:

--- a/cdip_admin/integrations/forms.py
+++ b/cdip_admin/integrations/forms.py
@@ -31,7 +31,7 @@ import json
 def tooltip_labels(text):
     return f""" <button type="button" class="btn btn-light btn-sm py-0 mb-0 align-top" 
     data-toggle="tooltip" data-placement="right" 
-    title="{text}">?</button>"""
+    title="{text}" tabindex="-1">?</button>"""
 
 
 class InboundIntegrationConfigurationForm(forms.ModelForm):
@@ -183,6 +183,7 @@ class InboundIntegrationConfigurationAddForm(forms.ModelForm):
             "type": forms.Select(
                 attrs={
                     'name': "type",
+                    'id': 'id_type',
                     'hx-trigger': 'change',
                     'hx-target': 'body',
                     'hx-swap': 'beforeend'
@@ -219,9 +220,8 @@ class InboundIntegrationConfigurationAddForm(forms.ModelForm):
                     )
                 else:
                     self.fields["owner"].queryset = qs
-            # TODO: review how we trigger the warning modal
-            self.fields['type'].widget.attrs['hx-get'] = reverse("inboundconfigurations/type_modal",
-                                                                 kwargs={"integration_id": self.instance.id})
+            # For Add Integration: Allow free type changes without warning modal
+            # The type field will trigger schema updates directly
             if hasattr(self.instance, 'type'):
                 # TODO: review how we trigger the schema view
                 self.fields['owner'].widget.attrs['hx-get'] = reverse("inboundconfigurations/schema",
@@ -231,6 +231,9 @@ class InboundIntegrationConfigurationAddForm(forms.ModelForm):
                 if hasattr(request, 'session'):
                     request.session["integration_type"] = str(self.instance.type.id)
                 self.fields['state'].widget.instance = self.instance.type.id
+            
+            # Configure type field to use the new add_type_modal endpoint
+            self.fields['type'].widget.attrs['hx-get'] = reverse("inboundconfigurations/add_type_modal")
 
     helper = FormHelper()
     helper.add_input(Submit("submit", "Save", css_class="btn-primary"))

--- a/cdip_admin/integrations/models/v1/models.py
+++ b/cdip_admin/integrations/models/v1/models.py
@@ -433,7 +433,7 @@ class Device(TimestampedModel):
         on_delete=models.PROTECT,
         blank=True,
         null=True,
-        help_text="Default subject type. Can be overriden by the integration or data provider",
+        help_text="Default subject type. Can be overridden by the integration or data provider",
     )
     additional = models.JSONField(
         blank=True,
@@ -525,7 +525,7 @@ class DeviceGroup(TimestampedModel):
         on_delete=models.PROTECT,
         blank=True,
         null=True,
-        help_text="Subject type to be used unless overriden by the integration or data provider.",
+        help_text="Subject type to be used unless overridden by the integration or data provider.",
     )
     history = HistoricalRecords()
 

--- a/cdip_admin/integrations/static/integrations/js/README.md
+++ b/cdip_admin/integrations/static/integrations/js/README.md
@@ -1,0 +1,37 @@
+# Searchable MultiSelect Widget
+
+This directory contains the JavaScript implementation for the searchable multiselect widget used in device group management forms.
+
+## Files
+
+- `searchable-multiselect.js` - Main JavaScript file that provides the searchable multiselect functionality
+
+## Features
+
+- **Search functionality**: Users can type to filter available destinations
+- **Visual selection**: Clear visual distinction between selected and available items
+- **Easy management**: Add/remove items with intuitive buttons
+- **Responsive design**: Works well on different screen sizes
+- **Bootstrap integration**: Uses Bootstrap classes for consistent styling
+
+## Usage
+
+The widget is automatically initialized when the form loads. It provides:
+
+1. A search input to filter available destinations
+2. A "Selected Destinations" section showing currently selected items
+3. An "Available Destinations" section showing items that can be added
+4. Add/remove buttons for each item
+
+## Dependencies
+
+- Font Awesome icons (loaded via CDN)
+- Bootstrap CSS classes
+- Modern JavaScript (ES6+ features)
+
+## Browser Support
+
+- Chrome 60+
+- Firefox 55+
+- Safari 12+
+- Edge 79+

--- a/cdip_admin/integrations/static/integrations/js/integration-type-warning.js
+++ b/cdip_admin/integrations/static/integrations/js/integration-type-warning.js
@@ -1,0 +1,31 @@
+// JavaScript for handling Integration Type change warnings
+// Tracks state field changes and modifies HTMX requests accordingly
+
+let stateFieldEdited = false;
+
+// Track when the state field is edited
+function trackStateChanges() {
+    const stateField = document.querySelector('#div_id_state input, #div_id_state textarea, #div_id_state select');
+    if (stateField) {
+        stateField.addEventListener('input', function() {
+            stateFieldEdited = true;
+        });
+        stateField.addEventListener('change', function() {
+            stateFieldEdited = true;
+        });
+    }
+}
+
+// Handle Integration Type changes
+document.addEventListener('DOMContentLoaded', function() {
+    // Set up state change tracking
+    trackStateChanges();
+    
+    // Re-setup state change tracking after HTMX updates
+    document.body.addEventListener('htmx:afterRequest', function(event) {
+        if (event.target.id === 'id_type' && event.detail.xhr.status === 200) {
+            // Re-setup state change tracking for any new state fields
+            trackStateChanges();
+        }
+    });
+});

--- a/cdip_admin/integrations/static/integrations/js/searchable-multiselect.js
+++ b/cdip_admin/integrations/static/integrations/js/searchable-multiselect.js
@@ -1,0 +1,226 @@
+/**
+ * Searchable MultiSelect Widget
+ * Provides a user-friendly interface for selecting multiple items from a searchable list
+ */
+
+function initSearchableMultiSelect(widgetId, options) {
+    const container = document.getElementById(widgetId + '_container');
+    const searchInput = document.getElementById(widgetId + '_search');
+    const selectedList = document.getElementById(widgetId + '_selected');
+    const availableList = document.getElementById(widgetId + '_available');
+    const hiddenInputsContainer = container.querySelector('.hidden-inputs');
+    
+    let allChoices = options.choices || [];
+    let selectedValues = new Set(options.selected || []);
+    let filteredChoices = [...allChoices];
+    
+    // Initialize the widget
+    function init() {
+        renderSelectedItems();
+        renderAvailableItems();
+        setupEventListeners();
+    }
+    
+    // Render selected items
+    function renderSelectedItems() {
+        selectedList.innerHTML = '';
+        
+        if (selectedValues.size === 0) {
+            selectedList.innerHTML = '<div class="text-muted">No destinations selected</div>';
+            return;
+        }
+        
+        selectedValues.forEach(value => {
+            const choice = allChoices.find(c => c[0] == value);
+            if (choice) {
+                const item = createSelectedItem(choice[0], choice[1]);
+                selectedList.appendChild(item);
+            }
+        });
+        
+        updateHiddenInputs();
+    }
+    
+    // Render available items
+    function renderAvailableItems() {
+        availableList.innerHTML = '';
+        
+        const availableChoices = filteredChoices.filter(choice => !selectedValues.has(choice[0]));
+        
+        if (availableChoices.length === 0) {
+            availableList.innerHTML = '<div class="text-muted">No destinations available</div>';
+            return;
+        }
+        
+        availableChoices.forEach(choice => {
+            const item = createAvailableItem(choice[0], choice[1]);
+            availableList.appendChild(item);
+        });
+    }
+    
+    // Create a selected item element
+    function createSelectedItem(value, label) {
+        const item = document.createElement('div');
+        item.className = 'selected-item d-flex justify-content-between align-items-center p-2 mb-1 bg-primary text-white rounded';
+        item.innerHTML = `
+            <span>${label}</span>
+            <button type="button" class="btn btn-sm btn-outline-light remove-item" data-value="${value}">
+                <i class="fas fa-times"></i>
+            </button>
+        `;
+        
+        // Add remove functionality
+        item.querySelector('.remove-item').addEventListener('click', () => {
+            selectedValues.delete(value);
+            renderSelectedItems();
+            renderAvailableItems();
+        });
+        
+        return item;
+    }
+    
+    // Create an available item element
+    function createAvailableItem(value, label) {
+        const item = document.createElement('div');
+        item.className = 'available-item p-2 mb-1 border rounded cursor-pointer';
+        item.style.cursor = 'pointer';
+        item.innerHTML = `
+            <div class="d-flex justify-content-between align-items-center">
+                <span>${label}</span>
+                <button type="button" class="btn btn-sm btn-outline-primary add-item" data-value="${value}">
+                    <i class="fas fa-plus"></i>
+                </button>
+            </div>
+        `;
+        
+        // Add click functionality to the entire item
+        item.addEventListener('click', (e) => {
+            if (!e.target.closest('.add-item')) {
+                addItem(value);
+            }
+        });
+        
+        // Add button click functionality
+        item.querySelector('.add-item').addEventListener('click', () => {
+            addItem(value);
+        });
+        
+        return item;
+    }
+    
+    // Add an item to selected
+    function addItem(value) {
+        selectedValues.add(value);
+        renderSelectedItems();
+        renderAvailableItems();
+    }
+    
+    // Update hidden inputs for form submission
+    function updateHiddenInputs() {
+        hiddenInputsContainer.innerHTML = '';
+        
+        // Convert Set to Array and use sequential indices
+        const selectedArray = Array.from(selectedValues);
+        selectedArray.forEach((value, index) => {
+            const input = document.createElement('input');
+            input.type = 'hidden';
+            input.name = `${options.name}_${index}`;
+            input.value = value;
+            hiddenInputsContainer.appendChild(input);
+        });
+        
+        // Debug: log the hidden inputs being created
+        console.log('Hidden inputs created:');
+        selectedArray.forEach((value, index) => {
+            console.log(`  ${options.name}_${index} = ${value}`);
+        });
+    }
+    
+    // Setup event listeners
+    function setupEventListeners() {
+        // Search functionality
+        searchInput.addEventListener('input', (e) => {
+            const searchTerm = e.target.value.toLowerCase();
+            filteredChoices = allChoices.filter(choice => 
+                choice[1].toLowerCase().includes(searchTerm)
+            );
+            renderAvailableItems();
+        });
+        
+        // Clear search when clicking outside
+        document.addEventListener('click', (e) => {
+            if (!container.contains(e.target)) {
+                searchInput.value = '';
+                filteredChoices = [...allChoices];
+                renderAvailableItems();
+            }
+        });
+    }
+    
+    // Initialize the widget
+    init();
+}
+
+// CSS styles (injected dynamically)
+const styles = `
+    .searchable-multiselect-container {
+        border: 1px solid #dee2e6;
+        border-radius: 0.375rem;
+        padding: 1rem;
+        background-color: #fff;
+    }
+    
+    .search-input-container .search-input {
+        border-radius: 0.375rem;
+        border: 1px solid #ced4da;
+        padding: 0.5rem 0.75rem;
+    }
+    
+    .search-input-container .search-input:focus {
+        border-color: #86b7fe;
+        outline: 0;
+        box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
+    }
+    
+    .selected-item, .available-item {
+        transition: all 0.2s ease-in-out;
+    }
+    
+    .available-item:hover {
+        background-color: #f8f9fa;
+        border-color: #86b7fe !important;
+    }
+    
+    .selected-list, .available-list {
+        max-height: 200px;
+        overflow-y: auto;
+        border: 1px solid #dee2e6;
+        border-radius: 0.375rem;
+        padding: 0.5rem;
+        background-color: #f8f9fa;
+    }
+    
+    .form-label {
+        font-weight: 600;
+        margin-bottom: 0.5rem;
+        color: #495057;
+    }
+    
+    .cursor-pointer {
+        cursor: pointer;
+    }
+    
+    .btn-sm {
+        padding: 0.25rem 0.5rem;
+        font-size: 0.875rem;
+        border-radius: 0.25rem;
+    }
+`;
+
+// Inject styles
+if (!document.getElementById('searchable-multiselect-styles')) {
+    const styleSheet = document.createElement('style');
+    styleSheet.id = 'searchable-multiselect-styles';
+    styleSheet.textContent = styles;
+    document.head.appendChild(styleSheet);
+}

--- a/cdip_admin/integrations/static/integrations/js/searchable-multiselect.js
+++ b/cdip_admin/integrations/static/integrations/js/searchable-multiselect.js
@@ -1,6 +1,7 @@
 /**
  * Searchable MultiSelect Widget
  * Provides a user-friendly interface for selecting multiple items from a searchable list
+ * Updated: Fixed empty selection bug - v1.1
  */
 
 function initSearchableMultiSelect(widgetId, options) {
@@ -27,17 +28,17 @@ function initSearchableMultiSelect(widgetId, options) {
         
         if (selectedValues.size === 0) {
             selectedList.innerHTML = '<div class="text-muted">No destinations selected</div>';
-            return;
+        } else {
+            selectedValues.forEach(value => {
+                const choice = allChoices.find(c => c[0] == value);
+                if (choice) {
+                    const item = createSelectedItem(choice[0], choice[1], choice[2], choice[3], choice[4]);
+                    selectedList.appendChild(item);
+                }
+            });
         }
         
-        selectedValues.forEach(value => {
-            const choice = allChoices.find(c => c[0] == value);
-            if (choice) {
-                const item = createSelectedItem(choice[0], choice[1]);
-                selectedList.appendChild(item);
-            }
-        });
-        
+        // Always update hidden inputs, even when no items are selected
         updateHiddenInputs();
     }
     
@@ -53,20 +54,40 @@ function initSearchableMultiSelect(widgetId, options) {
         }
         
         availableChoices.forEach(choice => {
-            const item = createAvailableItem(choice[0], choice[1]);
+            const item = createAvailableItem(choice[0], choice[1], choice[2], choice[3], choice[4]);
             availableList.appendChild(item);
         });
     }
     
-    // Create a selected item element
-    function createSelectedItem(value, label) {
+    // Create a selected item element as a card
+    function createSelectedItem(value, label, owner, type, endpoint) {
         const item = document.createElement('div');
-        item.className = 'selected-item d-flex justify-content-between align-items-center p-2 mb-1 bg-primary text-white rounded';
+        item.className = 'destination-card selected-card mb-2';
         item.innerHTML = `
-            <span>${label}</span>
-            <button type="button" class="btn btn-sm btn-outline-light remove-item" data-value="${value}">
-                <i class="fas fa-times"></i>
-            </button>
+            <div class="card border-success">
+                <div class="card-header bg-success text-white d-flex justify-content-between align-items-center">
+                    <strong>${label}</strong>
+                    <button type="button" class="btn btn-sm btn-outline-light remove-item" data-value="${value}">
+                        <i class="fas fa-times"></i>
+                    </button>
+                </div>
+                <div class="card-body">
+                    <div class="destination-info">
+                        <div class="info-row mb-1">
+                            <span class="info-label fw-bold">Owner:</span>
+                            <span class="info-value">${owner}</span>
+                        </div>
+                        <div class="info-row mb-1">
+                            <span class="info-label fw-bold">Type:</span>
+                            <span class="info-value">${type}</span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label fw-bold">Endpoint:</span>
+                            <span class="info-value text-break">${endpoint}</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
         `;
         
         // Add remove functionality
@@ -79,17 +100,35 @@ function initSearchableMultiSelect(widgetId, options) {
         return item;
     }
     
-    // Create an available item element
-    function createAvailableItem(value, label) {
+    // Create an available item element as a card
+    function createAvailableItem(value, label, owner, type, endpoint) {
         const item = document.createElement('div');
-        item.className = 'available-item p-2 mb-1 border rounded cursor-pointer';
+        item.className = 'destination-card available-card mb-2 cursor-pointer';
         item.style.cursor = 'pointer';
         item.innerHTML = `
-            <div class="d-flex justify-content-between align-items-center">
-                <span>${label}</span>
-                <button type="button" class="btn btn-sm btn-outline-primary add-item" data-value="${value}">
-                    <i class="fas fa-plus"></i>
-                </button>
+            <div class="card border-primary">
+                <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center">
+                    <strong>${label}</strong>
+                    <button type="button" class="btn btn-sm btn-outline-light add-item" data-value="${value}">
+                        <i class="fas fa-plus"></i>
+                    </button>
+                </div>
+                <div class="card-body">
+                    <div class="destination-info">
+                        <div class="info-row mb-1">
+                            <span class="info-label fw-bold">Owner:</span>
+                            <span class="info-value">${owner}</span>
+                        </div>
+                        <div class="info-row mb-1">
+                            <span class="info-label fw-bold">Type:</span>
+                            <span class="info-value">${type}</span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label fw-bold">Endpoint:</span>
+                            <span class="info-value text-break">${endpoint}</span>
+                        </div>
+                    </div>
+                </div>
             </div>
         `;
         
@@ -121,18 +160,32 @@ function initSearchableMultiSelect(widgetId, options) {
         
         // Convert Set to Array and use sequential indices
         const selectedArray = Array.from(selectedValues);
-        selectedArray.forEach((value, index) => {
+        
+        if (selectedArray.length === 0) {
+            // When no destinations are selected, create a single hidden input with empty value
+            // This ensures Django knows the field should be cleared
             const input = document.createElement('input');
             input.type = 'hidden';
-            input.name = `${options.name}_${index}`;
-            input.value = value;
+            input.name = `${options.name}_0`;
+            input.value = '';
             hiddenInputsContainer.appendChild(input);
-        });
+            console.log('Empty selection: created single hidden input with empty value');
+        } else {
+            // Create inputs for each selected destination
+            selectedArray.forEach((value, index) => {
+                const input = document.createElement('input');
+                input.type = 'hidden';
+                input.name = `${options.name}_${index}`;
+                input.value = value;
+                hiddenInputsContainer.appendChild(input);
+            });
+        }
         
         // Debug: log the hidden inputs being created
         console.log('Hidden inputs created:');
-        selectedArray.forEach((value, index) => {
-            console.log(`  ${options.name}_${index} = ${value}`);
+        const allInputs = hiddenInputsContainer.querySelectorAll('input');
+        allInputs.forEach((input, index) => {
+            console.log(`  ${input.name} = ${input.value}`);
         });
     }
     
@@ -182,17 +235,17 @@ const styles = `
         box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
     }
     
-    .selected-item, .available-item {
+    .destination-card {
         transition: all 0.2s ease-in-out;
     }
     
-    .available-item:hover {
-        background-color: #f8f9fa;
-        border-color: #86b7fe !important;
+    .available-card:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 8px rgba(0,0,0,0.1);
     }
     
     .selected-list, .available-list {
-        max-height: 200px;
+        max-height: 400px;
         overflow-y: auto;
         border: 1px solid #dee2e6;
         border-radius: 0.375rem;
@@ -200,10 +253,20 @@ const styles = `
         background-color: #f8f9fa;
     }
     
-    .form-label {
-        font-weight: 600;
-        margin-bottom: 0.5rem;
+    .info-label {
+        color: #6c757d;
+        font-size: 0.875rem;
+        margin-right: 0.5rem;
+    }
+    
+    .info-value {
         color: #495057;
+        font-size: 0.875rem;
+    }
+    
+    .info-row {
+        display: flex;
+        align-items: flex-start;
     }
     
     .cursor-pointer {
@@ -214,6 +277,18 @@ const styles = `
         padding: 0.25rem 0.5rem;
         font-size: 0.875rem;
         border-radius: 0.25rem;
+    }
+    
+    .text-break {
+        word-break: break-all;
+    }
+    
+    .card {
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    }
+    
+    .card:hover {
+        box-shadow: 0 4px 8px rgba(0,0,0,0.15);
     }
 `;
 

--- a/cdip_admin/integrations/static/integrations/js/searchable-multiselect.js
+++ b/cdip_admin/integrations/static/integrations/js/searchable-multiselect.js
@@ -27,7 +27,10 @@ function initSearchableMultiSelect(widgetId, options) {
         selectedList.innerHTML = '';
         
         if (selectedValues.size === 0) {
-            selectedList.innerHTML = '<div class="text-muted">No destinations selected</div>';
+            // Determine if this is for devices or destinations based on the first choice
+            const isDeviceWidget = allChoices.length > 0 && allChoices[0].length >= 6;
+            const emptyText = isDeviceWidget ? 'No devices selected' : 'No destinations selected';
+            selectedList.innerHTML = `<div class="text-muted">${emptyText}</div>`;
         } else {
             selectedValues.forEach(value => {
                 const choice = allChoices.find(c => c[0] == value);
@@ -60,7 +63,10 @@ function initSearchableMultiSelect(widgetId, options) {
         const availableChoices = filteredChoices.filter(choice => !selectedValues.has(choice[0]));
         
         if (availableChoices.length === 0) {
-            availableList.innerHTML = '<div class="text-muted">No destinations available</div>';
+            // Determine if this is for devices or destinations based on the first choice
+            const isDeviceWidget = allChoices.length > 0 && allChoices[0].length >= 6;
+            const emptyText = isDeviceWidget ? 'No devices available' : 'No destinations available';
+            availableList.innerHTML = `<div class="text-muted">${emptyText}</div>`;
             return;
         }
         
@@ -246,7 +252,7 @@ function initSearchableMultiSelect(widgetId, options) {
         const selectedArray = Array.from(selectedValues);
         
         if (selectedArray.length === 0) {
-            // When no destinations are selected, create a single hidden input with empty value
+            // When no items are selected, create a single hidden input with empty value
             // This ensures Django knows the field should be cleared
             const input = document.createElement('input');
             input.type = 'hidden';
@@ -255,7 +261,7 @@ function initSearchableMultiSelect(widgetId, options) {
             hiddenInputsContainer.appendChild(input);
             console.log('Empty selection: created single hidden input with empty value');
         } else {
-            // Create inputs for each selected destination
+            // Create inputs for each selected item
             selectedArray.forEach((value, index) => {
                 const input = document.createElement('input');
                 input.type = 'hidden';

--- a/cdip_admin/integrations/static/integrations/js/searchable-multiselect.js
+++ b/cdip_admin/integrations/static/integrations/js/searchable-multiselect.js
@@ -214,88 +214,89 @@ function initSearchableMultiSelect(widgetId, options) {
     init();
 }
 
-// CSS styles (injected dynamically)
-const styles = `
-    .searchable-multiselect-container {
-        border: 1px solid #dee2e6;
-        border-radius: 0.375rem;
-        padding: 1rem;
-        background-color: #fff;
+// CSS styles (injected dynamically) - only inject once
+(function() {
+    if (!document.getElementById('searchable-multiselect-styles')) {
+        const styles = `
+            .searchable-multiselect-container {
+                border: 1px solid #dee2e6;
+                border-radius: 0.375rem;
+                padding: 1rem;
+                background-color: #fff;
+            }
+            
+            .search-input-container .search-input {
+                border-radius: 0.375rem;
+                border: 1px solid #ced4da;
+                padding: 0.5rem 0.75rem;
+            }
+            
+            .search-input-container .search-input:focus {
+                border-color: #86b7fe;
+                outline: 0;
+                box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
+            }
+            
+            .destination-card {
+                transition: all 0.2s ease-in-out;
+            }
+            
+            .available-card:hover {
+                transform: translateY(-2px);
+                box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+            }
+            
+            .selected-list, .available-list {
+                max-height: 400px;
+                overflow-y: auto;
+                border: 1px solid #dee2e6;
+                border-radius: 0.375rem;
+                padding: 0.5rem;
+                background-color: #f8f9fa;
+            }
+            
+            .info-label {
+                color: #6c757d;
+                font-size: 0.875rem;
+                margin-right: 0.5rem;
+            }
+            
+            .info-value {
+                color: #495057;
+                font-size: 0.875rem;
+            }
+            
+            .info-row {
+                display: flex;
+                align-items: flex-start;
+            }
+            
+            .cursor-pointer {
+                cursor: pointer;
+            }
+            
+            .btn-sm {
+                padding: 0.25rem 0.5rem;
+                font-size: 0.875rem;
+                border-radius: 0.25rem;
+            }
+            
+            .text-break {
+                word-break: break-all;
+            }
+            
+            .card {
+                box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            }
+            
+            .card:hover {
+                box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+            }
+        `;
+        
+        const styleSheet = document.createElement('style');
+        styleSheet.id = 'searchable-multiselect-styles';
+        styleSheet.textContent = styles;
+        document.head.appendChild(styleSheet);
     }
-    
-    .search-input-container .search-input {
-        border-radius: 0.375rem;
-        border: 1px solid #ced4da;
-        padding: 0.5rem 0.75rem;
-    }
-    
-    .search-input-container .search-input:focus {
-        border-color: #86b7fe;
-        outline: 0;
-        box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
-    }
-    
-    .destination-card {
-        transition: all 0.2s ease-in-out;
-    }
-    
-    .available-card:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 4px 8px rgba(0,0,0,0.1);
-    }
-    
-    .selected-list, .available-list {
-        max-height: 400px;
-        overflow-y: auto;
-        border: 1px solid #dee2e6;
-        border-radius: 0.375rem;
-        padding: 0.5rem;
-        background-color: #f8f9fa;
-    }
-    
-    .info-label {
-        color: #6c757d;
-        font-size: 0.875rem;
-        margin-right: 0.5rem;
-    }
-    
-    .info-value {
-        color: #495057;
-        font-size: 0.875rem;
-    }
-    
-    .info-row {
-        display: flex;
-        align-items: flex-start;
-    }
-    
-    .cursor-pointer {
-        cursor: pointer;
-    }
-    
-    .btn-sm {
-        padding: 0.25rem 0.5rem;
-        font-size: 0.875rem;
-        border-radius: 0.25rem;
-    }
-    
-    .text-break {
-        word-break: break-all;
-    }
-    
-    .card {
-        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-    }
-    
-    .card:hover {
-        box-shadow: 0 4px 8px rgba(0,0,0,0.15);
-    }
-`;
-
-// Inject styles
-if (!document.getElementById('searchable-multiselect-styles')) {
-    const styleSheet = document.createElement('style');
-    styleSheet.id = 'searchable-multiselect-styles';
-    styleSheet.textContent = styles;
-    document.head.appendChild(styleSheet);
-}
+})();

--- a/cdip_admin/integrations/static/integrations/js/searchable-multiselect.js
+++ b/cdip_admin/integrations/static/integrations/js/searchable-multiselect.js
@@ -32,8 +32,19 @@ function initSearchableMultiSelect(widgetId, options) {
             selectedValues.forEach(value => {
                 const choice = allChoices.find(c => c[0] == value);
                 if (choice) {
-                    const item = createSelectedItem(choice[0], choice[1], choice[2], choice[3], choice[4]);
-                    selectedList.appendChild(item);
+                    // For devices: choice[0]=id, choice[1]=name, choice[2]=external_id, choice[3]=owner, choice[4]=type, choice[5]=config
+                    // For destinations: choice[0]=id, choice[1]=name, choice[2]=owner, choice[3]=type, choice[4]=endpoint
+                    if (choice.length >= 6) {
+                        // Device: (value, label, owner, type, endpoint, externalId)
+                        // choice[0]=id, choice[1]=name, choice[2]=external_id, choice[3]=owner, choice[4]=type, choice[5]=config
+                        const item = createSelectedItem(choice[0], choice[1], choice[3], choice[4], choice[5], choice[2]);
+                        selectedList.appendChild(item);
+                    } else {
+                        // Destination: (value, label, owner, type, endpoint, undefined)
+                        // choice[0]=id, choice[1]=name, choice[2]=owner, choice[3]=type, choice[4]=endpoint
+                        const item = createSelectedItem(choice[0], choice[1], choice[2], choice[3], choice[4], undefined);
+                        selectedList.appendChild(item);
+                    }
                 }
             });
         }
@@ -54,15 +65,69 @@ function initSearchableMultiSelect(widgetId, options) {
         }
         
         availableChoices.forEach(choice => {
-            const item = createAvailableItem(choice[0], choice[1], choice[2], choice[3], choice[4]);
-            availableList.appendChild(item);
+            // For devices: choice[0]=id, choice[1]=name, choice[2]=external_id, choice[3]=owner, choice[4]=type, choice[5]=config
+            // For destinations: choice[0]=id, choice[1]=name, choice[2]=owner, choice[3]=type, choice[4]=endpoint
+            if (choice.length >= 6) {
+                // Device: (value, label, owner, type, endpoint, externalId)
+                const item = createAvailableItem(choice[0], choice[1], choice[3], choice[4], choice[5], choice[2]);
+                availableList.appendChild(item);
+            } else {
+                // Destination: (value, label, owner, type, endpoint, undefined)
+                const item = createAvailableItem(choice[0], choice[1], choice[2], choice[3], choice[4], undefined);
+                availableList.appendChild(item);
+            }
         });
     }
     
     // Create a selected item element as a card
-    function createSelectedItem(value, label, owner, type, endpoint) {
+    function createSelectedItem(value, label, owner, type, endpoint, externalId) {
         const item = document.createElement('div');
         item.className = 'destination-card selected-card mb-2';
+        
+        // Determine if this is a device (6 elements) or destination (5 elements)
+        const isDevice = externalId !== undefined;
+        
+        let infoHtml = '';
+        if (isDevice) {
+            infoHtml = `
+                <div class="destination-info">
+                    <div class="info-row mb-1">
+                        <span class="info-label fw-bold">External ID:</span>
+                        <span class="info-value">${externalId}</span>
+                    </div>
+                    <div class="info-row mb-1">
+                        <span class="info-label fw-bold">Owner:</span>
+                        <span class="info-value">${owner}</span>
+                    </div>
+                    <div class="info-row mb-1">
+                        <span class="info-label fw-bold">Type:</span>
+                        <span class="info-value">${type}</span>
+                    </div>
+                    <div class="info-row">
+                        <span class="info-label fw-bold">Configuration:</span>
+                        <span class="info-value text-break">${endpoint}</span>
+                    </div>
+                </div>
+            `;
+        } else {
+            infoHtml = `
+                <div class="destination-info">
+                    <div class="info-row mb-1">
+                        <span class="info-label fw-bold">Owner:</span>
+                        <span class="info-value">${owner}</span>
+                    </div>
+                    <div class="info-row mb-1">
+                        <span class="info-label fw-bold">Type:</span>
+                        <span class="info-value">${type}</span>
+                    </div>
+                    <div class="info-row">
+                        <span class="info-label fw-bold">Endpoint:</span>
+                        <span class="info-value text-break">${endpoint}</span>
+                    </div>
+                </div>
+            `;
+        }
+        
         item.innerHTML = `
             <div class="card border-success">
                 <div class="card-header bg-success text-white d-flex justify-content-between align-items-center">
@@ -72,20 +137,7 @@ function initSearchableMultiSelect(widgetId, options) {
                     </button>
                 </div>
                 <div class="card-body">
-                    <div class="destination-info">
-                        <div class="info-row mb-1">
-                            <span class="info-label fw-bold">Owner:</span>
-                            <span class="info-value">${owner}</span>
-                        </div>
-                        <div class="info-row mb-1">
-                            <span class="info-label fw-bold">Type:</span>
-                            <span class="info-value">${type}</span>
-                        </div>
-                        <div class="info-row">
-                            <span class="info-label fw-bold">Endpoint:</span>
-                            <span class="info-value text-break">${endpoint}</span>
-                        </div>
-                    </div>
+                    ${infoHtml}
                 </div>
             </div>
         `;
@@ -101,10 +153,55 @@ function initSearchableMultiSelect(widgetId, options) {
     }
     
     // Create an available item element as a card
-    function createAvailableItem(value, label, owner, type, endpoint) {
+    function createAvailableItem(value, label, owner, type, endpoint, externalId) {
         const item = document.createElement('div');
         item.className = 'destination-card available-card mb-2 cursor-pointer';
         item.style.cursor = 'pointer';
+        
+        // Determine if this is a device (6 elements) or destination (5 elements)
+        const isDevice = externalId !== undefined;
+        
+        let infoHtml = '';
+        if (isDevice) {
+            infoHtml = `
+                <div class="destination-info">
+                    <div class="info-row mb-1">
+                        <span class="info-label fw-bold">External ID:</span>
+                        <span class="info-value">${externalId}</span>
+                    </div>
+                    <div class="info-row mb-1">
+                        <span class="info-label fw-bold">Owner:</span>
+                        <span class="info-value">${owner}</span>
+                    </div>
+                    <div class="info-row mb-1">
+                        <span class="info-label fw-bold">Type:</span>
+                        <span class="info-value">${type}</span>
+                    </div>
+                    <div class="info-row">
+                        <span class="info-label fw-bold">Configuration:</span>
+                        <span class="info-value text-break">${endpoint}</span>
+                    </div>
+                </div>
+            `;
+        } else {
+            infoHtml = `
+                <div class="destination-info">
+                    <div class="info-row mb-1">
+                        <span class="info-label fw-bold">Owner:</span>
+                        <span class="info-value">${owner}</span>
+                    </div>
+                    <div class="info-row mb-1">
+                        <span class="info-label fw-bold">Type:</span>
+                        <span class="info-value">${type}</span>
+                    </div>
+                    <div class="info-row">
+                        <span class="info-label fw-bold">Endpoint:</span>
+                        <span class="info-value text-break">${endpoint}</span>
+                    </div>
+                </div>
+            `;
+        }
+        
         item.innerHTML = `
             <div class="card border-primary">
                 <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center">
@@ -114,20 +211,7 @@ function initSearchableMultiSelect(widgetId, options) {
                     </button>
                 </div>
                 <div class="card-body">
-                    <div class="destination-info">
-                        <div class="info-row mb-1">
-                            <span class="info-label fw-bold">Owner:</span>
-                            <span class="info-value">${owner}</span>
-                        </div>
-                        <div class="info-row mb-1">
-                            <span class="info-label fw-bold">Type:</span>
-                            <span class="info-value">${type}</span>
-                        </div>
-                        <div class="info-row">
-                            <span class="info-label fw-bold">Endpoint:</span>
-                            <span class="info-value text-break">${endpoint}</span>
-                        </div>
-                    </div>
+                    ${infoHtml}
                 </div>
             </div>
         `;
@@ -195,11 +279,26 @@ function initSearchableMultiSelect(widgetId, options) {
         searchInput.addEventListener('input', (e) => {
             const searchTerm = e.target.value.toLowerCase();
             filteredChoices = allChoices.filter(choice => {
-                // Search in: name (choice[1]), owner (choice[2]), type (choice[3]), endpoint (choice[4])
-                return choice[1].toLowerCase().includes(searchTerm) ||  // name
-                       choice[2].toLowerCase().includes(searchTerm) ||  // owner
-                       choice[3].toLowerCase().includes(searchTerm) ||  // type
-                       choice[4].toLowerCase().includes(searchTerm);    // endpoint
+                // For devices: choice[0]=id, choice[1]=name, choice[2]=external_id, choice[3]=owner, choice[4]=type, choice[5]=config
+                // For destinations: choice[0]=id, choice[1]=name, choice[2]=owner, choice[3]=type, choice[4]=endpoint
+                let matches = choice[1].toLowerCase().includes(searchTerm);  // name (always choice[1])
+                
+                if (choice.length >= 6) {
+                    // Device: search in external_id, owner, type, config
+                    matches = matches || 
+                             choice[2].toLowerCase().includes(searchTerm) ||  // external_id
+                             choice[3].toLowerCase().includes(searchTerm) ||  // owner
+                             choice[4].toLowerCase().includes(searchTerm) ||  // type
+                             choice[5].toLowerCase().includes(searchTerm);    // config
+                } else {
+                    // Destination: search in owner, type, endpoint
+                    matches = matches || 
+                             choice[2].toLowerCase().includes(searchTerm) ||  // owner
+                             choice[3].toLowerCase().includes(searchTerm) ||  // type
+                             choice[4].toLowerCase().includes(searchTerm);    // endpoint
+                }
+                
+                return matches;
             });
             renderAvailableItems();
         });

--- a/cdip_admin/integrations/static/integrations/js/searchable-multiselect.js
+++ b/cdip_admin/integrations/static/integrations/js/searchable-multiselect.js
@@ -194,9 +194,13 @@ function initSearchableMultiSelect(widgetId, options) {
         // Search functionality
         searchInput.addEventListener('input', (e) => {
             const searchTerm = e.target.value.toLowerCase();
-            filteredChoices = allChoices.filter(choice => 
-                choice[1].toLowerCase().includes(searchTerm)
-            );
+            filteredChoices = allChoices.filter(choice => {
+                // Search in: name (choice[1]), owner (choice[2]), type (choice[3]), endpoint (choice[4])
+                return choice[1].toLowerCase().includes(searchTerm) ||  // name
+                       choice[2].toLowerCase().includes(searchTerm) ||  // owner
+                       choice[3].toLowerCase().includes(searchTerm) ||  // type
+                       choice[4].toLowerCase().includes(searchTerm);    // endpoint
+            });
             renderAvailableItems();
         });
         

--- a/cdip_admin/integrations/static/integrations/js/subject-type-autocomplete.js
+++ b/cdip_admin/integrations/static/integrations/js/subject-type-autocomplete.js
@@ -1,0 +1,476 @@
+/**
+ * Subject Type Autocomplete Widget
+ * Provides auto-complete functionality for subject type selection with ability to create new ones
+ * Version: 1.0
+ */
+
+function initSubjectTypeAutocomplete(widgetId, options) {
+    const container = document.getElementById(widgetId + '_container');
+    const input = document.getElementById(widgetId + '_input');
+    const hiddenInput = document.getElementById(widgetId + '_hidden');
+    const dropdown = document.getElementById(widgetId + '_dropdown');
+    const dropdownMenu = document.getElementById(widgetId + '_dropdown_menu');
+    const selectedSection = document.getElementById(widgetId + '_selected');
+    const createNewSection = document.getElementById(widgetId + '_create_new');
+    
+    let allChoices = options.choices || [];
+    let currentValue = options.currentValue || '';
+    let selectedChoice = null;
+    
+    // Initialize the widget
+    function init() {
+        console.log('Subject Type Widget: Initializing...');
+        console.log('Subject Type Widget: allChoices =', allChoices);
+        console.log('Subject Type Widget: currentValue =', currentValue);
+        
+        setupEventListeners();
+        if (currentValue) {
+            // Find and set the current selection
+            const choice = allChoices.find(c => c[0] === currentValue);
+            if (choice) {
+                selectChoice(choice);
+            }
+        }
+        
+        console.log('Subject Type Widget: Initialization complete');
+    }
+    
+    // Setup event listeners
+    function setupEventListeners() {
+        // Input typing for autocomplete
+        input.addEventListener('input', handleInput);
+        input.addEventListener('focus', () => {
+            showDropdown();
+            if (dropdownMenu.innerHTML === '') {
+                showAllChoices();
+            }
+        });
+        input.addEventListener('blur', hideDropdown);
+        
+        // Dropdown toggle
+        dropdown.addEventListener('click', toggleDropdown);
+        
+        // Click outside to close dropdown
+        document.addEventListener('click', (e) => {
+            if (!container.contains(e.target)) {
+                hideDropdown();
+            }
+        });
+        
+        // Clear selection
+        container.addEventListener('click', (e) => {
+            if (e.target.closest('.clear-selection')) {
+                clearSelection();
+            }
+        });
+        
+        // Show create new section
+        container.addEventListener('click', (e) => {
+            if (e.target.closest('.show-create-new')) {
+                // Get the search term from the input field
+                const currentSearchTerm = input.value.toLowerCase();
+                showCreateNewSection(currentSearchTerm);
+            }
+        });
+        
+        // Cancel create new
+        container.addEventListener('click', (e) => {
+            if (e.target.closest('.cancel-create')) {
+                hideCreateNewSection();
+            }
+        });
+        
+        // Create new subject type
+        container.addEventListener('click', (e) => {
+            if (e.target.closest('.create-subject-type')) {
+                createNewSubjectType();
+            }
+        });
+        
+        // Auto-generate slug from display name
+        const displayNameInput = container.querySelector('.new-display-name');
+        const valueInput = container.querySelector('.new-value');
+        
+        if (displayNameInput && valueInput) {
+            displayNameInput.addEventListener('input', (e) => {
+                const slug = e.target.value.toLowerCase()
+                    .replace(/[^a-z0-9\s-]/g, '')
+                    .replace(/\s+/g, '_')
+                    .replace(/_+/g, '_')
+                    .replace(/^_|_$/g, '');
+                valueInput.value = slug;
+                // Trigger validation after auto-filling
+                validateValueField();
+            });
+            
+            // Add validation for the value field
+            valueInput.addEventListener('input', validateValueField);
+            valueInput.addEventListener('blur', validateValueField);
+        }
+    }
+    
+    // Handle input typing
+    function handleInput(e) {
+        const searchTerm = e.target.value.toLowerCase();
+        
+        if (searchTerm.length === 0) {
+            showAllChoices();
+            hideCreateNewSection();
+        } else {
+            const filteredChoices = allChoices.filter(choice => 
+                choice[1].toLowerCase().includes(searchTerm) || 
+                choice[2].toLowerCase().includes(searchTerm)
+            );
+            
+            // Always render filtered choices (or empty state)
+            renderChoices(filteredChoices);
+            
+            // Always show create new option when there's a search term
+            showCreateNewOption(searchTerm);
+        }
+        
+        showDropdown();
+    }
+    
+    // Show all choices
+    function showAllChoices() {
+        console.log('Subject Type Widget: showAllChoices called, choices =', allChoices);
+        renderChoices(allChoices);
+    }
+    
+    // Render choices in dropdown
+    function renderChoices(choices) {
+        console.log('Subject Type Widget: renderChoices called with', choices);
+        dropdownMenu.innerHTML = '';
+        
+        if (choices.length === 0) {
+            dropdownMenu.innerHTML = '<div class="dropdown-item-text text-muted">No subject types found</div>';
+            console.log('Subject Type Widget: No choices to render');
+            return;
+        }
+        
+        choices.forEach(choice => {
+            const item = document.createElement('div');
+            item.className = 'dropdown-item choice-item';
+            item.innerHTML = `
+                <div>
+                    <strong>${choice[1]}</strong>
+                    <small class="text-muted d-block">${choice[2]}</small>
+                </div>
+            `;
+            
+            item.addEventListener('click', () => {
+                selectChoice(choice);
+                hideDropdown();
+            });
+            
+            dropdownMenu.appendChild(item);
+        });
+    }
+    
+    // Show create new option
+    function showCreateNewOption(searchTerm) {
+        // Check if a create new item already exists and remove it
+        const existingCreateNew = dropdownMenu.querySelector('.show-create-new');
+        if (existingCreateNew) {
+            existingCreateNew.remove();
+        }
+        
+        const createNewItem = document.createElement('div');
+        createNewItem.className = 'dropdown-item show-create-new';
+        createNewItem.innerHTML = `
+            <div class="text-primary">
+                <i class="fas fa-plus"></i> Create new: "${searchTerm}"
+            </div>
+        `;
+        
+        createNewItem.addEventListener('click', (e) => {
+            e.stopPropagation();
+            showCreateNewSection(searchTerm);
+            hideDropdown();
+        });
+        
+        dropdownMenu.appendChild(createNewItem);
+    }
+    
+    // Select a choice
+    function selectChoice(choice) {
+        selectedChoice = choice;
+        hiddenInput.value = choice[0];
+        input.value = '';
+        
+        // Show selected section
+        selectedSection.querySelector('.selected-name').textContent = choice[1];
+        selectedSection.querySelector('.selected-value').textContent = choice[2];
+        selectedSection.style.display = 'block';
+        
+        console.log('Selected subject type:', choice);
+    }
+    
+    // Clear selection
+    function clearSelection() {
+        selectedChoice = null;
+        hiddenInput.value = '';
+        input.value = '';
+        selectedSection.style.display = 'none';
+        console.log('Cleared subject type selection');
+    }
+    
+    // Show dropdown
+    function showDropdown() {
+        console.log('Subject Type Widget: showDropdown called');
+        dropdownMenu.style.display = 'block';
+        dropdown.setAttribute('aria-expanded', 'true');
+    }
+    
+    // Hide dropdown
+    function hideDropdown() {
+        // Delay hiding to allow clicks on dropdown items
+        setTimeout(() => {
+            dropdownMenu.style.display = 'none';
+            dropdown.setAttribute('aria-expanded', 'false');
+        }, 150);
+    }
+    
+    // Toggle dropdown
+    function toggleDropdown() {
+        if (dropdownMenu.style.display === 'block') {
+            hideDropdown();
+        } else {
+            showDropdown();
+            if (dropdownMenu.innerHTML === '') {
+                showAllChoices();
+            }
+        }
+    }
+    
+    // Show create new section
+    function showCreateNewSection(searchTerm = '') {
+        createNewSection.style.display = 'block';
+        input.value = '';
+        hideDropdown();
+        
+        // Pre-populate the fields with the search term
+        if (searchTerm) {
+            const displayNameInput = container.querySelector('.new-display-name');
+            const valueInput = container.querySelector('.new-value');
+            
+            if (displayNameInput) {
+                // Convert search term to a more user-friendly display name
+                // Handle both underscore-separated slugs and space-separated text
+                let displayName;
+                if (searchTerm.includes('_') || searchTerm.includes('-')) {
+                    // If it contains underscores or hyphens, treat as slug and convert to title case
+                    const separator = searchTerm.includes('_') ? '_' : '-';
+                    displayName = searchTerm
+                        .split(separator)
+                        .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+                        .join(' ');
+                } else {
+                    // If it's regular text, just capitalize each word
+                    displayName = searchTerm
+                        .split(' ')
+                        .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+                        .join(' ');
+                }
+                displayNameInput.value = displayName;
+            }
+            
+            if (valueInput) {
+                // Generate a proper slug from the search term
+                const slug = searchTerm.toLowerCase()
+                    .replace(/[^a-z0-9\s-]/g, '')
+                    .replace(/\s+/g, '_')
+                    .replace(/_+/g, '_')
+                    .replace(/^_|_$/g, '');
+                valueInput.value = slug;
+            }
+        }
+        
+        // Initial validation
+        validateValueField();
+    }
+    
+    // Validate the value field
+    function validateValueField() {
+        const valueInput = container.querySelector('.new-value');
+        const createButton = container.querySelector('.create-subject-type');
+        const validationMessage = container.querySelector('.validation-message');
+        
+        if (!valueInput || !createButton) return;
+        
+        const value = valueInput.value.trim();
+        const isValid = isValidValue(value);
+        
+        // Update button state
+        createButton.disabled = !isValid;
+        
+        // Update visual feedback
+        if (value.length === 0) {
+            // Empty field - neutral state
+            valueInput.classList.remove('is-valid', 'is-invalid');
+            if (validationMessage) {
+                validationMessage.style.display = 'none';
+            }
+        } else if (isValid) {
+            // Valid field
+            valueInput.classList.remove('is-invalid');
+            valueInput.classList.add('is-valid');
+            if (validationMessage) {
+                validationMessage.style.display = 'none';
+            }
+        } else {
+            // Invalid field
+            valueInput.classList.remove('is-valid');
+            valueInput.classList.add('is-invalid');
+            if (validationMessage) {
+                validationMessage.style.display = 'block';
+                validationMessage.textContent = getValidationMessage(value);
+            }
+        }
+    }
+    
+    // Check if value is valid
+    function isValidValue(value) {
+        if (!value || value.length === 0) {
+            return false;
+        }
+        
+        // Check length (up to 32 characters)
+        if (value.length > 32) {
+            return false;
+        }
+        
+        // Check characters (lowercase letters, digits, underscores, and hyphens)
+        const validPattern = /^[a-z0-9_-]+$/;
+        return validPattern.test(value);
+    }
+    
+    // Get validation error message
+    function getValidationMessage(value) {
+        if (value.length > 32) {
+            return 'Value must be 32 characters or less';
+        }
+        
+        const invalidChars = value.match(/[^a-z0-9_-]/g);
+        if (invalidChars) {
+            return `Invalid characters: ${invalidChars.join(', ')}. Only lowercase letters, digits, underscores, and hyphens are allowed.`;
+        }
+        
+        return 'Invalid value format';
+    }
+    
+    // Hide create new section
+    function hideCreateNewSection() {
+        createNewSection.style.display = 'none';
+    }
+    
+    // Create new subject type
+    async function createNewSubjectType() {
+        const displayNameInput = container.querySelector('.new-display-name');
+        const valueInput = container.querySelector('.new-value');
+        
+        const displayName = displayNameInput.value.trim();
+        const value = valueInput.value.trim();
+        
+        if (!displayName || !value) {
+            alert('Please fill in both Display Name and Value fields.');
+            return;
+        }
+        
+        try {
+            // Create new subject type via AJAX
+            const response = await fetch('/integrations/api/create-subject-type/', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value,
+                },
+                body: JSON.stringify({
+                    display_name: displayName,
+                    value: value
+                })
+            });
+            
+            if (response.ok) {
+                const data = await response.json();
+                const newChoice = [data.id, data.display_name, data.value];
+                
+                // Add to choices list
+                allChoices.push(newChoice);
+                allChoices.sort((a, b) => a[1].localeCompare(b[1]));
+                
+                // Select the new choice
+                selectChoice(newChoice);
+                
+                // Hide create new section
+                hideCreateNewSection();
+                
+                console.log('Created new subject type:', newChoice);
+            } else {
+                const error = await response.json();
+                alert('Error creating subject type: ' + (error.message || 'Unknown error'));
+            }
+        } catch (error) {
+            console.error('Error creating subject type:', error);
+            alert('Error creating subject type. Please try again.');
+        }
+    }
+    
+    // Initialize
+    init();
+}
+
+// CSS styles (injected dynamically) - only inject once
+(function() {
+    if (!document.getElementById('subject-type-autocomplete-styles')) {
+        const styles = `
+            .subject-type-autocomplete-container .autocomplete-dropdown {
+                width: 100%;
+                max-height: 200px;
+                overflow-y: auto;
+                border: 1px solid #ced4da;
+                border-radius: 0.375rem;
+                box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+            }
+            
+            .subject-type-autocomplete-container .choice-item {
+                cursor: pointer;
+                padding: 0.5rem 0.75rem;
+            }
+            
+            .subject-type-autocomplete-container .choice-item:hover {
+                background-color: #f8f9fa;
+            }
+            
+            .subject-type-autocomplete-container .show-create-new {
+                cursor: pointer;
+                padding: 0.5rem 0.75rem;
+                border-top: 1px solid #dee2e6;
+            }
+            
+            .subject-type-autocomplete-container .show-create-new:hover {
+                background-color: #e3f2fd;
+            }
+            
+            .subject-type-autocomplete-container .dropdown-toggle::after {
+                display: none;
+            }
+            
+            .subject-type-autocomplete-container .input-group .form-control {
+                border-top-right-radius: 0;
+                border-bottom-right-radius: 0;
+            }
+            
+            .subject-type-autocomplete-container .input-group .btn {
+                border-top-left-radius: 0;
+                border-bottom-left-radius: 0;
+            }
+        `;
+        
+        const styleSheet = document.createElement('style');
+        styleSheet.id = 'subject-type-autocomplete-styles';
+        styleSheet.textContent = styles;
+        document.head.appendChild(styleSheet);
+    }
+})();

--- a/cdip_admin/integrations/templates/integrations/device_group_detail.html
+++ b/cdip_admin/integrations/templates/integrations/device_group_detail.html
@@ -14,8 +14,7 @@
             <h2>Devices in Group</h2>
         </div>
         <div class="col-md-6 d-flex justify-content-end mb-1">
-            <a class="btn btn-primary" href="{% url 'device_group_update' object.id %}" role="button">Edit Group</a>
-            <a class="btn btn-primary mx-1" href="{% url 'device_group_management_update' object.id %}" role="button">Manage Devices</a>
+            <a class="btn btn-primary" href="{% url 'device_group_management_update' object.id %}" role="button">Manage Group</a>
             <a class="btn btn-primary" href="{% url 'device_group_list' %}" role="button">Close</a>
         </div>
     </div>

--- a/cdip_admin/integrations/templates/integrations/device_group_detail.html
+++ b/cdip_admin/integrations/templates/integrations/device_group_detail.html
@@ -8,6 +8,22 @@
 {% block content %}
     <h3>{{object.name}}</h3>
     <p>Organization: {{object.owner.name}}</p>
+    
+    {% if inbound_integration %}
+    <div class="alert alert-info">
+        <div class="d-flex align-items-center">
+            <i class="fas fa-info-circle me-2"></i>
+            <div>
+                <strong>Default Device Group for:</strong> 
+                <a href="{% url 'inbound_integration_configuration_update' inbound_integration.id %}" class="alert-link">
+                    {{ inbound_integration.name|default:inbound_integration.type.name }}
+                </a>
+                <br>
+                <small>This device group is used as the default for the {{ inbound_integration.type.name }} integration configuration.</small>
+            </div>
+        </div>
+    </div>
+    {% endif %}
 
     <div class="row">
         <div class="col-md-6">

--- a/cdip_admin/integrations/templates/integrations/device_group_management_update.html
+++ b/cdip_admin/integrations/templates/integrations/device_group_management_update.html
@@ -1,10 +1,13 @@
 {% extends "base.html" %}
 
 {% load crispy_forms_tags %}
+{% load static %}
 
 {% block title %}Manage Devices{% endblock %}
 
 {% block content %}
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    
     <form method="post">
         {% csrf_token %}
         {% crispy form %}

--- a/cdip_admin/integrations/templates/integrations/device_group_management_update.html
+++ b/cdip_admin/integrations/templates/integrations/device_group_management_update.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 {% load static %}
 
-{% block title %}Manage Devices{% endblock %}
+{% block title %}Manage Device Group{% endblock %}
 
 {% block content %}
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">

--- a/cdip_admin/integrations/templates/integrations/device_group_update.html
+++ b/cdip_admin/integrations/templates/integrations/device_group_update.html
@@ -1,10 +1,13 @@
 {% extends "base.html" %}
 
 {% load crispy_forms_tags %}
+{% load static %}
 
 {% block title %}Update Device Group{% endblock %}
 
 {% block content %}
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    
     <form method="post">
         <h3>Device Group</h3>
         {% csrf_token %}

--- a/cdip_admin/integrations/templates/integrations/device_group_update.html
+++ b/cdip_admin/integrations/templates/integrations/device_group_update.html
@@ -8,8 +8,24 @@
 {% block content %}
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     
+    {% if inbound_integration %}
+    <div class="alert alert-info mb-3">
+        <div class="d-flex align-items-center">
+            <i class="fas fa-info-circle me-2"></i>
+            <div>
+                <strong>Default Device Group for:</strong> 
+                <a href="{% url 'inbound_integration_configuration_update' inbound_integration.id %}" class="alert-link">
+                    {{ inbound_integration.name|default:inbound_integration.type.name }}
+                </a>
+                <br>
+                <small>This device group is used as the default for the {{ inbound_integration.type.name }} integration configuration.</small>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+    
     <form method="post">
-        <h3>Device Group</h3>
+        <h3>Manage Device Group</h3>
         {% csrf_token %}
         {% crispy form %}
     </form>

--- a/cdip_admin/integrations/templates/integrations/inbound_integration_configuration_add.html
+++ b/cdip_admin/integrations/templates/integrations/inbound_integration_configuration_add.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load crispy_forms_filters %}
-
 {% load crispy_forms_tags %}
+{% load static %}
 
 {% block title %}Add Inbound Integration Configuration{% endblock %}
 
@@ -12,4 +12,8 @@
         <div class="form-group col-lg-6 px-0 list-inline">{{form.errors}}</div>
         {% crispy form %}
      </form>
+{% endblock %}
+
+{% block extra_js %}
+    <script src="{% static 'integrations/js/integration-type-warning.js' %}"></script>
 {% endblock %}

--- a/cdip_admin/integrations/urls.py
+++ b/cdip_admin/integrations/urls.py
@@ -19,11 +19,6 @@ urlpatterns = [
     path("devicegroups", views.DeviceGroupListView.as_view(), name="device_group_list"),
     path("devicegroups/add", views.DeviceGroupAddView.as_view(), name="device_group_add"),
     path(
-        "devicegroups/<uuid:device_group_id>/edit",
-        views.DeviceGroupUpdateView.as_view(),
-        name="device_group_update",
-    ),
-    path(
         "devicegroups/<uuid:device_group_id>/manage",
         views.DeviceGroupManagementUpdateView.as_view(),
         name="device_group_management_update",

--- a/cdip_admin/integrations/urls.py
+++ b/cdip_admin/integrations/urls.py
@@ -90,6 +90,21 @@ urlpatterns = [
         name="inboundconfigurations/type_modal",
     ),
     path(
+        "inboundconfigurations/add_type_modal/",
+        views.InboundIntegrationConfigurationAddView.type_modal,
+        name="inboundconfigurations/add_type_modal",
+    ),
+    path(
+        "inboundconfigurations/add_schema/<str:integration_type>/<str:update>",
+        views.InboundIntegrationConfigurationAddView.add_schema,
+        name="inboundconfigurations/add_schema",
+    ),
+    path(
+        "inboundconfigurations/add_dropdown_restore/",
+        views.InboundIntegrationConfigurationAddView.add_dropdown_restore,
+        name="inboundconfigurations/add_dropdown_restore",
+    ),
+    path(
         "inboundconfigurations/schema/<str:integration_type>/<uuid:integration_id>/<str:update>",
         views.InboundIntegrationConfigurationUpdateView.schema,
         name="inboundconfigurations/schema",

--- a/cdip_admin/integrations/urls.py
+++ b/cdip_admin/integrations/urls.py
@@ -171,5 +171,7 @@ urlpatterns = [
         "bridges/dropdown_restore/<uuid:integration_id>/",
         views.BridgeIntegrationUpdateView.dropdown_restore,
         name="bridges/dropdown_restore",
-    )
+    ),
+    # API endpoints
+    path("api/create-subject-type/", views.create_subject_type_api, name="create_subject_type_api"),
 ]

--- a/cdip_admin/integrations/views.py
+++ b/cdip_admin/integrations/views.py
@@ -254,13 +254,13 @@ class DeviceGroupAddView(PermissionRequiredMixin, FormView):
     permission_required = "integrations.add_devicegroup"
 
     def post(self, request, *args, **kwargs):
-        form = DeviceGroupForm(request.POST)
+        form = DeviceGroupForm(request.POST, request=request)
         if form.is_valid():
             config = form.save()
             return redirect("device_group", str(config.id))
 
     def get_form(self, form_class=None):
-        form = DeviceGroupForm()
+        form = DeviceGroupForm(request=self.request)
         if not IsGlobalAdmin.has_permission(None, self.request, None):
             # can only add if you are an admin of at least one organization
             if not IsOrganizationMember.filter_queryset_for_user(
@@ -272,19 +272,13 @@ class DeviceGroupAddView(PermissionRequiredMixin, FormView):
         return form
 
 
-class DeviceGroupUpdateView(PermissionRequiredMixin, UpdateView):
+
+
+class DeviceGroupManagementUpdateView(PermissionRequiredMixin, UpdateView):
     template_name = "integrations/device_group_update.html"
-    form_class = DeviceGroupForm
+    form_class = DeviceGroupManagementForm
     model = DeviceGroup
     permission_required = "integrations.change_devicegroup"
-
-    def get(self, request, *args, **kwargs):
-        form_class = self.get_form_class()
-        self.object = self.get_object()
-        form = form_class(instance=self.object)
-        if not IsGlobalAdmin.has_permission(None, self.request, None):
-            form = filter_device_group_form_fields(form, self.request.user)
-        return self.render_to_response(self.get_context_data(form=form))
 
     def get_object(self):
         device_group = get_object_or_404(
@@ -297,23 +291,6 @@ class DeviceGroupUpdateView(PermissionRequiredMixin, UpdateView):
                 raise PermissionDenied
         return device_group
 
-    def get_success_url(self):
-        return reverse(
-            "device_group", kwargs={"module_id": self.kwargs.get("device_group_id")}
-        )
-
-
-class DeviceGroupManagementUpdateView(LoginRequiredMixin, UpdateView):
-    template_name = "integrations/device_group_update.html"
-    form_class = DeviceGroupManagementForm
-    model = DeviceGroup
-
-    def get_object(self):
-        device_group = get_object_or_404(
-            DeviceGroup, pk=self.kwargs.get("device_group_id")
-        )
-        return device_group
-
     def get(self, request, *args, **kwargs):
         print("=== VIEW GET DEBUG ===")
         form_class = self.get_form_class()
@@ -321,7 +298,7 @@ class DeviceGroupManagementUpdateView(LoginRequiredMixin, UpdateView):
         self.object = self.get_object()
         print(f"Object: {self.object}")
         print(f"Object destinations: {list(self.object.destinations.all())}")
-        form = form_class(instance=self.object)
+        form = form_class(instance=self.object, request=request)
         print(f"Form created with instance")
         print(f"Form fields: {list(form.fields.keys())}")
         if 'destinations' in form.fields:
@@ -335,6 +312,8 @@ class DeviceGroupManagementUpdateView(LoginRequiredMixin, UpdateView):
         """Override post method to ensure many-to-many relationships are saved properly."""
         self.object = self.get_object()
         form = self.get_form()
+        # Pass request to form for proper initialization
+        form = self.form_class(request.POST, instance=self.object, request=request)
         
         # Debug: Print form data
         print("=== FORM SUBMISSION DEBUG ===")

--- a/cdip_admin/integrations/views.py
+++ b/cdip_admin/integrations/views.py
@@ -28,6 +28,7 @@ from .filters import (
 )
 from .forms import (
     InboundIntegrationConfigurationForm,
+    InboundIntegrationConfigurationAddForm,
     OutboundIntegrationConfigurationForm,
     DeviceGroupForm,
     DeviceGroupManagementForm,
@@ -524,20 +525,20 @@ def inbound_integration_configuration_detail(request, id):
 
 class InboundIntegrationConfigurationAddView(PermissionRequiredMixin, FormView):
     template_name = "integrations/inbound_integration_configuration_add.html"
-    form_class = InboundIntegrationConfigurationForm
+    form_class = InboundIntegrationConfigurationAddForm
     model = InboundIntegrationConfiguration
     permission_required = "integrations.add_inboundintegrationconfiguration"
 
     def post(self, request, *args, **kwargs):
-        form = InboundIntegrationConfigurationForm(request.POST)
+        form = InboundIntegrationConfigurationAddForm(request.POST, request=request)
         if form.is_valid():
             config: InboundIntegrationConfiguration = form.save()
             device_group = config.default_devicegroup
-            return redirect("device_group_update", device_group_id=device_group.id)
+            return redirect("device_group_management_update", device_group_id=device_group.id)
         return render(request, self.template_name, {'form': form})
 
     def get_form(self, form_class=None):
-        form = InboundIntegrationConfigurationForm()
+        form = InboundIntegrationConfigurationAddForm(request=self.request)
         if not IsGlobalAdmin.has_permission(None, self.request, None):
             form.fields[
                 "owner"
@@ -555,6 +556,12 @@ class InboundIntegrationConfigurationUpdateView(
     form_class = InboundIntegrationConfigurationForm
     model = InboundIntegrationConfiguration
     permission_required = "integrations.change_inboundintegrationconfiguration"
+
+    def get_form_kwargs(self):
+        """Add request to form kwargs."""
+        kwargs = super().get_form_kwargs()
+        kwargs['request'] = self.request
+        return kwargs
 
     @staticmethod
     @requires_csrf_token

--- a/cdip_admin/integrations/views.py
+++ b/cdip_admin/integrations/views.py
@@ -209,6 +209,14 @@ class DeviceGroupDetail(PermissionRequiredMixin, SingleTableMixin, DetailView):
         context = super().get_context_data(**kwargs)
         base_url = reverse("device_list")
         context["base_url"] = base_url
+        
+        # Get the inbound integration configuration that uses this device group as default
+        try:
+            inbound_integration = self.object.inbound_integration_configuration.get()
+            context["inbound_integration"] = inbound_integration
+        except (InboundIntegrationConfiguration.DoesNotExist, InboundIntegrationConfiguration.MultipleObjectsReturned):
+            context["inbound_integration"] = None
+        
         return context
 
 
@@ -308,6 +316,18 @@ class DeviceGroupManagementUpdateView(PermissionRequiredMixin, UpdateView):
         if not IsGlobalAdmin.has_permission(None, self.request, None):
             form = filter_device_group_form_fields(form, self.request.user)
         return self.render_to_response(self.get_context_data(form=form))
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        
+        # Get the inbound integration configuration that uses this device group as default
+        try:
+            inbound_integration = self.object.inbound_integration_configuration.get()
+            context["inbound_integration"] = inbound_integration
+        except (InboundIntegrationConfiguration.DoesNotExist, InboundIntegrationConfiguration.MultipleObjectsReturned):
+            context["inbound_integration"] = None
+        
+        return context
 
     def post(self, request, *args, **kwargs):
         """Override post method to ensure many-to-many relationships are saved properly."""

--- a/cdip_admin/integrations/views.py
+++ b/cdip_admin/integrations/views.py
@@ -547,6 +547,84 @@ class InboundIntegrationConfigurationAddView(PermissionRequiredMixin, FormView):
             )
         return form
 
+    @staticmethod
+    @requires_csrf_token
+    def type_modal(request):
+        """
+        Type modal for Add Integration form.
+        Always shows warning modal when changing integration type.
+        """
+        if request.GET.get("type"):
+            integration_type = request.GET.get("type")
+            selected_type = InboundIntegrationType.objects.get(id=integration_type)
+        else:
+            integration_type = "none"
+            selected_type = "None"
+        
+        # Always show warning modal when changing integration type
+        rendered = render_to_string('integrations/type_modal.html', {
+            'selected_type': selected_type,
+            'target': '#div_id_state',
+            'proceed_button': reverse("inboundconfigurations/add_schema",
+                                    kwargs={
+                                        "integration_type": integration_type,
+                                        "update": "true"
+                                    }),
+            'cancel_button': reverse("inboundconfigurations/add_dropdown_restore")
+        })
+        return HttpResponse(rendered)
+
+    @staticmethod
+    @requires_csrf_token
+    def add_schema(request, integration_type, update):
+        """
+        Schema endpoint for Add Integration form.
+        """
+        if integration_type != "none":
+            integration_type_obj = InboundIntegrationType.objects.get(id=integration_type)
+            form = InboundIntegrationConfigurationAddForm()
+            
+            # Set the session for the integration type
+            request.session["integration_type"] = integration_type
+            
+            # Set up the state field widget based on the schema
+            if integration_type_obj.configuration_schema != {}:
+                form.fields['state'].widget = JSONFormWidget(
+                    schema=integration_type_obj.configuration_schema,
+                )
+            else:
+                form.fields['state'].widget = FormattedJsonFieldWidget()
+            
+            return HttpResponse(as_crispy_field(form["state"]))
+        return HttpResponse("")
+
+    @staticmethod
+    @requires_csrf_token
+    def add_dropdown_restore(request):
+        """
+        Dropdown restore for Add Integration form.
+        """
+        response = f"""<div id="div_id_type" class="form-group">
+                        <label for="id_type" class=" requiredField">
+                        Type
+                        <button type="button" class="btn btn-light btn-sm py-0 mb-0 align-top" 
+                            data-toggle="tooltip" data-placement="right" 
+                            title="Integration component that can process the data." tabindex="-1">?
+                        </button>
+                        <span class="asteriskField">*</span></label> 
+                        <div class="">
+                            <select name="type" hx-trigger="change" hx-target="#div_id_state" hx-swap="outerHTML"
+                            class="select form-control"
+                            required id="id_type">
+                                <option value="" selected>-------</option>"""
+        integration_types = InboundIntegrationType.objects.values_list("id", "name", named=True)
+        for option in integration_types:
+            response += f'<option value="{option.id}">{option.name}</option>'
+        response += """</select>
+                        </div>
+                    </div>"""
+        return HttpResponse(response)
+
 
 class InboundIntegrationConfigurationUpdateView(
     PermissionRequiredMixin,

--- a/cdip_admin/integrations/views.py
+++ b/cdip_admin/integrations/views.py
@@ -10,6 +10,9 @@ from django.views.generic import ListView, DetailView, UpdateView, FormView
 from django_filters.views import FilterView
 from django_tables2.views import SingleTableMixin
 from django.db.models import Count
+from django.http import JsonResponse
+from django.views.decorators.http import require_http_methods
+from django.views.decorators.csrf import csrf_exempt
 
 from cdip_admin import settings
 from core.permissions import IsGlobalAdmin, IsOrganizationMember
@@ -771,7 +774,7 @@ class OutboundIntegrationConfigurationUpdateView(PermissionRequiredMixin, Update
     @staticmethod
     @requires_csrf_token
     def type_modal(request, configuration_id):
-        if request.GET.get("type") is not '':
+        if request.GET.get("type") != '':
             integration_type = request.GET.get("type")
             selected_type = OutboundIntegrationType.objects.get(id=integration_type)
         else:
@@ -1092,3 +1095,56 @@ class BridgeIntegrationUpdateView(PermissionRequiredMixin, UpdateView):
         return reverse(
             "bridge_integration_view", kwargs={"module_id": self.kwargs.get("id")}
         )
+
+
+@require_http_methods(["POST"])
+@csrf_exempt
+def create_subject_type_api(request):
+    """
+    API endpoint to create new subject types via AJAX.
+    """
+    if request.method == 'POST':
+        try:
+            import json
+            data = json.loads(request.body)
+            
+            display_name = data.get('display_name', '').strip()
+            value = data.get('value', '').strip()
+            
+            if not display_name or not value:
+                return JsonResponse({
+                    'error': 'Both display_name and value are required'
+                }, status=400)
+            
+            # Check if value already exists
+            from integrations.models import SubjectType
+            if SubjectType.objects.filter(value=value).exists():
+                return JsonResponse({
+                    'error': f'Subject type with value "{value}" already exists'
+                }, status=400)
+            
+            # Create new subject type
+            subject_type = SubjectType.objects.create(
+                display_name=display_name,
+                value=value
+            )
+            
+            return JsonResponse({
+                'id': str(subject_type.id),
+                'display_name': subject_type.display_name,
+                'value': subject_type.value,
+                'message': 'Subject type created successfully'
+            })
+            
+        except json.JSONDecodeError:
+            return JsonResponse({
+                'error': 'Invalid JSON data'
+            }, status=400)
+        except Exception as e:
+            return JsonResponse({
+                'error': str(e)
+            }, status=500)
+    
+    return JsonResponse({
+        'error': 'Method not allowed'
+    }, status=405)

--- a/cdip_admin/integrations/widgets.py
+++ b/cdip_admin/integrations/widgets.py
@@ -1,0 +1,250 @@
+from django import forms
+from django.utils.html import format_html
+from django.utils.safestring import mark_safe
+
+
+class SearchableMultiSelectWidget(forms.Widget):
+    """
+    A custom widget that provides a searchable multiselect interface
+    for ManyToManyField relationships.
+    """
+    
+    def __init__(self, attrs=None):
+        default_attrs = {
+            'class': 'searchable-multiselect',
+            'data-toggle': 'searchable-multiselect'
+        }
+        if attrs:
+            default_attrs.update(attrs)
+        super().__init__(default_attrs)
+    
+    def render(self, name, value, attrs=None, renderer=None):
+        print(f"=== WIDGET RENDER DEBUG ===")
+        print(f"Widget render called for field: {name}")
+        print(f"Value: {value}")
+        print(f"Attrs: {attrs}")
+        
+        if value is None:
+            value = []
+        
+        # Convert value to list of strings if it's a QuerySet or list of objects
+        if hasattr(value, '__iter__') and not isinstance(value, str):
+            try:
+                # If it's a QuerySet or list of model instances, extract the primary keys
+                if hasattr(value, 'values_list'):
+                    # It's a QuerySet
+                    value = list(value.values_list('pk', flat=True))
+                elif value and hasattr(value[0], 'pk'):
+                    # It's a list of model instances
+                    value = [str(obj.pk) for obj in value]
+                else:
+                    # It's already a list of values
+                    value = [str(v) for v in value]
+            except (AttributeError, IndexError):
+                # Fallback to string conversion
+                value = [str(v) for v in value] if value else []
+        elif value:
+            value = [str(value)]
+        else:
+            value = []
+        
+        # Ensure attrs is a dictionary
+        if attrs is None:
+            attrs = {}
+        
+        # Get the field instance to access choices
+        field = self.attrs.get('field')
+        if not field:
+            return format_html('<div class="alert alert-warning">Field not available</div>')
+        
+        # Get all available choices
+        choices = []
+        # First try to get choices from attrs (set by widget_attrs)
+        if 'choices' in attrs:
+            choices = attrs['choices']
+        elif hasattr(field, 'queryset') and field.queryset:
+            try:
+                queryset = field.queryset.all()
+                for obj in queryset:
+                    choices.append((str(obj.pk), str(obj)))
+            except Exception as e:
+                print(f"Error getting queryset: {e}")
+        elif hasattr(field, 'choices') and field.choices:
+            choices = field.choices
+        
+        # Convert value to list of strings for comparison
+        if isinstance(value, (list, tuple)):
+            selected_values = [str(v) for v in value]
+        else:
+            selected_values = [str(value)] if value else []
+        
+        # Render the widget HTML
+        widget_id = attrs.get('id', f'id_{name}')
+        
+        html = format_html(
+            '''
+            <div class="searchable-multiselect-container" id="{widget_id}_container">
+                <div class="search-input-container mb-2">
+                    <input type="text" 
+                           class="form-control search-input" 
+                           placeholder="Search destinations..." 
+                           id="{widget_id}_search">
+                </div>
+                
+                <div class="selected-items mb-2">
+                    <label class="form-label">Selected Destinations:</label>
+                    <div class="selected-list" id="{widget_id}_selected">
+                        <!-- Selected items will be populated here -->
+                    </div>
+                </div>
+                
+                <div class="available-items">
+                    <label class="form-label">Available Destinations:</label>
+                    <div class="available-list" id="{widget_id}_available">
+                        <!-- Available items will be populated here -->
+                    </div>
+                </div>
+                
+                <!-- Hidden inputs for selected values -->
+                <div class="hidden-inputs">
+                    <!-- Will be populated by JavaScript -->
+                </div>
+            </div>
+            ''',
+            widget_id=widget_id
+        )
+        
+        # Add JavaScript to initialize the widget
+        import json
+        from django.utils.safestring import mark_safe
+        
+        choices_json = mark_safe(json.dumps(choices))
+        selected_json = mark_safe(json.dumps(selected_values))
+        
+        # Read the JavaScript file content and include it inline
+        import os
+        js_file_path = os.path.join(os.path.dirname(__file__), 'static', 'integrations', 'js', 'searchable-multiselect.js')
+        
+        js_content = ""
+        if os.path.exists(js_file_path):
+            with open(js_file_path, 'r') as f:
+                js_content = f.read()
+        
+        js = format_html(
+            '''
+            <script>
+            {js_content}
+            
+            document.addEventListener('DOMContentLoaded', function() {{
+                console.log('DOM loaded, initializing searchable multiselect...');
+                console.log('Widget ID:', '{widget_id}');
+                console.log('Choices:', {choices_json});
+                console.log('Selected:', {selected_json});
+                
+                try {{
+                    initSearchableMultiSelect('{widget_id}', {{
+                        choices: {choices_json},
+                        selected: {selected_json},
+                        name: '{name}'
+                    }});
+                    console.log('Searchable multiselect initialized successfully');
+                }} catch (error) {{
+                    console.error('Error initializing searchable multiselect:', error);
+                }}
+                
+                // Add debugging for form submission
+                const form = document.querySelector('form');
+                console.log('Form found:', form);
+                if (form) {{
+                    form.addEventListener('submit', function(e) {{
+                        console.log('=== FORM SUBMISSION START ===');
+                        console.log('Form submitted');
+                        const hiddenInputs = document.querySelectorAll('input[name^="{name}_"]');
+                        console.log('Hidden inputs found:', hiddenInputs.length);
+                        hiddenInputs.forEach((input, index) => {{
+                            console.log(`Hidden input ${{index}}: name=${{input.name}}, value=${{input.value}}`);
+                        }});
+                        
+                        // Also log all form data
+                        const formData = new FormData(form);
+                        console.log('All form data:');
+                        for (let [key, value] of formData.entries()) {{
+                            console.log(`  ${{key}}: ${{value}}`);
+                        }}
+                        console.log('=== FORM SUBMISSION END ===');
+                    }});
+                }} else {{
+                    console.error('No form found on page');
+                }}
+            }});
+            </script>
+            ''',
+            js_content=mark_safe(js_content),
+            widget_id=widget_id,
+            choices_json=choices_json,
+            selected_json=selected_json,
+            name=name
+        )
+        
+        return mark_safe(html + js)
+    
+    def value_from_datadict(self, data, files, name):
+        """Extract selected values from form data."""
+        print(f"=== VALUE_FROM_DATADICT DEBUG ===")
+        print(f"Field name: {name}")
+        print(f"Data keys: {list(data.keys())}")
+        
+        values = []
+        
+        # Look for values with the pattern name_0, name_1, etc.
+        i = 0
+        while True:
+            key = f"{name}_{i}"
+            if key in data:
+                values.append(data[key])
+                print(f"Found {key}: {data[key]}")
+                i += 1
+            else:
+                break
+        
+        # Also check for a single value with the name
+        if name in data:
+            values.append(data[name])
+            print(f"Found {name}: {data[name]}")
+        
+        # Handle the case where field names might include UUIDs
+        # Look for any keys that start with the field name
+        for key in data.keys():
+            if key.startswith(f"{name}_") and key not in [f"{name}_{i}" for i in range(len(values))]:
+                # This might be a UUID-based field name
+                values.append(data[key])
+                print(f"Found UUID-based field {key}: {data[key]}")
+        
+        print(f"Final values: {values}")
+        return values
+
+
+class SearchableMultiSelectField(forms.ModelMultipleChoiceField):
+    """
+    A custom field that uses the SearchableMultiSelectWidget.
+    """
+    
+    def __init__(self, *args, **kwargs):
+        # Create the widget instance first
+        widget = SearchableMultiSelectWidget()
+        kwargs['widget'] = widget
+        super().__init__(*args, **kwargs)
+        # Store the field reference in the widget after initialization
+        self.widget.attrs['field'] = self
+    
+    def bound_data(self, data, initial):
+        """Override to ensure initial values are properly handled."""
+        if initial is None:
+            initial = []
+        return super().bound_data(data, initial)
+        
+    def widget_attrs(self, widget):
+        """Override to pass choices to the widget."""
+        attrs = super().widget_attrs(widget)
+        # Don't set choices here - let the widget get them during render
+        return attrs

--- a/cdip_admin/integrations/widgets.py
+++ b/cdip_admin/integrations/widgets.py
@@ -267,3 +267,227 @@ class SearchableMultiSelectField(forms.ModelMultipleChoiceField):
         attrs = super().widget_attrs(widget)
         # Don't set choices here - let the widget get them during render
         return attrs
+
+
+class SubjectTypeAutocompleteWidget(forms.Widget):
+    """
+    A widget for selecting subject types with auto-complete and the ability to create new ones.
+    """
+    template_name = 'integrations/widgets/subject_type_autocomplete.html'
+
+    def __init__(self, attrs=None):
+        default_attrs = {
+            'class': 'subject-type-autocomplete',
+            'data-toggle': 'subject-type-autocomplete',
+        }
+        if attrs:
+            default_attrs.update(attrs)
+        super().__init__(default_attrs)
+
+    def render(self, name, value, attrs=None, renderer=None):
+        print(f"=== SUBJECT TYPE WIDGET RENDER DEBUG ===")
+        print(f"Widget render called for field: {name}")
+        print(f"Value: {value}")
+        print(f"Attrs: {attrs}")
+
+        if value is None:
+            value = ''
+
+        # Get all available subject types
+        from integrations.models import SubjectType
+        subject_types = SubjectType.objects.all().order_by('display_name')
+        choices = [(str(st.id), st.display_name, st.value) for st in subject_types]
+
+        if attrs is None:
+            attrs = {}
+
+        widget_id = attrs.get('id', f'id_{name}')
+
+        html = format_html(
+            '''
+            <div class="subject-type-autocomplete-container" id="{widget_id}_container">
+                <div class="input-group">
+                    <input type="text" 
+                           class="form-control autocomplete-input" 
+                           placeholder="Type to search or create new subject type..." 
+                           id="{widget_id}_input"
+                           autocomplete="off">
+                    <input type="hidden" 
+                           name="{name}" 
+                           id="{widget_id}_hidden"
+                           value="{value}">
+                    <button type="button" 
+                            class="btn btn-outline-secondary dropdown-toggle" 
+                            id="{widget_id}_dropdown"
+                            data-bs-toggle="dropdown">
+                        <i class="fas fa-chevron-down"></i>
+                    </button>
+                    <div class="dropdown-menu autocomplete-dropdown" 
+                         id="{widget_id}_dropdown_menu">
+                        <!-- Options will be populated by JavaScript -->
+                    </div>
+                </div>
+                
+                <div class="selected-subject-type mt-2" id="{widget_id}_selected" style="display: none;">
+                    <div class="alert alert-info d-flex justify-content-between align-items-center">
+                        <span>
+                            <strong>Selected:</strong> <span class="selected-name"></span>
+                            <small class="text-muted">(<span class="selected-value"></span>)</small>
+                        </span>
+                        <button type="button" class="btn btn-sm btn-outline-danger clear-selection">
+                            <i class="fas fa-times"></i>
+                        </button>
+                    </div>
+                </div>
+                
+                <div class="create-new-section mt-2" id="{widget_id}_create_new" style="display: none;">
+                    <div class="alert alert-warning">
+                        <div class="d-flex justify-content-between align-items-center mb-2">
+                            <strong>Create New Subject Type</strong>
+                            <button type="button" class="btn btn-sm btn-outline-secondary cancel-create">
+                                <i class="fas fa-times"></i>
+                            </button>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-6">
+                                <label class="form-label">Display Name:</label>
+                                <input type="text" 
+                                       class="form-control new-display-name" 
+                                       placeholder="e.g., Elephant">
+                            </div>
+                            <div class="col-md-6">
+                                <label class="form-label">Value (Slug):</label>
+                                <input type="text" 
+                                       class="form-control new-value" 
+                                       placeholder="e.g., elephant"
+                                       maxlength="32">
+                                <div class="validation-message invalid-feedback" style="display: none;"></div>
+                                <small class="form-text text-muted">Up to 32 characters, lowercase letters, digits, underscores, and hyphens only</small>
+                            </div>
+                        </div>
+                        <button type="button" class="btn btn-primary btn-sm mt-2 create-subject-type" disabled>
+                            <i class="fas fa-plus"></i> Create & Select
+                        </button>
+                    </div>
+                </div>
+            </div>
+            ''',
+            widget_id=widget_id,
+            name=name,
+            value=value
+        )
+
+        # Add JavaScript to initialize the widget
+        import json
+        import os
+        from django.utils.safestring import mark_safe
+        
+        # Ensure proper JSON escaping
+        choices_json = json.dumps(choices)
+        current_value = value if value else ''
+
+        # Read the JavaScript file content and include it inline
+        js_file_path = '/Users/chrisdo/padas/cdip/cdip_admin/integrations/static/integrations/js/subject-type-autocomplete.js'
+        
+        js_content = ""
+        if os.path.exists(js_file_path):
+            with open(js_file_path, 'r') as f:
+                js_content = f.read()
+                print(f"DEBUG: Read {len(js_content)} characters from JavaScript file")
+        else:
+            print(f"DEBUG: JavaScript file not found at {js_file_path}")
+            # Fallback: embed a minimal version of the JavaScript
+            js_content = """
+            function initSubjectTypeAutocomplete(widgetId, options) {
+                console.log('Subject Type Widget: Fallback initialization');
+                console.log('Subject Type Widget: allChoices =', options.choices);
+                
+                const container = document.getElementById(widgetId + '_container');
+                const input = document.getElementById(widgetId + '_input');
+                const hiddenInput = document.getElementById(widgetId + '_hidden');
+                const dropdown = document.getElementById(widgetId + '_dropdown');
+                const dropdownMenu = document.getElementById(widgetId + '_dropdown_menu');
+                
+                if (!container || !input || !hiddenInput || !dropdown || !dropdownMenu) {
+                    console.error('Subject Type Widget: Required elements not found');
+                    return;
+                }
+                
+                let allChoices = options.choices || [];
+                let currentValue = options.currentValue || '';
+                
+                // Show all choices when dropdown is clicked
+                dropdown.addEventListener('click', function() {
+                    console.log('Subject Type Widget: Dropdown clicked');
+                    dropdownMenu.innerHTML = '';
+                    
+                    if (allChoices.length === 0) {
+                        dropdownMenu.innerHTML = '<div class="dropdown-item-text text-muted">No subject types found</div>';
+                        return;
+                    }
+                    
+                    allChoices.forEach(choice => {
+                        const item = document.createElement('div');
+                        item.className = 'dropdown-item choice-item';
+                        item.innerHTML = '<div><strong>' + choice[1] + '</strong><small class="text-muted d-block">' + choice[2] + '</small></div>';
+                        item.addEventListener('click', function() {
+                            hiddenInput.value = choice[0];
+                            input.value = choice[1];
+                            dropdownMenu.style.display = 'none';
+                            console.log('Subject Type Widget: Selected', choice[1]);
+                        });
+                        dropdownMenu.appendChild(item);
+                    });
+                    
+                    dropdownMenu.style.display = 'block';
+                });
+                
+                // Hide dropdown when clicking outside
+                document.addEventListener('click', function(e) {
+                    if (!container.contains(e.target)) {
+                        dropdownMenu.style.display = 'none';
+                    }
+                });
+            }
+            """
+
+        js = format_html(
+            '''
+            <script>
+            {js_content}
+            
+            document.addEventListener('DOMContentLoaded', function() {{
+                console.log('Initializing subject type autocomplete widget...');
+                console.log('Widget ID:', '{widget_id}');
+                console.log('Choices:', {choices_json});
+                console.log('Current value:', '{current_value}');
+                
+                initSubjectTypeAutocomplete('{widget_id}', {{
+                    choices: {choices_json},
+                    currentValue: '{current_value}',
+                    name: '{name}'
+                }});
+            }});
+            </script>
+            ''',
+            js_content=mark_safe(js_content),
+            widget_id=widget_id,
+            choices_json=mark_safe(choices_json),
+            current_value=current_value,
+            name=name
+        )
+        
+        return mark_safe(html + js)
+
+
+class SubjectTypeAutocompleteField(forms.ModelChoiceField):
+    """
+    A custom field that uses the SubjectTypeAutocompleteWidget.
+    """
+    def __init__(self, *args, **kwargs):
+        from integrations.models import SubjectType
+        queryset = kwargs.get('queryset', SubjectType.objects.all())
+        kwargs['queryset'] = queryset
+        widget = SubjectTypeAutocompleteWidget()
+        kwargs['widget'] = widget
+        super().__init__(*args, **kwargs)

--- a/cdip_admin/integrations/widgets.py
+++ b/cdip_admin/integrations/widgets.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
+from django.urls import reverse
 
 
 class SearchableMultiSelectWidget(forms.Widget):
@@ -942,3 +943,47 @@ class DeviceGroupAutoCreateField(forms.ModelChoiceField):
         kwargs['widget'] = widget
         kwargs['required'] = False
         super().__init__(*args, **kwargs)
+
+
+class DeviceGroupDisplayWidget(forms.Widget):
+    """
+    A widget that displays the device group name with a link to its manage page.
+    """
+    
+    def render(self, name, value, attrs=None, renderer=None):
+        if not value:
+            return format_html('<div class="text-muted">No default device group set</div>')
+        
+        try:
+            from integrations.models import DeviceGroup
+            device_group = DeviceGroup.objects.get(id=value)
+            manage_url = reverse('device_group_management_update', kwargs={'device_group_id': device_group.id})
+            
+            return format_html(
+                '''
+                <div class="device-group-display">
+                    <div class="d-flex align-items-center">
+                        <i class="fas fa-layer-group me-2 text-primary"></i>
+                        <div>
+                            <strong>{device_group_name}</strong><br>
+                            <small class="text-muted">Organization: {owner_name}</small><br>
+                            <a href="{manage_url}" class="btn btn-sm btn-outline-primary mt-1">
+                                <i class="fas fa-cog"></i> Manage Device Group
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                <input type="hidden" name="{name}" value="{value}">
+                ''',
+                device_group_name=device_group.name,
+                owner_name=device_group.owner.name,
+                manage_url=manage_url,
+                name=name,
+                value=value
+            )
+        except DeviceGroup.DoesNotExist:
+            return format_html('<div class="text-muted">Device group not found</div>')
+    
+    def value_from_datadict(self, data, files, name):
+        """Return the hidden input value to preserve the device group ID."""
+        return data.get(name)

--- a/cdip_admin/integrations/widgets.py
+++ b/cdip_admin/integrations/widgets.py
@@ -758,3 +758,187 @@ class SubjectTypeAutocompleteField(forms.ModelChoiceField):
         widget = SubjectTypeAutocompleteWidget()
         kwargs['widget'] = widget
         super().__init__(*args, **kwargs)
+
+
+class DeviceGroupSelectWithLinkWidget(forms.Widget):
+    """
+    A widget that displays a device group select field with a link to manage the selected group.
+    """
+    
+    def __init__(self, attrs=None):
+        default_attrs = {
+            'class': 'form-control device-group-select-with-link'
+        }
+        if attrs:
+            default_attrs.update(attrs)
+        super().__init__(default_attrs)
+    
+    def render(self, name, value, attrs=None, renderer=None):
+        if attrs is None:
+            attrs = {}
+        
+        # Get the field instance to access choices
+        field = self.attrs.get('field')
+        if not field:
+            return format_html('<div class="alert alert-warning">Field not available</div>')
+        
+        # Get all available choices
+        choices = []
+        if hasattr(field, 'queryset') and field.queryset:
+            try:
+                queryset = field.queryset.all().select_related('owner')
+                for obj in queryset:
+                    choices.append((str(obj.pk), str(obj)))
+            except Exception as e:
+                print(f"Error getting queryset: {e}")
+        elif hasattr(field, 'choices') and field.choices:
+            choices = field.choices
+        
+        widget_id = attrs.get('id', f'id_{name}')
+        
+        # Create the select element
+        select_html = f'<select name="{name}" id="{widget_id}" class="form-control">'
+        select_html += '<option value="">---------</option>'
+        
+        for choice_value, choice_label in choices:
+            selected = 'selected' if str(choice_value) == str(value) else ''
+            select_html += f'<option value="{choice_value}" {selected}>{choice_label}</option>'
+        
+        select_html += '</select>'
+        
+        # Create the manage link (only show if a value is selected)
+        manage_link_html = ''
+        if value:
+            manage_link_html = f'''
+                <div class="mt-2">
+                    <a href="/integrations/devicegroups/{value}/manage" 
+                       class="btn btn-sm btn-outline-primary" 
+                       target="_blank">
+                        <i class="fas fa-cog"></i> Manage Device Group
+                    </a>
+                </div>
+            '''
+        
+        # Add JavaScript to update the manage link when selection changes
+        js_html = f'''
+            <script>
+            document.addEventListener('DOMContentLoaded', function() {{
+                const select = document.getElementById('{widget_id}');
+                const manageLinkContainer = document.getElementById('{widget_id}_manage_link');
+                
+                if (select && manageLinkContainer) {{
+                    select.addEventListener('change', function() {{
+                        const selectedValue = this.value;
+                        if (selectedValue) {{
+                            manageLinkContainer.innerHTML = `
+                                <div class="mt-2">
+                                    <a href="/integrations/devicegroups/${{selectedValue}}/manage" 
+                                       class="btn btn-sm btn-outline-primary" 
+                                       target="_blank">
+                                        <i class="fas fa-cog"></i> Manage Device Group
+                                    </a>
+                                </div>
+                            `;
+                        }} else {{
+                            manageLinkContainer.innerHTML = '';
+                        }}
+                    }});
+                }}
+            }});
+            </script>
+        '''
+        
+        html = format_html(
+            '''
+            <div class="device-group-select-with-link-container">
+                {select_html}
+                <div id="{widget_id}_manage_link">
+                    {manage_link_html}
+                </div>
+            </div>
+            {js_html}
+            ''',
+            select_html=mark_safe(select_html),
+            widget_id=widget_id,
+            manage_link_html=mark_safe(manage_link_html),
+            js_html=mark_safe(js_html)
+        )
+        
+        return html
+    
+    def value_from_datadict(self, data, files, name):
+        """Extract the selected value from form data."""
+        return data.get(name)
+
+
+class DeviceGroupSelectWithLinkField(forms.ModelChoiceField):
+    """
+    A custom field that uses the DeviceGroupSelectWithLinkWidget.
+    """
+    
+    def __init__(self, *args, **kwargs):
+        from integrations.models import DeviceGroup
+        queryset = kwargs.get('queryset', DeviceGroup.objects.all())
+        kwargs['queryset'] = queryset
+        widget = DeviceGroupSelectWithLinkWidget()
+        kwargs['widget'] = widget
+        super().__init__(*args, **kwargs)
+        # Store the field reference in the widget after initialization
+        self.widget.attrs['field'] = self
+
+
+class DeviceGroupAutoCreateWidget(forms.Widget):
+    """
+    A widget that displays a message indicating a default device group will be created automatically.
+    """
+    
+    def __init__(self, attrs=None):
+        default_attrs = {
+            'class': 'form-control device-group-auto-create'
+        }
+        if attrs:
+            default_attrs.update(attrs)
+        super().__init__(default_attrs)
+    
+    def render(self, name, value, attrs=None, renderer=None):
+        widget_id = attrs.get('id', f'id_{name}') if attrs else f'id_{name}'
+        
+        html = format_html(
+            '''
+            <div class="device-group-auto-create-container">
+                <div class="alert alert-info">
+                    <div class="d-flex align-items-center">
+                        <i class="fas fa-info-circle me-2"></i>
+                        <div>
+                            <strong>Default Device Group</strong><br>
+                            <small>A default device group will be created automatically when you save this integration configuration.</small>
+                        </div>
+                    </div>
+                </div>
+                <input type="hidden" name="{name}" id="{widget_id}" value="">
+            </div>
+            ''',
+            name=name,
+            widget_id=widget_id
+        )
+        
+        return html
+    
+    def value_from_datadict(self, data, files, name):
+        """Return empty value since this field is auto-created."""
+        return None
+
+
+class DeviceGroupAutoCreateField(forms.ModelChoiceField):
+    """
+    A custom field that uses the DeviceGroupAutoCreateWidget.
+    """
+    
+    def __init__(self, *args, **kwargs):
+        from integrations.models import DeviceGroup
+        queryset = kwargs.get('queryset', DeviceGroup.objects.none())  # Empty queryset since we don't want to show options
+        kwargs['queryset'] = queryset
+        widget = DeviceGroupAutoCreateWidget()
+        kwargs['widget'] = widget
+        kwargs['required'] = False
+        super().__init__(*args, **kwargs)

--- a/cdip_admin/integrations/widgets.py
+++ b/cdip_admin/integrations/widgets.py
@@ -269,6 +269,273 @@ class SearchableMultiSelectField(forms.ModelMultipleChoiceField):
         return attrs
 
 
+class DeviceSearchableMultiSelectWidget(forms.Widget):
+    """
+    A custom widget that provides a searchable multiselect interface
+    for Device ManyToManyField relationships.
+    """
+    
+    def __init__(self, attrs=None):
+        default_attrs = {
+            'class': 'searchable-multiselect',
+            'data-toggle': 'searchable-multiselect'
+        }
+        if attrs:
+            default_attrs.update(attrs)
+        super().__init__(default_attrs)
+    
+    def render(self, name, value, attrs=None, renderer=None):
+        print(f"=== DEVICE WIDGET RENDER DEBUG ===")
+        print(f"Widget render called for field: {name}")
+        print(f"Value: {value}")
+        print(f"Attrs: {attrs}")
+        
+        if value is None:
+            value = []
+        
+        # Convert value to list of strings if it's a QuerySet or list of objects
+        if hasattr(value, '__iter__') and not isinstance(value, str):
+            try:
+                # If it's a QuerySet or list of model instances, extract the primary keys
+                if hasattr(value, 'values_list'):
+                    # It's a QuerySet
+                    value = list(value.values_list('pk', flat=True))
+                elif value and hasattr(value[0], 'pk'):
+                    # It's a list of model instances
+                    value = [str(obj.pk) for obj in value]
+                else:
+                    # It's already a list of values
+                    value = [str(v) for v in value]
+            except (AttributeError, IndexError):
+                # Fallback to string conversion
+                value = [str(v) for v in value] if value else []
+        elif value:
+            value = [str(value)]
+        else:
+            value = []
+        
+        # Ensure attrs is a dictionary
+        if attrs is None:
+            attrs = {}
+        
+        # Get the field instance to access choices
+        field = self.attrs.get('field')
+        if not field:
+            return format_html('<div class="alert alert-warning">Field not available</div>')
+        
+        # Get all available choices
+        choices = []
+        # First try to get choices from attrs (set by widget_attrs)
+        if 'choices' in attrs:
+            choices = attrs['choices']
+        elif hasattr(field, 'queryset') and field.queryset:
+            try:
+                queryset = field.queryset.all().select_related('inbound_configuration__owner', 'inbound_configuration__type')
+                for obj in queryset:
+                    # Create choice tuple with: (id, name, external_id, owner, type, inbound_config)
+                    choices.append((
+                        str(obj.pk), 
+                        obj.name or str(obj),
+                        obj.external_id or 'N/A',
+                        obj.owner.name if obj.owner else 'N/A',
+                        obj.inbound_configuration.type.name if obj.inbound_configuration and obj.inbound_configuration.type else 'N/A',
+                        obj.inbound_configuration.name if obj.inbound_configuration else 'N/A'
+                    ))
+            except Exception as e:
+                print(f"Error getting queryset: {e}")
+        elif hasattr(field, 'choices') and field.choices:
+            choices = field.choices
+        
+        # Convert value to list of strings for comparison
+        if isinstance(value, (list, tuple)):
+            selected_values = [str(v) for v in value]
+        else:
+            selected_values = [str(value)] if value else []
+        
+        # Render the widget HTML
+        widget_id = attrs.get('id', f'id_{name}')
+        
+        html = format_html(
+                   '''
+                   <div class="searchable-multiselect-container" id="{widget_id}_container">
+                       <div class="search-input-container mb-3">
+                           <input type="text" 
+                                  class="form-control search-input" 
+                                  placeholder="Search by name, external ID, owner, type, or configuration..." 
+                                  id="{widget_id}_search">
+                       </div>
+                       
+                       <div class="row">
+                           <div class="col-md-6">
+                               <div class="available-items">
+                                   <h6 class="text-muted mb-3">Available Devices</h6>
+                                   <div class="available-list" id="{widget_id}_available">
+                                       <!-- Available items will be populated here -->
+                                   </div>
+                               </div>
+                           </div>
+                           
+                           <div class="col-md-6">
+                               <div class="selected-items">
+                                   <h6 class="text-muted mb-3">Selected Devices</h6>
+                                   <div class="selected-list" id="{widget_id}_selected">
+                                       <!-- Selected items will be populated here -->
+                                   </div>
+                               </div>
+                           </div>
+                       </div>
+                       
+                       <!-- Hidden inputs for selected values -->
+                       <div class="hidden-inputs">
+                           <!-- Will be populated by JavaScript -->
+                       </div>
+                   </div>
+                   ''',
+                   widget_id=widget_id
+               )
+        
+        # Add JavaScript to initialize the widget
+        import json
+        from django.utils.safestring import mark_safe
+        
+        choices_json = mark_safe(json.dumps(choices))
+        selected_json = mark_safe(json.dumps(selected_values))
+        
+        # Read the JavaScript file content and include it inline
+        import os
+        js_file_path = os.path.join(os.path.dirname(__file__), 'static', 'integrations', 'js', 'searchable-multiselect.js')
+        
+        js_content = ""
+        if os.path.exists(js_file_path):
+            with open(js_file_path, 'r') as f:
+                js_content = f.read()
+        
+        js = format_html(
+            '''
+            <script>
+            {js_content}
+            
+            document.addEventListener('DOMContentLoaded', function() {{
+                console.log('DOM loaded, initializing device searchable multiselect...');
+                console.log('Widget ID:', '{widget_id}');
+                console.log('Choices:', {choices_json});
+                console.log('Selected:', {selected_json});
+                
+                try {{
+                    initSearchableMultiSelect('{widget_id}', {{
+                        choices: {choices_json},
+                        selected: {selected_json},
+                        name: '{name}'
+                    }});
+                    console.log('Device searchable multiselect initialized successfully');
+                }} catch (error) {{
+                    console.error('Error initializing device searchable multiselect:', error);
+                }}
+                
+                // Add debugging for form submission
+                const form = document.querySelector('form');
+                console.log('Form found:', form);
+                if (form) {{
+                    form.addEventListener('submit', function(e) {{
+                        console.log('=== FORM SUBMISSION START ===');
+                        console.log('Form submitted');
+                        const hiddenInputs = document.querySelectorAll('input[name^="{name}_"]');
+                        console.log('Hidden inputs found:', hiddenInputs.length);
+                        hiddenInputs.forEach((input, index) => {{
+                            console.log(`Hidden input ${{index}}: name=${{input.name}}, value=${{input.value}}`);
+                        }});
+                        
+                        // Also log all form data
+                        const formData = new FormData(form);
+                        console.log('All form data:');
+                        for (let [key, value] of formData.entries()) {{
+                            console.log(`  ${{key}}: ${{value}}`);
+                        }}
+                        console.log('=== FORM SUBMISSION END ===');
+                    }});
+                }} else {{
+                    console.error('No form found on page');
+                }}
+            }});
+            </script>
+            ''',
+            js_content=mark_safe(js_content),
+            widget_id=widget_id,
+            choices_json=choices_json,
+            selected_json=selected_json,
+            name=name
+        )
+        
+        return mark_safe(html + js)
+    
+    def value_from_datadict(self, data, files, name):
+        """Extract selected values from form data."""
+        print(f"=== DEVICE VALUE_FROM_DATADICT DEBUG ===")
+        print(f"Field name: {name}")
+        print(f"Data keys: {list(data.keys())}")
+        
+        values = []
+        
+        # Look for values with the pattern name_0, name_1, etc.
+        i = 0
+        while True:
+            key = f"{name}_{i}"
+            if key in data:
+                value = data[key]
+                # Skip empty values (they indicate clearing the selection)
+                if value and value.strip():
+                    values.append(value)
+                print(f"Found {key}: {value} {'(skipped empty)' if not value or not value.strip() else ''}")
+                i += 1
+            else:
+                break
+        
+        # Also check for a single value with the name
+        if name in data:
+            values.append(data[name])
+            print(f"Found {name}: {data[name]}")
+        
+        # Handle the case where field names might include UUIDs
+        # Look for any keys that start with the field name
+        for key in data.keys():
+            if key.startswith(f"{name}_") and key not in [f"{name}_{i}" for i in range(len(values))]:
+                # This might be a UUID-based field name
+                value = data[key]
+                # Only add non-empty values
+                if value and value.strip():
+                    values.append(value)
+                print(f"Found UUID-based field {key}: {value} {'(skipped empty)' if not value or not value.strip() else ''}")
+        
+        print(f"Final values: {values}")
+        return values
+
+
+class DeviceSearchableMultiSelectField(forms.ModelMultipleChoiceField):
+    """
+    A custom field that uses the DeviceSearchableMultiSelectWidget.
+    """
+    
+    def __init__(self, *args, **kwargs):
+        # Create the widget instance first
+        widget = DeviceSearchableMultiSelectWidget()
+        kwargs['widget'] = widget
+        super().__init__(*args, **kwargs)
+        # Store the field reference in the widget after initialization
+        self.widget.attrs['field'] = self
+    
+    def bound_data(self, data, initial):
+        """Override to ensure initial values are properly handled."""
+        if initial is None:
+            initial = []
+        return super().bound_data(data, initial)
+        
+    def widget_attrs(self, widget):
+        """Override to pass choices to the widget."""
+        attrs = super().widget_attrs(widget)
+        # Don't set choices here - let the widget get them during render
+        return attrs
+
+
 class SubjectTypeAutocompleteWidget(forms.Widget):
     """
     A widget for selecting subject types with auto-complete and the ability to create new ones.

--- a/cdip_admin/integrations/widgets.py
+++ b/cdip_admin/integrations/widgets.py
@@ -94,7 +94,7 @@ class SearchableMultiSelectWidget(forms.Widget):
                        <div class="search-input-container mb-3">
                            <input type="text" 
                                   class="form-control search-input" 
-                                  placeholder="Search destinations..." 
+                                  placeholder="Search by name, owner, type, or endpoint..." 
                                   id="{widget_id}_search">
                        </div>
                        

--- a/cdip_admin/integrations/widgets.py
+++ b/cdip_admin/integrations/widgets.py
@@ -64,9 +64,16 @@ class SearchableMultiSelectWidget(forms.Widget):
             choices = attrs['choices']
         elif hasattr(field, 'queryset') and field.queryset:
             try:
-                queryset = field.queryset.all()
+                queryset = field.queryset.all().select_related('owner', 'type')
                 for obj in queryset:
-                    choices.append((str(obj.pk), str(obj)))
+                    # Create choice tuple with: (id, name, owner, type, endpoint)
+                    choices.append((
+                        str(obj.pk), 
+                        obj.name or str(obj),
+                        obj.owner.name if obj.owner else 'N/A',
+                        obj.type.name if obj.type else 'N/A',
+                        obj.endpoint or 'N/A'
+                    ))
             except Exception as e:
                 print(f"Error getting queryset: {e}")
         elif hasattr(field, 'choices') and field.choices:
@@ -82,37 +89,43 @@ class SearchableMultiSelectWidget(forms.Widget):
         widget_id = attrs.get('id', f'id_{name}')
         
         html = format_html(
-            '''
-            <div class="searchable-multiselect-container" id="{widget_id}_container">
-                <div class="search-input-container mb-2">
-                    <input type="text" 
-                           class="form-control search-input" 
-                           placeholder="Search destinations..." 
-                           id="{widget_id}_search">
-                </div>
-                
-                <div class="selected-items mb-2">
-                    <label class="form-label">Selected Destinations:</label>
-                    <div class="selected-list" id="{widget_id}_selected">
-                        <!-- Selected items will be populated here -->
-                    </div>
-                </div>
-                
-                <div class="available-items">
-                    <label class="form-label">Available Destinations:</label>
-                    <div class="available-list" id="{widget_id}_available">
-                        <!-- Available items will be populated here -->
-                    </div>
-                </div>
-                
-                <!-- Hidden inputs for selected values -->
-                <div class="hidden-inputs">
-                    <!-- Will be populated by JavaScript -->
-                </div>
-            </div>
-            ''',
-            widget_id=widget_id
-        )
+                   '''
+                   <div class="searchable-multiselect-container" id="{widget_id}_container">
+                       <div class="search-input-container mb-3">
+                           <input type="text" 
+                                  class="form-control search-input" 
+                                  placeholder="Search destinations..." 
+                                  id="{widget_id}_search">
+                       </div>
+                       
+                       <div class="row">
+                           <div class="col-md-6">
+                               <div class="available-items">
+                                   <h6 class="text-muted mb-3">Available Destinations</h6>
+                                   <div class="available-list" id="{widget_id}_available">
+                                       <!-- Available items will be populated here -->
+                                   </div>
+                               </div>
+                           </div>
+                           
+                           <div class="col-md-6">
+                               <div class="selected-items">
+                                   <h6 class="text-muted mb-3">Selected Destinations</h6>
+                                   <div class="selected-list" id="{widget_id}_selected">
+                                       <!-- Selected items will be populated here -->
+                                   </div>
+                               </div>
+                           </div>
+                       </div>
+                       
+                       <!-- Hidden inputs for selected values -->
+                       <div class="hidden-inputs">
+                           <!-- Will be populated by JavaScript -->
+                       </div>
+                   </div>
+                   ''',
+                   widget_id=widget_id
+               )
         
         # Add JavaScript to initialize the widget
         import json
@@ -201,8 +214,11 @@ class SearchableMultiSelectWidget(forms.Widget):
         while True:
             key = f"{name}_{i}"
             if key in data:
-                values.append(data[key])
-                print(f"Found {key}: {data[key]}")
+                value = data[key]
+                # Skip empty values (they indicate clearing the selection)
+                if value and value.strip():
+                    values.append(value)
+                print(f"Found {key}: {value} {'(skipped empty)' if not value or not value.strip() else ''}")
                 i += 1
             else:
                 break
@@ -217,8 +233,11 @@ class SearchableMultiSelectWidget(forms.Widget):
         for key in data.keys():
             if key.startswith(f"{name}_") and key not in [f"{name}_{i}" for i in range(len(values))]:
                 # This might be a UUID-based field name
-                values.append(data[key])
-                print(f"Found UUID-based field {key}: {data[key]}")
+                value = data[key]
+                # Only add non-empty values
+                if value and value.strip():
+                    values.append(value)
+                print(f"Found UUID-based field {key}: {value} {'(skipped empty)' if not value or not value.strip() else ''}")
         
         print(f"Final values: {values}")
         return values


### PR DESCRIPTION
This pull request introduces several enhancements and usability improvements to device group and integration management forms in the admin interface, focusing on better widget support, user experience, and permission-based filtering. It also adds new documentation and frontend scripts for custom widgets and integration type warnings. Minor corrections to spelling and help texts are included for consistency.

**Form and Widget Enhancements**

* Custom widgets (`SearchableMultiSelectField`, `DeviceSearchableMultiSelectField`, `SubjectTypeAutocompleteField`, `DeviceGroupSelectWithLinkField`, `DeviceGroupAutoCreateField`, `DeviceGroupDisplayWidget`) are now used in device group and integration forms, improving selection and autocomplete experiences for destinations, devices, and subject types. [[1]](diffhunk://#diff-fbab083dc42026290ee912533550ba18bf1a2ac4009ba0e36ee3d714dca411aaR25) [[2]](diffhunk://#diff-fbab083dc42026290ee912533550ba18bf1a2ac4009ba0e36ee3d714dca411aaL33-R44) [[3]](diffhunk://#diff-fbab083dc42026290ee912533550ba18bf1a2ac4009ba0e36ee3d714dca411aaR297-R303) [[4]](diffhunk://#diff-fbab083dc42026290ee912533550ba18bf1a2ac4009ba0e36ee3d714dca411aaR342-R403)
* Device group and integration forms now filter available device groups and organizations based on user permissions, and for existing integrations, prevent changing the default device group by displaying it with a non-editable widget. [[1]](diffhunk://#diff-fbab083dc42026290ee912533550ba18bf1a2ac4009ba0e36ee3d714dca411aaR97-R112) [[2]](diffhunk://#diff-fbab083dc42026290ee912533550ba18bf1a2ac4009ba0e36ee3d714dca411aaR126-R254) [[3]](diffhunk://#diff-fbab083dc42026290ee912533550ba18bf1a2ac4009ba0e36ee3d714dca411aaR342-R403)

**Frontend and Documentation Additions**

* Added `integration-type-warning.js` to track changes to integration type and state fields, improving user awareness of configuration changes. [[1]](diffhunk://#diff-f4d3deac18ac8f028f4e3ae9b697a17f7368139ecff69e7f6f0aa3fb6da28fa2R1-R31) [[2]](diffhunk://#diff-b5016318a9c3eb20c83e0fbfc5cc606151839b6f075e02f9bbe547dba3cd0b33R16-R19)
* Included a README for the searchable multiselect widget, describing its features, usage, and dependencies.

**Template and UI Improvements**

* Device group detail and update templates now display an info alert when the group is the default for an inbound integration, and have updated button labels and layout for clarity. Font Awesome is loaded for improved iconography. [[1]](diffhunk://#diff-342e1469ae4dc60043c3408aa238c99e3f9c58906779a843191d1a96497817d4R12-R33) [[2]](diffhunk://#diff-e162860a142cc634375806a7c9e01ba31bc48f471d893aab4b498552a0ff09bcR4-R28) [[3]](diffhunk://#diff-06767fe50a450d24b759cd24e1edff211d034394b387d009186f9ee57901879bR4-R10)
* The device group edit URL is removed from routing, consolidating management under the "manage" view.

**Spelling and Help Text Corrections**

* Corrected spelling of "overridden" in several help texts and comments for consistency and clarity. [[1]](diffhunk://#diff-46b71600be12187985851c9e97b3631f862fa709770df13e08d5238d63f3f087L1350-R1350) [[2]](diffhunk://#diff-bdcc211030969ea864c353a94e1508ef0411b44543099939dca2ac8eed555afbL57-R57) [[3]](diffhunk://#diff-67fa85d9817de0cc3e57b08d63b07f3c41d42bbfeb39ace19a193e9ecca287faL436-R436) [[4]](diffhunk://#diff-67fa85d9817de0cc3e57b08d63b07f3c41d42bbfeb39ace19a193e9ecca287faL528-R528)