### PR TITLE
GUNDI-4744: InReach Route configs fixer script

### DIFF
--- a/cdip_admin/integrations/management/commands/fix_migrated_route_configs.py
+++ b/cdip_admin/integrations/management/commands/fix_migrated_route_configs.py
@@ -1,0 +1,66 @@
+import copy
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from integrations.models import Integration
+
+
+DEFAULT_FIELD_MAPPING = {"default": "", "destination_field": "provider_key"}
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        def extract_provider_key(d):
+            for k, v in d.items():
+                if k == "default":
+                    return v
+                result = extract_provider_key(v)
+                if result is not None:
+                    return result
+            return None
+
+        self.stdout.write(f" -- InReach route configs fixer script -- \n\n")
+
+        integrations = Integration.objects.filter(
+            type__value="inreach",
+            name__contains="[V1 to V2]"
+        )
+
+        self.stdout.write(f" -- Got {len(integrations)} InReach integrations to fix -- \n\n")
+
+        for integration in integrations:
+            try:
+                with transaction.atomic():
+                    route_config_data = integration.default_route.configuration.data
+
+                    self.stdout.write(f" -- Current route config for integration '{integration.name}': '{route_config_data}' -- ")
+
+                    current_provider_key = extract_provider_key(integration.default_route.configuration.data)
+                    field_mappings = {
+                        str(integration.id): {
+                            "obv": {},
+                            "txt": {}
+                        }
+                    }
+                    for destination in integration.default_route.destinations.all():
+                        inbound_field_mapping = copy.deepcopy(DEFAULT_FIELD_MAPPING)
+                        inbound_field_mapping["default"] = current_provider_key
+
+                        field_mappings[str(integration.id)]["obv"][str(destination.id)] = inbound_field_mapping
+                        field_mappings[str(integration.id)]["txt"][str(destination.id)] = inbound_field_mapping
+
+                    field_mappings_result = {
+                        "field_mappings": field_mappings
+                    }
+
+                    self.stdout.write(f" -- New route config for integration '{integration.name}': '{field_mappings_result}' -- ")
+
+                    integration.default_route.configuration.data = field_mappings_result
+                    integration.default_route.configuration.save()
+                    integration.default_route.save()
+                    integration.save()
+
+                    self.stdout.write(f" -- Route config for integration {integration.name} updated correctly -- \n\n")
+            except Exception as e:
+                self.stderr.write(f"\n\n -- ERROR updating integration '{integration.name}' route config: {e} -- \n\n")


### PR DESCRIPTION
This pull request adds a new Django management command to help fix and standardize the route configuration for migrated InReach integrations. 

The script locates relevant integrations, extracts the current provider key, and rewrites the route configuration in a consistent format for each integration.

Key changes in this pull request:

**New management command for InReach integrations:**

* Added `fix_migrated_route_configs.py`, a management command that:
  * Locates all `Integration` objects of type "inreach" with names containing "[V1 to V2]".
  * Extracts the current provider key from the existing configuration.
  * Constructs a new standardized `field_mappings` structure for each integration and its destinations.
  * Updates and saves the new configuration for each integration in a transaction, with error handling and progress output.

### Some test execution logs:

```
 -- InReach route configs fixer script -- 

 -- Got 136 InReach integrations to fix -- 

 -- Current route config for integration '[V1 to V2] - 51 Degrees - inReach (InReach to ER)': '{'field_mappings': {'94b08cbf-2b1c-4a47-b4b2-522827e2e6be': {'obv': {'3cf0371b-d52f-45ef-9864-f55a7f62bef9': {'default': '51-inreach', 'destination_field': 'provider_key'}}}}}' -- 
 -- New route config for integration '[V1 to V2] - 51 Degrees - inReach (InReach to ER)': '{'field_mappings': {'226e2cfb-c854-4f06-abf8-4912ae01543d': {'obv': {'a38b8f7e-ffc4-4bd5-8912-846f7843b063': {'default': '51-inreach', 'destination_field': 'provider_key'}}, 'txt': {'a38b8f7e-ffc4-4bd5-8912-846f7843b063': {'default': '51-inreach', 'destination_field': 'provider_key'}}}}}' -- 
 -- Route config for integration [V1 to V2] - 51 Degrees - inReach (InReach to ER) updated correctly -- 

 -- Current route config for integration '[V1 to V2] - Aouk - InReach (InReach to ER)': '{'field_mappings': {'48292db0-276a-410b-9737-ce6b6c2be729': {'obv': {'6ef44298-a45f-4627-b270-8927d1044a27': {'default': 'aouk-inreach', 'destination_field': 'provider_key'}}}}}' -- 
 -- New route config for integration '[V1 to V2] - Aouk - InReach (InReach to ER)': '{'field_mappings': {'e0ce93f4-d183-4fd6-b671-bf152efbaad0': {'obv': {'1cf0a3b7-b705-41ff-b48e-32d77383f9de': {'default': 'aouk-inreach', 'destination_field': 'provider_key'}}, 'txt': {'1cf0a3b7-b705-41ff-b48e-32d77383f9de': {'default': 'aouk-inreach', 'destination_field': 'provider_key'}}}}}' -- 
 -- Route config for integration [V1 to V2] - Aouk - InReach (InReach to ER) updated correctly -- 

 -- Current route config for integration '[V1 to V2] - AP - South Sudan 2 (03/03/2025) (InReach to ER)': '{'field_mappings': {'4bc9cf17-9c8d-4cb1-95c5-3a7932476a5c': {'obv': {'427067b8-e09e-4b73-84a8-e6cdea16fde1': {'default': 'AP-SS-Inreach-2', 'destination_field': 'provider_key'}}}}}' -- 
 -- New route config for integration '[V1 to V2] - AP - South Sudan 2 (03/03/2025) (InReach to ER)': '{'field_mappings': {'967aabc4-8f6a-49d2-a4ab-8b05861b3766': {'obv': {'5e695a73-3a10-40c2-a3c2-187be4d6d13b': {'default': 'AP-SS-Inreach-2', 'destination_field': 'provider_key'}}, 'txt': {'5e695a73-3a10-40c2-a3c2-187be4d6d13b': {'default': 'AP-SS-Inreach-2', 'destination_field': 'provider_key'}}}}}' -- 
 -- Route config for integration [V1 to V2] - AP - South Sudan 2 (03/03/2025) (InReach to ER) updated correctly -- 

 -- Current route config for integration '[V1 to V2] - AP - South Sudan (InReach to ER)': '{'field_mappings': {'9f84736a-54c5-4431-b8de-ef2188b05173': {'obv': {'e5eb7f64-7693-4654-b282-bd4e55b47633': {'default': 'ss-inreach', 'destination_field': 'provider_key'}}}}}' -- 
 -- New route config for integration '[V1 to V2] - AP - South Sudan (InReach to ER)': '{'field_mappings': {'e3ff99f6-6674-47a0-8713-9ab07bb1d09e': {'obv': {'deb040e7-2ad0-4929-871c-d4f9c29d6134': {'default': 'ss-inreach', 'destination_field': 'provider_key'}}, 'txt': {'deb040e7-2ad0-4929-871c-d4f9c29d6134': {'default': 'ss-inreach', 'destination_field': 'provider_key'}}}}}' -- 
 -- Route config for integration [V1 to V2] - AP - South Sudan (InReach to ER) updated correctly -- 

 -- Current route config for integration '[V1 to V2] - Bangweulu - InReach (InReach to ER)': '{'field_mappings': {'638e8845-89ae-4c2a-9a0d-c4884bc9aa6f': {'obv': {'f7d56bb8-16c5-4ae2-9d51-c65fd88853d8': {'default': 'bangweulu-inreach', 'destination_field': 'provider_key'}}}}}' -- 
 -- New route config for integration '[V1 to V2] - Bangweulu - InReach (InReach to ER)': '{'field_mappings': {'f992bac8-5011-4286-9021-21d70bc2499e': {'obv': {'c458dc95-a7c4-4c44-8426-2286f3d013a6': {'default': 'bangweulu-inreach', 'destination_field': 'provider_key'}}, 'txt': {'c458dc95-a7c4-4c44-8426-2286f3d013a6': {'default': 'bangweulu-inreach', 'destination_field': 'provider_key'}}}}}' -- 
 -- Route config for integration [V1 to V2] - Bangweulu - InReach (InReach to ER) updated correctly -- 
...
```