### PR TITLE
Remove SessionAuthentication from REST framework settings

### DIFF
--- a/cdip_admin/cdip_admin/settings.py
+++ b/cdip_admin/cdip_admin/settings.py
@@ -124,7 +124,6 @@ REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
     "DEFAULT_AUTHENTICATION_CLASSES": (
         "cdip_admin.auth.authentication.SimpleUserInfoAuthentication",
-        "rest_framework.authentication.SessionAuthentication",
         "rest_framework.authentication.BasicAuthentication",
     ),
     "DEFAULT_SCHEMA_CLASS": "rest_framework.schemas.coreapi.AutoSchema",


### PR DESCRIPTION
This pull request makes a minor change to the authentication configuration in the `cdip_admin/settings.py` file. Specifically, it removes `SessionAuthentication` from the list of default authentication classes, which will affect how users are authenticated in the API.

- Removed `rest_framework.authentication.SessionAuthentication` from the `DEFAULT_AUTHENTICATION_CLASSES` setting in `cdip_admin/settings.py`, leaving only custom and basic authentication enabled.