### PR TITLE
Track dispatcher deployment failures and surface in connection health

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,31 @@
+# Caddyfile for local development with automatic HTTPS
+
+# Keycloak
+keycloak.127.0.0.1.nip.io {
+    reverse_proxy keycloak:8080
+    tls internal
+}
+
+# Kong Proxy
+kong.127.0.0.1.nip.io {
+    reverse_proxy kong:8000
+    tls internal
+}
+
+# Django Web App
+web.127.0.0.1.nip.io {
+    reverse_proxy web:8888
+    tls internal
+}
+
+# Kong Admin API
+kong-admin.127.0.0.1.nip.io {
+    reverse_proxy kong:8001
+    tls internal
+}
+
+# Gundi Portal (React frontend)
+portal.127.0.0.1.nip.io {
+    reverse_proxy portal:3000
+    tls internal
+}

--- a/Caddyfile
+++ b/Caddyfile
@@ -12,9 +12,14 @@ kong.127.0.0.1.nip.io {
     tls internal
 }
 
-# Django Web App
+# Django Web App — routed through Kong so the kong-oidc plugin terminates
+# auth and injects X-Userinfo, matching the prod ingress→kong→service flow.
+# Caddy retains TLS termination + the public hostname.
 web.127.0.0.1.nip.io {
-    reverse_proxy web:8888
+    reverse_proxy kong:8000 {
+        header_up X-Forwarded-Proto https
+        header_up X-Forwarded-Host {host}
+    }
     tls internal
 }
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,101 @@
+FROM ubuntu:22.04
+
+LABEL maintainer="chrisdo@vulcan.com"
+LABEL description="Local development Dockerfile for CDIP Admin Portal"
+
+# Install basic tools first
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y \
+    curl \
+    wget \
+    gnupg \
+    lsb-release \
+    software-properties-common \
+    git \
+    vim \
+    cargo \
+    rustc \
+    && apt-get autoremove
+
+# Add PostgreSQL official repository for PostgreSQL 12
+RUN curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg && \
+    echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
+
+# Install postgresql-client-12 and other base packages
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y \
+    libpq-dev \
+    python3-pip \
+    python3-openssl \
+    libssl-dev \
+    libffi-dev \
+    locales locales-all \
+    postgresql-client-12 \
+    build-essential \
+    pkg-config \
+    && apt-get autoremove
+
+# Install Python 3.11
+RUN add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    python3.11 \
+    python3.11-dev \
+    python3.11-venv \
+    python3.11-distutils && \
+    apt-get autoremove
+
+# Install pip for Python 3.11
+RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11
+
+# Create symlinks for python3.11 as python3 and pip
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 && \
+    update-alternatives --install /usr/bin/pip3 pip3 /usr/local/bin/pip3.11 1
+
+# Use ubuntugis/ppa for jammy (Ubuntu 22.04)
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 089EBE08314DF160
+RUN /bin/sh -c 'echo "deb http://ppa.launchpad.net/ubuntugis/ppa/ubuntu jammy main" >> /etc/apt/sources.list.d/ubuntugis.list'
+
+RUN apt-get update && \
+    apt-get -y install gdal-bin libgdal-dev
+RUN export CPLUS_INCLUDE_PATH=/usr/include/gdal
+RUN export C_INCLUDE_PATH=/usr/include/gdal
+RUN python3.11 -m pip install GDAL==$(gdal-config --version)
+
+# Set working directory
+WORKDIR /workspace
+
+# Copy requirements files
+COPY dependencies/requirements.txt /workspace/requirements.txt
+COPY dependencies/requirements-dev.txt /workspace/requirements-dev.txt
+
+# Upgrade pip and install wheel for better package support
+# Pin setuptools<71 to keep pkg_resources available for older packages like cryptography==2.9.2
+RUN python3.11 -m pip install -U "pip" "wheel" "setuptools<71"
+
+# Install Python dependencies
+# cryptography==2.9.2 in requirements.txt is incompatible with Python 3.11.
+# Remove it from requirements, install deps, then install a compatible cryptography.
+RUN sed -i '/^cryptography==/d' /workspace/requirements.txt /workspace/requirements-dev.txt && \
+    python3.11 -m pip install "cryptography==42.0.8" --no-cache-dir && \
+    python3.11 -m pip install -r /workspace/requirements.txt --no-cache-dir && \
+    python3.11 -m pip install -r /workspace/requirements-dev.txt --no-cache-dir
+
+# Set environment variables
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+ENV LANGUAGE=C.UTF-8
+ENV DJANGO_SETTINGS_MODULE=cdip_admin.settings
+ENV PYTHONUNBUFFERED=1
+
+# Set working directory to app
+WORKDIR /var/www/app
+
+# Expose port for Django dev server
+EXPOSE 8888
+
+# Default command (can be overridden in docker-compose)
+CMD ["python3.11", "manage.py", "runserver", "0.0.0.0:8888"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -82,13 +82,23 @@ COPY dependencies/requirements-dev.txt /workspace/requirements-dev.txt
 # Pin setuptools<71 to keep pkg_resources available for older packages like cryptography==2.9.2
 RUN python3.11 -m pip install -U "pip" "wheel" "setuptools<71"
 
-# Install Python dependencies
-# cryptography==2.9.2 in requirements.txt is incompatible with Python 3.11.
-# Remove it from requirements, install deps, then install a compatible cryptography.
-RUN sed -i '/^cryptography==/d' /workspace/requirements.txt /workspace/requirements-dev.txt && \
+# Install Python dependencies.
+#
+# cryptography==2.9.2 (pinned in the tracked requirements) is incompatible with
+# Python 3.11. To avoid this dev image, work around the pin without mutating
+# the tracked requirements files: copy them to /tmp, drop the cryptography
+# pin from the copies, install a 3.11-compatible cryptography first, then
+# install everything else from the temp files. /workspace keeps the original
+# pins so the image build doesn't disagree with what CI/prod read.
+#
+# This is a dev-only override; the right long-term fix is bumping
+# cryptography in the tracked requirements (out of scope for this PR).
+RUN cp /workspace/requirements.txt /tmp/requirements.txt && \
+    cp /workspace/requirements-dev.txt /tmp/requirements-dev.txt && \
+    sed -i '/^cryptography==/d' /tmp/requirements.txt /tmp/requirements-dev.txt && \
     python3.11 -m pip install "cryptography==42.0.8" --no-cache-dir && \
-    python3.11 -m pip install -r /workspace/requirements.txt --no-cache-dir && \
-    python3.11 -m pip install -r /workspace/requirements-dev.txt --no-cache-dir
+    python3.11 -m pip install -r /tmp/requirements.txt --no-cache-dir && \
+    python3.11 -m pip install -r /tmp/requirements-dev.txt --no-cache-dir
 
 # Set environment variables
 ENV LC_ALL=C.UTF-8

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -55,15 +55,21 @@ RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 && \
     update-alternatives --install /usr/bin/pip3 pip3 /usr/local/bin/pip3.11 1
 
-# Use ubuntugis/ppa for jammy (Ubuntu 22.04)
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 089EBE08314DF160
-RUN /bin/sh -c 'echo "deb http://ppa.launchpad.net/ubuntugis/ppa/ubuntu jammy main" >> /etc/apt/sources.list.d/ubuntugis.list'
+# Use ubuntugis/ppa for jammy (Ubuntu 22.04). apt-key is deprecated; place a
+# dearmored key in /etc/apt/keyrings and reference it via signed-by= so the
+# build doesn't break on newer base images that disable apt-key.
+RUN mkdir -p /etc/apt/keyrings && \
+    curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x089EBE08314DF160" | gpg --dearmor -o /etc/apt/keyrings/ubuntugis-archive-keyring.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/ubuntugis-archive-keyring.gpg] http://ppa.launchpad.net/ubuntugis/ppa/ubuntu jammy main" > /etc/apt/sources.list.d/ubuntugis.list
 
 RUN apt-get update && \
     apt-get -y install gdal-bin libgdal-dev
-RUN export CPLUS_INCLUDE_PATH=/usr/include/gdal
-RUN export C_INCLUDE_PATH=/usr/include/gdal
-RUN python3.11 -m pip install GDAL==$(gdal-config --version)
+# Combine the include-path exports with the pip install in a single RUN so
+# the env vars actually apply when building the GDAL python package; in
+# separate layers they would not persist.
+RUN export CPLUS_INCLUDE_PATH=/usr/include/gdal && \
+    export C_INCLUDE_PATH=/usr/include/gdal && \
+    python3.11 -m pip install GDAL==$(gdal-config --version)
 
 # Set working directory
 WORKDIR /workspace

--- a/cdip_admin/deployments/admin.py
+++ b/cdip_admin/deployments/admin.py
@@ -59,6 +59,9 @@ class DispatcherDeploymentAdmin(admin.ModelAdmin):
     list_display = (
         "name",
         "status",
+        "failure_reason",
+        "attempt_count",
+        "last_attempt_at",
         "status_details",
         "integration",
         "topic_name",
@@ -68,9 +71,15 @@ class DispatcherDeploymentAdmin(admin.ModelAdmin):
     )
     list_filter = (
         "status",
+        "failure_reason",
         OrphanedFilter,
         "integration__type",
         "legacy_integration__type",
+    )
+    readonly_fields = (
+        "attempt_count",
+        "last_attempt_at",
+        "last_error",
     )
     actions = [restart_deployments, recreate_dispatchers, delete_orphaned_dispatchers]
     search_fields = (

--- a/cdip_admin/deployments/migrations/0009_deployment_failure_tracking.py
+++ b/cdip_admin/deployments/migrations/0009_deployment_failure_tracking.py
@@ -1,0 +1,41 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('deployments', '0008_rename_topic_path_dispatcherdeployment_topic_name'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='dispatcherdeployment',
+            name='failure_reason',
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ('quota_exhausted', 'Quota Exhausted'),
+                    ('transient', 'Transient Error'),
+                    ('config_error', 'Configuration Error'),
+                    ('unknown', 'Unknown'),
+                ],
+                default='',
+                max_length=32,
+            ),
+        ),
+        migrations.AddField(
+            model_name='dispatcherdeployment',
+            name='last_error',
+            field=models.TextField(blank=True, default=''),
+        ),
+        migrations.AddField(
+            model_name='dispatcherdeployment',
+            name='attempt_count',
+            field=models.PositiveIntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name='dispatcherdeployment',
+            name='last_attempt_at',
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+    ]

--- a/cdip_admin/deployments/models.py
+++ b/cdip_admin/deployments/models.py
@@ -11,6 +11,13 @@ class DispatcherDeployment(UUIDAbstractModel, TimestampedModel):
         ERROR = "err", "Failed"
         COMPLETE = "com", "Deployment Complete"
         DELETING = "del", "Deleting"
+
+    class FailureReason(models.TextChoices):
+        QUOTA_EXHAUSTED = "quota_exhausted", "Quota Exhausted"
+        TRANSIENT = "transient", "Transient Error"
+        CONFIG_ERROR = "config_error", "Configuration Error"
+        UNKNOWN = "unknown", "Unknown"
+
     status = models.CharField(
         max_length=20,
         choices=Status.choices,
@@ -21,6 +28,23 @@ class DispatcherDeployment(UUIDAbstractModel, TimestampedModel):
         default="",
         blank=True,
         null=True
+    )
+    failure_reason = models.CharField(
+        max_length=32,
+        choices=FailureReason.choices,
+        blank=True,
+        default="",
+    )
+    last_error = models.TextField(
+        blank=True,
+        default="",
+    )
+    attempt_count = models.PositiveIntegerField(
+        default=0,
+    )
+    last_attempt_at = models.DateTimeField(
+        blank=True,
+        null=True,
     )
     name = models.CharField(
         max_length=63,

--- a/cdip_admin/deployments/tasks.py
+++ b/cdip_admin/deployments/tasks.py
@@ -181,7 +181,11 @@ def deploy_serverless_dispatcher(deployment_id, force_recreate=False, deployment
         print(error_msg)
         deployment.status = DispatcherDeployment.Status.ERROR
         deployment.status_details = error_msg[:500]
-        deployment.save()
+        # update_fields= is critical here and below: never .save() attempt_count /
+        # last_attempt_at, since the F() update at task entry is the only atomic
+        # writer of those columns. Saving them via this in-memory instance can
+        # clobber a concurrent task's increment.
+        deployment.save(update_fields=["status", "status_details"])
         return
     function_name = deployment.name or utils.get_default_dispatcher_name(integration=integration, gundi_version=gundi_version)
     if not deployment.configuration:  # Use default settings
@@ -194,7 +198,7 @@ def deploy_serverless_dispatcher(deployment_id, force_recreate=False, deployment
     topic = integration.additional.get("topic", utils.get_default_topic_name(integration=integration, gundi_version=gundi_version))
     topic_path = f'projects/{project_id}/topics/{topic}'
     deployment.topic_name = topic  # Save the topic for retries or deletions
-    deployment.save()
+    deployment.save(update_fields=["topic_name"])
 
     try:
         topic_created_this_run = create_topic(topic_path=topic_path)
@@ -216,7 +220,7 @@ def deploy_serverless_dispatcher(deployment_id, force_recreate=False, deployment
                     print(f"Error deleting function {function_name}: {e}")
                     deployment.status = DispatcherDeployment.Status.ERROR
                     deployment.status_details = f"Error deleting function {function_name}: {e}"
-                    deployment.save()
+                    deployment.save(update_fields=["status", "status_details"])
                     return
             function_response = create_or_update_function(
                 function_request=function_request,
@@ -235,7 +239,7 @@ def deploy_serverless_dispatcher(deployment_id, force_recreate=False, deployment
                     print(f"Error deleting Cloudrun service {function_name}: {e}")
                     deployment.status = DispatcherDeployment.Status.ERROR
                     deployment.status_details = f"Error deleting Cloudrun service {function_name}: {e}"
-                    deployment.save()
+                    deployment.save(update_fields=["status", "status_details"])
                     return
 
             service_response = create_or_update_cloud_run_service(
@@ -252,11 +256,11 @@ def deploy_serverless_dispatcher(deployment_id, force_recreate=False, deployment
             print(error_msg)
             deployment.status = DispatcherDeployment.Status.ERROR
             deployment.status_details = error_msg[:500]
-            deployment.save()
+            deployment.save(update_fields=["status", "status_details"])
             return
         print(f"Deploy complete.")
         deployment.status = DispatcherDeployment.Status.COMPLETE
-        deployment.save()
+        deployment.save(update_fields=["status"])
     except Exception as e:  # ToDo: Catch more specific errors like validation errors?
         error_msg = f"Error deploying dispatcher: {e}"
         print(error_msg)
@@ -267,7 +271,9 @@ def deploy_serverless_dispatcher(deployment_id, force_recreate=False, deployment
         # what fits in the 500-char status_details column.
         deployment.last_error = traceback.format_exc()
         deployment.failure_reason = failure_reason
-        deployment.save()
+        deployment.save(
+            update_fields=["status", "status_details", "last_error", "failure_reason"]
+        )
         _log_deployment_failure(
             integration=deployment.integration,
             error_msg=error_msg,

--- a/cdip_admin/deployments/tasks.py
+++ b/cdip_admin/deployments/tasks.py
@@ -1,4 +1,5 @@
 import logging
+import traceback
 
 import google.auth
 from celery import shared_task
@@ -249,12 +250,14 @@ def deploy_serverless_dispatcher(deployment_id, force_recreate=False, deployment
         deployment.status = DispatcherDeployment.Status.COMPLETE
         deployment.save()
     except Exception as e:  # ToDo: Catch more specific errors like validation errors?
-        error_msg = f"Error deploying function: {e}"
+        error_msg = f"Error deploying dispatcher: {e}"
         print(error_msg)
         failure_reason = utils.classify_deployment_error(e)
         deployment.status = DispatcherDeployment.Status.ERROR
         deployment.status_details = error_msg[:500]
-        deployment.last_error = error_msg
+        # Capture the full traceback so last_error has actionable detail beyond
+        # what fits in the 500-char status_details column.
+        deployment.last_error = traceback.format_exc()
         deployment.failure_reason = failure_reason
         deployment.save()
         _log_deployment_failure(

--- a/cdip_admin/deployments/tasks.py
+++ b/cdip_admin/deployments/tasks.py
@@ -1,3 +1,5 @@
+import logging
+
 import google.auth
 from celery import shared_task
 from google.cloud import pubsub_v1
@@ -11,6 +13,9 @@ from django.apps import apps
 from django.conf import settings
 from django.utils import timezone
 from . import utils
+
+
+logger = logging.getLogger(__name__)
 
 
 if settings.GCP_ENVIRONMENT_ENABLED:
@@ -79,7 +84,7 @@ def _log_deployment_failure(integration, error_msg, failure_reason, attempt_coun
         )
     except Exception as log_exc:
         # Logging must never mask the underlying deployment error.
-        print(f"Failed to record deployment failure ActivityLog: {log_exc}")
+        logger.warning(f"Failed to record deployment failure ActivityLog: {log_exc}")
 
 
 def get_function_subscription_request(function, topic_path, configuration):
@@ -268,7 +273,7 @@ def deploy_serverless_dispatcher(deployment_id, force_recreate=False, deployment
             except NotFound:
                 pass
             except Exception as cleanup_exc:
-                print(f"Failed to clean up orphaned topic {topic}: {cleanup_exc}")
+                logger.warning(f"Failed to clean up orphaned topic {topic}: {cleanup_exc}")
         return
 
 
@@ -343,6 +348,7 @@ def create_topic(topic_path):
         return True
     except AlreadyExists:
         print(f"Topic {topic_path} already exists. Skipping creation.")
+        print(f"Topic {topic_path} ready.")
         return False
 
 

--- a/cdip_admin/deployments/tasks.py
+++ b/cdip_admin/deployments/tasks.py
@@ -284,7 +284,12 @@ def deploy_serverless_dispatcher(deployment_id, force_recreate=False, deployment
             except NotFound:
                 pass
             except Exception as cleanup_exc:
-                logger.warning(f"Failed to clean up orphaned topic {topic}: {cleanup_exc}")
+                logger.warning(
+                    "Failed to clean up orphaned topic %s: %s",
+                    topic,
+                    cleanup_exc,
+                    exc_info=True,
+                )
         return
 
 

--- a/cdip_admin/deployments/tasks.py
+++ b/cdip_admin/deployments/tasks.py
@@ -12,6 +12,7 @@ from google.cloud.eventarc_v1.types import Trigger, Destination, CloudRun
 from google.api_core.exceptions import AlreadyExists, NotFound
 from django.apps import apps
 from django.conf import settings
+from django.db.models import F
 from django.utils import timezone
 from . import utils
 
@@ -85,7 +86,11 @@ def _log_deployment_failure(integration, error_msg, failure_reason, attempt_coun
         )
     except Exception as log_exc:
         # Logging must never mask the underlying deployment error.
-        logger.warning(f"Failed to record deployment failure ActivityLog: {log_exc}")
+        logger.warning(
+            "Failed to record deployment failure ActivityLog: %s",
+            log_exc,
+            exc_info=True,
+        )
 
 
 def get_function_subscription_request(function, topic_path, configuration):
@@ -151,14 +156,17 @@ def get_service_subscription_request(service_response, topic_path, configuration
 @shared_task
 def deploy_serverless_dispatcher(deployment_id, force_recreate=False, deployment_settings=None):
     DispatcherDeployment = apps.get_model("deployments", "DispatcherDeployment")
+    # Atomic counter bump: if multiple deploy tasks race for the same deployment
+    # (model on_commit + admin restart, etc.) F() prevents lost increments.
+    DispatcherDeployment.objects.filter(id=deployment_id).update(
+        status=DispatcherDeployment.Status.IN_PROGRESS,
+        status_details="",
+        last_error="",
+        failure_reason="",
+        attempt_count=F("attempt_count") + 1,
+        last_attempt_at=timezone.now(),
+    )
     deployment = DispatcherDeployment.objects.get(id=deployment_id)
-    deployment.status = DispatcherDeployment.Status.IN_PROGRESS
-    deployment.status_details = ""  # Clean previous errors
-    deployment.last_error = ""
-    deployment.failure_reason = ""
-    deployment.attempt_count = (deployment.attempt_count or 0) + 1
-    deployment.last_attempt_at = timezone.now()
-    deployment.save()
     topic_created_this_run = False
 
     # Get settings from the database

--- a/cdip_admin/deployments/tasks.py
+++ b/cdip_admin/deployments/tasks.py
@@ -9,6 +9,7 @@ from google.cloud.eventarc_v1.types import Trigger, Destination, CloudRun
 from google.api_core.exceptions import AlreadyExists, NotFound
 from django.apps import apps
 from django.conf import settings
+from django.utils import timezone
 from . import utils
 
 
@@ -41,6 +42,44 @@ else:
     DISPATCHER_DEFAULT_SETTINGS_SMART = {}
     DISPATCHER_DEFAULT_SETTINGS_WPSWATCH = {}
     DISPATCHER_DEFAULT_SETTINGS_TRAPTAGGER = {}
+
+
+def _log_deployment_failure(integration, error_msg, failure_reason, attempt_count, topic_name):
+    """Record a dispatcher deployment failure in the ActivityLog so it feeds
+    Connection health and shows up in the per-integration activity feed.
+
+    No-op for legacy v1 integrations: ActivityLog.integration FK is to v2
+    Integration only.
+    """
+    if integration is None:
+        return
+    ActivityLog = apps.get_model("activity_log", "ActivityLog")
+    is_quota = failure_reason == utils.FAILURE_REASON_QUOTA_EXHAUSTED
+    # SlugField max_length=40
+    value = "dispatcher_quota_exhausted" if is_quota else "dispatcher_deploy_failed"
+    title = (
+        f"Dispatcher deployment blocked by GCP quota for '{integration.name}'"
+        if is_quota
+        else f"Dispatcher deployment failed for '{integration.name}'"
+    )
+    try:
+        ActivityLog.objects.create(
+            log_level=ActivityLog.LogLevels.ERROR,
+            log_type=ActivityLog.LogTypes.EVENT,
+            origin=ActivityLog.Origin.DISPATCHER,
+            integration=integration,
+            value=value,
+            title=title[:200],
+            details={
+                "failure_reason": failure_reason,
+                "attempt_count": attempt_count,
+                "topic_name": topic_name,
+                "error": error_msg,
+            },
+        )
+    except Exception as log_exc:
+        # Logging must never mask the underlying deployment error.
+        print(f"Failed to record deployment failure ActivityLog: {log_exc}")
 
 
 def get_function_subscription_request(function, topic_path, configuration):
@@ -109,7 +148,12 @@ def deploy_serverless_dispatcher(deployment_id, force_recreate=False, deployment
     deployment = DispatcherDeployment.objects.get(id=deployment_id)
     deployment.status = DispatcherDeployment.Status.IN_PROGRESS
     deployment.status_details = ""  # Clean previous errors
+    deployment.last_error = ""
+    deployment.failure_reason = ""
+    deployment.attempt_count = (deployment.attempt_count or 0) + 1
+    deployment.last_attempt_at = timezone.now()
     deployment.save()
+    topic_created_this_run = False
 
     # Get settings from the database
     if deployment.integration:  # v2 models
@@ -139,7 +183,7 @@ def deploy_serverless_dispatcher(deployment_id, force_recreate=False, deployment
     deployment.save()
 
     try:
-        create_topic(topic_path=topic_path)
+        topic_created_this_run = create_topic(topic_path=topic_path)
 
         # Create the dispatcher
         if integration.is_er_site:  # Deploy a Cloud function
@@ -202,9 +246,29 @@ def deploy_serverless_dispatcher(deployment_id, force_recreate=False, deployment
     except Exception as e:  # ToDo: Catch more specific errors like validation errors?
         error_msg = f"Error deploying function: {e}"
         print(error_msg)
+        failure_reason = utils.classify_deployment_error(e)
         deployment.status = DispatcherDeployment.Status.ERROR
         deployment.status_details = error_msg[:500]
+        deployment.last_error = error_msg
+        deployment.failure_reason = failure_reason
         deployment.save()
+        _log_deployment_failure(
+            integration=deployment.integration,
+            error_msg=error_msg,
+            failure_reason=failure_reason,
+            attempt_count=deployment.attempt_count,
+            topic_name=topic,
+        )
+        # Quota failures leave us with an orphaned topic for every retry.
+        # Drop the topic we created in this run so the next attempt starts clean
+        # and we don't accumulate topics while the regional Cloud Run ceiling is full.
+        if failure_reason == utils.FAILURE_REASON_QUOTA_EXHAUSTED and topic_created_this_run:
+            try:
+                delete_topic(topic_name=topic, configuration=configuration)
+            except NotFound:
+                pass
+            except Exception as cleanup_exc:
+                print(f"Failed to clean up orphaned topic {topic}: {cleanup_exc}")
         return
 
 
@@ -271,12 +335,15 @@ def delete_serverless_dispatcher(deployment_id, topic):
 
 
 def create_topic(topic_path):
+    """Create a PubSub topic. Returns True if newly created, False if it already existed."""
     try:
         print(f"Creating Topic {topic_path}..")
         pubsub_client.create_topic(name=topic_path)
-    except AlreadyExists as e:
+        print(f"Topic {topic_path} ready.")
+        return True
+    except AlreadyExists:
         print(f"Topic {topic_path} already exists. Skipping creation.")
-    print(f"Topic {topic_path} ready.")
+        return False
 
 
 def get_function_request(configuration, function_name, topic_path):

--- a/cdip_admin/deployments/tests/test_failure_handling.py
+++ b/cdip_admin/deployments/tests/test_failure_handling.py
@@ -48,9 +48,6 @@ class TestClassifyDeploymentError:
         assert classify_deployment_error(RuntimeError("???")) == FAILURE_REASON_UNKNOWN
 
 
-pytestmark_db = pytest.mark.django_db
-
-
 @pytest.mark.django_db
 def test_quota_exhausted_marks_failure_and_cleans_up_topic(
     mocker, organization, integration_type_smart, mock_get_dispatcher_defaults_from_gcp_secrets,

--- a/cdip_admin/deployments/tests/test_failure_handling.py
+++ b/cdip_admin/deployments/tests/test_failure_handling.py
@@ -1,0 +1,343 @@
+import pytest
+from google.api_core import exceptions as gcp_exceptions
+
+from deployments.utils import (
+    classify_deployment_error,
+    FAILURE_REASON_QUOTA_EXHAUSTED,
+    FAILURE_REASON_TRANSIENT,
+    FAILURE_REASON_CONFIG_ERROR,
+    FAILURE_REASON_UNKNOWN,
+)
+
+
+class TestClassifyDeploymentError:
+    def test_resource_exhausted_is_quota(self):
+        exc = gcp_exceptions.ResourceExhausted("Quota exceeded for cloudrun services")
+        assert classify_deployment_error(exc) == FAILURE_REASON_QUOTA_EXHAUSTED
+
+    def test_too_many_requests_is_quota(self):
+        exc = gcp_exceptions.TooManyRequests("429")
+        assert classify_deployment_error(exc) == FAILURE_REASON_QUOTA_EXHAUSTED
+
+    def test_quota_message_on_plain_exception_is_quota(self):
+        # Real-world shape: LRO operation.result() failure surfaces as a plain
+        # Exception whose message starts "Operation failed due to insufficient quota."
+        exc = Exception(
+            "429 Could not create Cloud Run service olaremot-earth-dis-bbb92f66. "
+            "Operation failed due to insufficient quota."
+        )
+        assert classify_deployment_error(exc) == FAILURE_REASON_QUOTA_EXHAUSTED
+
+    def test_invalid_argument_is_config_error(self):
+        exc = gcp_exceptions.InvalidArgument("bad service name")
+        assert classify_deployment_error(exc) == FAILURE_REASON_CONFIG_ERROR
+
+    def test_permission_denied_is_config_error(self):
+        exc = gcp_exceptions.PermissionDenied("missing role")
+        assert classify_deployment_error(exc) == FAILURE_REASON_CONFIG_ERROR
+
+    def test_deadline_exceeded_is_transient(self):
+        exc = gcp_exceptions.DeadlineExceeded("timed out")
+        assert classify_deployment_error(exc) == FAILURE_REASON_TRANSIENT
+
+    def test_service_unavailable_is_transient(self):
+        exc = gcp_exceptions.ServiceUnavailable("503")
+        assert classify_deployment_error(exc) == FAILURE_REASON_TRANSIENT
+
+    def test_unrecognized_falls_back_to_unknown(self):
+        assert classify_deployment_error(RuntimeError("???")) == FAILURE_REASON_UNKNOWN
+
+
+pytestmark_db = pytest.mark.django_db
+
+
+@pytest.mark.django_db
+def test_quota_exhausted_marks_failure_and_cleans_up_topic(
+    mocker, organization, integration_type_smart, mock_get_dispatcher_defaults_from_gcp_secrets,
+    smart_action_push_events,
+):
+    """When Cloud Run returns 429, the deployment should:
+       - end in ERROR with failure_reason=QUOTA_EXHAUSTED
+       - record the full error in last_error
+       - delete the topic that was created in this run
+       - never reach create_subscription
+    """
+    from django.test import override_settings
+    from integrations.models import Integration
+    from deployments.models import DispatcherDeployment
+
+    # Stub the per-integration auto-deploy hook so creating the Integration
+    # doesn't synchronously try to deploy. We drive the task explicitly below.
+    mocker.patch("deployments.models.transaction.on_commit", lambda fn: None)
+    mocker.patch("integrations.models.v2.models.transaction.on_commit", lambda fn: None)
+    mocker.patch(
+        "integrations.models.v2.models.get_dispatcher_defaults_from_gcp_secrets",
+        mock_get_dispatcher_defaults_from_gcp_secrets,
+    )
+
+    with override_settings(GCP_ENVIRONMENT_ENABLED=True):
+        integration = Integration.objects.create(
+            type=integration_type_smart,
+            name="Reserve",
+            owner=organization,
+            base_url="https://reserve.domain.org",
+        )
+
+    deployment = integration.dispatcher_by_integration
+    assert deployment is not None
+
+    # Patch the GCP-touching helpers used by deploy_serverless_dispatcher.
+    create_topic_mock = mocker.patch(
+        "deployments.tasks.create_topic", return_value=True
+    )
+    delete_topic_mock = mocker.patch("deployments.tasks.delete_topic")
+    create_subscription_mock = mocker.patch("deployments.tasks.create_subscription")
+    quota_error = Exception(
+        "429 Could not create Cloud Run service. "
+        "Operation failed due to insufficient quota."
+    )
+    mocker.patch(
+        "deployments.tasks.create_or_update_cloud_run_service",
+        side_effect=quota_error,
+    )
+
+    from deployments.tasks import deploy_serverless_dispatcher
+    deploy_serverless_dispatcher(deployment_id=deployment.id)
+
+    deployment.refresh_from_db()
+    assert deployment.status == DispatcherDeployment.Status.ERROR
+    assert deployment.failure_reason == DispatcherDeployment.FailureReason.QUOTA_EXHAUSTED
+    assert "insufficient quota" in deployment.last_error
+    assert deployment.attempt_count == 1
+    assert deployment.last_attempt_at is not None
+
+    create_topic_mock.assert_called_once()
+    delete_topic_mock.assert_called_once()
+    create_subscription_mock.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_quota_exhausted_skips_topic_cleanup_when_topic_preexisted(
+    mocker, organization, integration_type_smart, mock_get_dispatcher_defaults_from_gcp_secrets,
+    smart_action_push_events,
+):
+    """If the topic already existed (AlreadyExists), we did not create it in
+    this run and must not delete it on quota failure — another deployment may
+    legitimately own it.
+    """
+    from django.test import override_settings
+    from integrations.models import Integration
+    from deployments.models import DispatcherDeployment
+
+    mocker.patch("deployments.models.transaction.on_commit", lambda fn: None)
+    mocker.patch("integrations.models.v2.models.transaction.on_commit", lambda fn: None)
+    mocker.patch(
+        "integrations.models.v2.models.get_dispatcher_defaults_from_gcp_secrets",
+        mock_get_dispatcher_defaults_from_gcp_secrets,
+    )
+
+    with override_settings(GCP_ENVIRONMENT_ENABLED=True):
+        integration = Integration.objects.create(
+            type=integration_type_smart,
+            name="Reserve",
+            owner=organization,
+            base_url="https://reserve.domain.org",
+        )
+
+    deployment = integration.dispatcher_by_integration
+
+    mocker.patch("deployments.tasks.create_topic", return_value=False)  # already existed
+    delete_topic_mock = mocker.patch("deployments.tasks.delete_topic")
+    mocker.patch(
+        "deployments.tasks.create_or_update_cloud_run_service",
+        side_effect=Exception("429 insufficient quota"),
+    )
+    mocker.patch("deployments.tasks.create_subscription")
+
+    from deployments.tasks import deploy_serverless_dispatcher
+    deploy_serverless_dispatcher(deployment_id=deployment.id)
+
+    deployment.refresh_from_db()
+    assert deployment.failure_reason == DispatcherDeployment.FailureReason.QUOTA_EXHAUSTED
+    delete_topic_mock.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_quota_failure_records_activity_log(
+    mocker, organization, integration_type_smart, mock_get_dispatcher_defaults_from_gcp_secrets,
+    smart_action_push_events,
+):
+    """A quota failure should write an ActivityLog tied to the v2 Integration
+    so existing health calculations and the activity feed pick it up.
+    """
+    from django.test import override_settings
+    from integrations.models import Integration
+    from activity_log.models import ActivityLog
+
+    mocker.patch("deployments.models.transaction.on_commit", lambda fn: None)
+    mocker.patch("integrations.models.v2.models.transaction.on_commit", lambda fn: None)
+    mocker.patch(
+        "integrations.models.v2.models.get_dispatcher_defaults_from_gcp_secrets",
+        mock_get_dispatcher_defaults_from_gcp_secrets,
+    )
+
+    with override_settings(GCP_ENVIRONMENT_ENABLED=True):
+        integration = Integration.objects.create(
+            type=integration_type_smart,
+            name="Reserve",
+            owner=organization,
+            base_url="https://reserve.domain.org",
+        )
+
+    deployment = integration.dispatcher_by_integration
+
+    mocker.patch("deployments.tasks.create_topic", return_value=True)
+    mocker.patch("deployments.tasks.delete_topic")
+    mocker.patch("deployments.tasks.create_subscription")
+    mocker.patch(
+        "deployments.tasks.create_or_update_cloud_run_service",
+        side_effect=Exception(
+            "429 Could not create Cloud Run service. "
+            "Operation failed due to insufficient quota."
+        ),
+    )
+
+    from deployments.tasks import deploy_serverless_dispatcher
+    deploy_serverless_dispatcher(deployment_id=deployment.id)
+
+    logs = ActivityLog.objects.filter(
+        integration=integration, origin=ActivityLog.Origin.DISPATCHER
+    )
+    assert logs.count() == 1
+    log = logs.first()
+    assert log.log_level == ActivityLog.LogLevels.ERROR
+    assert log.log_type == ActivityLog.LogTypes.EVENT
+    assert log.value == "dispatcher_quota_exhausted"
+    assert "quota" in log.title.lower()
+    assert log.details["failure_reason"] == "quota_exhausted"
+    assert log.details["attempt_count"] == 1
+    assert "insufficient quota" in log.details["error"]
+
+
+@pytest.mark.django_db
+def test_non_quota_failure_records_generic_activity_log(
+    mocker, organization, integration_type_smart, mock_get_dispatcher_defaults_from_gcp_secrets,
+    smart_action_push_events,
+):
+    """Non-quota failures still get an ActivityLog, with the generic slug."""
+    from django.test import override_settings
+    from integrations.models import Integration
+    from activity_log.models import ActivityLog
+
+    mocker.patch("deployments.models.transaction.on_commit", lambda fn: None)
+    mocker.patch("integrations.models.v2.models.transaction.on_commit", lambda fn: None)
+    mocker.patch(
+        "integrations.models.v2.models.get_dispatcher_defaults_from_gcp_secrets",
+        mock_get_dispatcher_defaults_from_gcp_secrets,
+    )
+
+    with override_settings(GCP_ENVIRONMENT_ENABLED=True):
+        integration = Integration.objects.create(
+            type=integration_type_smart,
+            name="Reserve",
+            owner=organization,
+            base_url="https://reserve.domain.org",
+        )
+
+    deployment = integration.dispatcher_by_integration
+
+    mocker.patch("deployments.tasks.create_topic", return_value=True)
+    mocker.patch("deployments.tasks.delete_topic")
+    mocker.patch("deployments.tasks.create_subscription")
+    mocker.patch(
+        "deployments.tasks.create_or_update_cloud_run_service",
+        side_effect=RuntimeError("something else went wrong"),
+    )
+
+    from deployments.tasks import deploy_serverless_dispatcher
+    deploy_serverless_dispatcher(deployment_id=deployment.id)
+
+    log = ActivityLog.objects.filter(
+        integration=integration, origin=ActivityLog.Origin.DISPATCHER
+    ).first()
+    assert log is not None
+    assert log.value == "dispatcher_deploy_failed"
+    assert log.details["failure_reason"] == "unknown"
+
+
+@pytest.mark.django_db
+def test_calculate_integration_status_unhealthy_when_dispatcher_quota_exhausted(
+    mocker, organization, integration_type_smart, mock_get_dispatcher_defaults_from_gcp_secrets,
+    smart_action_push_events,
+):
+    """A dispatcher in ERROR/QUOTA_EXHAUSTED should immediately make the
+    integration UNHEALTHY, with quota-specific status_details — no need to wait
+    for 3 activity-log errors to accumulate.
+    """
+    from django.test import override_settings
+    from integrations.models import Integration
+    from integrations.models.v2.models import IntegrationStatus
+    from integrations.models.v2.services import calculate_integration_status
+    from deployments.models import DispatcherDeployment
+
+    mocker.patch("deployments.models.transaction.on_commit", lambda fn: None)
+    mocker.patch("integrations.models.v2.models.transaction.on_commit", lambda fn: None)
+    mocker.patch(
+        "integrations.models.v2.models.get_dispatcher_defaults_from_gcp_secrets",
+        mock_get_dispatcher_defaults_from_gcp_secrets,
+    )
+
+    with override_settings(GCP_ENVIRONMENT_ENABLED=True):
+        integration = Integration.objects.create(
+            type=integration_type_smart,
+            name="Reserve",
+            owner=organization,
+            base_url="https://reserve.domain.org",
+        )
+
+    deployment = integration.dispatcher_by_integration
+    deployment.status = DispatcherDeployment.Status.ERROR
+    deployment.failure_reason = DispatcherDeployment.FailureReason.QUOTA_EXHAUSTED
+    deployment.last_error = "429 insufficient quota"
+    deployment.save()
+
+    status = calculate_integration_status(integration.id)
+    assert status == IntegrationStatus.Status.UNHEALTHY
+    integration.status.refresh_from_db()
+    assert "quota" in integration.status.status_details.lower()
+
+
+@pytest.mark.django_db
+def test_calculate_integration_status_healthy_when_dispatcher_complete(
+    mocker, organization, integration_type_smart, mock_get_dispatcher_defaults_from_gcp_secrets,
+    smart_action_push_events,
+):
+    """When the dispatcher is COMPLETE and there are no error logs, the
+    integration is HEALTHY — confirms the new short-circuit doesn't false-positive.
+    """
+    from django.test import override_settings
+    from integrations.models import Integration
+    from integrations.models.v2.models import IntegrationStatus
+    from integrations.models.v2.services import calculate_integration_status
+    from deployments.models import DispatcherDeployment
+
+    mocker.patch("deployments.models.transaction.on_commit", lambda fn: None)
+    mocker.patch("integrations.models.v2.models.transaction.on_commit", lambda fn: None)
+    mocker.patch(
+        "integrations.models.v2.models.get_dispatcher_defaults_from_gcp_secrets",
+        mock_get_dispatcher_defaults_from_gcp_secrets,
+    )
+
+    with override_settings(GCP_ENVIRONMENT_ENABLED=True):
+        integration = Integration.objects.create(
+            type=integration_type_smart,
+            name="Reserve",
+            owner=organization,
+            base_url="https://reserve.domain.org",
+        )
+
+    deployment = integration.dispatcher_by_integration
+    deployment.status = DispatcherDeployment.Status.COMPLETE
+    deployment.save()
+
+    assert calculate_integration_status(integration.id) == IntegrationStatus.Status.HEALTHY

--- a/cdip_admin/deployments/utils.py
+++ b/cdip_admin/deployments/utils.py
@@ -1,12 +1,79 @@
 import logging
 import json
 from urllib.parse import urlparse
+from google.api_core import exceptions as gcp_exceptions
 from google.cloud import secretmanager
 from django.conf import settings
 from core.utils import generate_short_id_milliseconds
 
 
 logger = logging.getLogger(__name__)
+
+
+# Failure-reason values mirror DispatcherDeployment.FailureReason choices.
+# Kept as plain strings here to avoid a circular import from models.
+FAILURE_REASON_QUOTA_EXHAUSTED = "quota_exhausted"
+FAILURE_REASON_TRANSIENT = "transient"
+FAILURE_REASON_CONFIG_ERROR = "config_error"
+FAILURE_REASON_UNKNOWN = "unknown"
+
+
+_QUOTA_MESSAGE_MARKERS = (
+    "insufficient quota",
+    "quota exceeded",
+    "resource_exhausted",
+    "resourceexhausted",
+)
+
+_TRANSIENT_MESSAGE_MARKERS = (
+    "deadline exceeded",
+    "service unavailable",
+    "internal error",
+    "connection reset",
+    "temporarily unavailable",
+)
+
+
+def classify_deployment_error(exc):
+    """Map a deployment exception to a DispatcherDeployment.FailureReason value.
+
+    Quota failures (HTTP 429 / ResourceExhausted) come back in two shapes from
+    the GCP client libs: a typed ``google.api_core.exceptions`` instance, or a
+    plain ``Exception`` whose string contains "insufficient quota" (this is
+    what we see when an LRO ``operation.result()`` resolves to a failed
+    operation). Both are treated as ``QUOTA_EXHAUSTED`` so callers can clean
+    up orphaned topics and back off instead of thrashing.
+    """
+    message = str(exc) if exc is not None else ""
+    lowered = message.lower()
+
+    if isinstance(exc, gcp_exceptions.ResourceExhausted):
+        return FAILURE_REASON_QUOTA_EXHAUSTED
+    if isinstance(exc, gcp_exceptions.TooManyRequests):
+        return FAILURE_REASON_QUOTA_EXHAUSTED
+    if any(marker in lowered for marker in _QUOTA_MESSAGE_MARKERS):
+        return FAILURE_REASON_QUOTA_EXHAUSTED
+
+    if isinstance(exc, (
+        gcp_exceptions.InvalidArgument,
+        gcp_exceptions.FailedPrecondition,
+        gcp_exceptions.PermissionDenied,
+        gcp_exceptions.NotFound,
+        gcp_exceptions.Unauthenticated,
+    )):
+        return FAILURE_REASON_CONFIG_ERROR
+
+    if isinstance(exc, (
+        gcp_exceptions.DeadlineExceeded,
+        gcp_exceptions.ServiceUnavailable,
+        gcp_exceptions.InternalServerError,
+        gcp_exceptions.Aborted,
+    )):
+        return FAILURE_REASON_TRANSIENT
+    if any(marker in lowered for marker in _TRANSIENT_MESSAGE_MARKERS):
+        return FAILURE_REASON_TRANSIENT
+
+    return FAILURE_REASON_UNKNOWN
 
 
 class PubSubDummyClient:

--- a/cdip_admin/integrations/models/v2/services.py
+++ b/cdip_admin/integrations/models/v2/services.py
@@ -106,7 +106,7 @@ def calculate_integration_status(integration_id):
         created_at__gte=time_window
     ).count() >= errors_threshold:
         integration_status.status = IntegrationStatus.Status.UNHEALTHY
-        integration_status.status_details = "Errors where detected while executing the integration"
+        integration_status.status_details = "Errors were detected while executing the integration"
     elif ActivityLog.objects.filter(
         origin=ActivityLog.Origin.DISPATCHER,
         integration=integration,
@@ -114,7 +114,7 @@ def calculate_integration_status(integration_id):
         created_at__gte=time_window
     ).count() >= errors_threshold:
         integration_status.status = IntegrationStatus.Status.UNHEALTHY
-        integration_status.status_details = "Errors where detected while pushing data to the destination"
+        integration_status.status_details = "Errors were detected while pushing data to the destination"
     integration_status.save()
     return integration_status.status
 

--- a/cdip_admin/integrations/models/v2/services.py
+++ b/cdip_admin/integrations/models/v2/services.py
@@ -81,8 +81,11 @@ def calculate_integration_status(integration_id):
     # actually deliver. Short-circuit so a single failure (e.g. GCP quota)
     # surfaces as UNHEALTHY immediately, instead of waiting for the activity-log
     # error threshold to accumulate.
-    deployment = getattr(integration, "dispatcher_by_integration", None)
+    # Use a queryset filter rather than the OneToOne descriptor: the descriptor
+    # raises DispatcherDeployment.DoesNotExist when no row exists yet, which is
+    # what happens for legacy/freshly-created integrations.
     DispatcherDeployment = apps.get_model("deployments", "DispatcherDeployment")
+    deployment = DispatcherDeployment.objects.filter(integration=integration).first()
 
     if not integration.enabled:
         integration_status.status = IntegrationStatus.Status.DISABLED

--- a/cdip_admin/integrations/models/v2/services.py
+++ b/cdip_admin/integrations/models/v2/services.py
@@ -75,12 +75,29 @@ def calculate_integration_status(integration_id):
     integration_status.status_details = "No issues detected"
     time_window = datetime.now(timezone.utc) - timedelta(minutes=healthcheck_settings.time_window_minutes)
     errors_threshold = healthcheck_settings.error_count_threshold
-    if not integration_status.integration.enabled:
+    integration = integration_status.integration
+
+    # If the dispatcher itself never reached COMPLETE, the integration cannot
+    # actually deliver. Short-circuit so a single failure (e.g. GCP quota)
+    # surfaces as UNHEALTHY immediately, instead of waiting for the activity-log
+    # error threshold to accumulate.
+    deployment = getattr(integration, "dispatcher_by_integration", None)
+    DispatcherDeployment = apps.get_model("deployments", "DispatcherDeployment")
+
+    if not integration.enabled:
         integration_status.status = IntegrationStatus.Status.DISABLED
         integration_status.status_details = "Integration is disabled"
+    elif deployment and deployment.status == DispatcherDeployment.Status.ERROR:
+        integration_status.status = IntegrationStatus.Status.UNHEALTHY
+        if deployment.failure_reason == DispatcherDeployment.FailureReason.QUOTA_EXHAUSTED:
+            integration_status.status_details = (
+                "Dispatcher deployment blocked by GCP quota — Cloud Run service ceiling reached"
+            )
+        else:
+            integration_status.status_details = "Dispatcher deployment failed"
     elif ActivityLog.objects.filter(
         origin=ActivityLog.Origin.INTEGRATION,
-        integration=integration_status.integration,
+        integration=integration,
         log_level=ActivityLog.LogLevels.ERROR,
         created_at__gte=time_window
     ).count() >= errors_threshold:
@@ -88,7 +105,7 @@ def calculate_integration_status(integration_id):
         integration_status.status_details = "Errors where detected while executing the integration"
     elif ActivityLog.objects.filter(
         origin=ActivityLog.Origin.DISPATCHER,
-        integration=integration_status.integration,
+        integration=integration,
         log_level=ActivityLog.LogLevels.ERROR,
         created_at__gte=time_window
     ).count() >= errors_threshold:

--- a/cdip_admin/integrations/models/v2/services.py
+++ b/cdip_admin/integrations/models/v2/services.py
@@ -77,20 +77,21 @@ def calculate_integration_status(integration_id):
     errors_threshold = healthcheck_settings.error_count_threshold
     integration = integration_status.integration
 
-    # If the dispatcher itself never reached COMPLETE, the integration cannot
-    # actually deliver. Short-circuit so a single failure (e.g. GCP quota)
-    # surfaces as UNHEALTHY immediately, instead of waiting for the activity-log
-    # error threshold to accumulate.
-    # Use a queryset filter rather than the OneToOne descriptor: the descriptor
-    # raises DispatcherDeployment.DoesNotExist when no row exists yet, which is
-    # what happens for legacy/freshly-created integrations.
-    DispatcherDeployment = apps.get_model("deployments", "DispatcherDeployment")
-    deployment = DispatcherDeployment.objects.filter(integration=integration).first()
-
     if not integration.enabled:
         integration_status.status = IntegrationStatus.Status.DISABLED
         integration_status.status_details = "Integration is disabled"
-    elif deployment and deployment.status == DispatcherDeployment.Status.ERROR:
+        integration_status.save()
+        return integration_status.status
+
+    # When the dispatcher is in ERROR (e.g. GCP quota exhausted), short-circuit
+    # to UNHEALTHY immediately rather than waiting for the activity-log error
+    # threshold to accumulate. Use a queryset filter rather than the OneToOne
+    # descriptor: the descriptor raises DispatcherDeployment.DoesNotExist when
+    # no row exists yet (legacy/freshly-created integrations).
+    DispatcherDeployment = apps.get_model("deployments", "DispatcherDeployment")
+    deployment = DispatcherDeployment.objects.filter(integration=integration).first()
+
+    if deployment and deployment.status == DispatcherDeployment.Status.ERROR:
         integration_status.status = IntegrationStatus.Status.UNHEALTHY
         if deployment.failure_reason == DispatcherDeployment.FailureReason.QUOTA_EXHAUSTED:
             integration_status.status_details = (

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,211 @@
+#!/bin/bash
+
+# CDIP Admin Portal - Development Helper Script
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+function print_help() {
+    echo "CDIP Admin Portal - Development Helper Script"
+    echo ""
+    echo "Usage: ./dev.sh [command]"
+    echo ""
+    echo "Commands:"
+    echo "  start           - Start all services"
+    echo "  stop            - Stop all services"
+    echo "  restart         - Restart all services"
+    echo "  build           - Build/rebuild containers"
+    echo "  logs [service]  - View logs (optionally for specific service)"
+    echo "  shell           - Open Django shell"
+    echo "  dbshell         - Open database shell"
+    echo "  migrate         - Run database migrations"
+    echo "  makemigrations  - Create new migrations"
+    echo "  test [path]     - Run tests (optionally for specific path)"
+    echo "  createsuperuser - Create Django superuser"
+    echo "  clean           - Stop and remove all containers and volumes"
+    echo "  status          - Show status of all services"
+    echo "  setup           - Initial setup (copy env, build, migrate, createsuperuser)"
+    echo ""
+}
+
+function start_services() {
+    echo -e "${GREEN}Starting all services...${NC}"
+    docker-compose up -d
+    echo -e "${GREEN}Services started!${NC}"
+    echo ""
+    docker-compose ps
+}
+
+function stop_services() {
+    echo -e "${YELLOW}Stopping all services...${NC}"
+    docker-compose stop
+    echo -e "${GREEN}Services stopped!${NC}"
+}
+
+function restart_services() {
+    echo -e "${YELLOW}Restarting all services...${NC}"
+    docker-compose restart
+    echo -e "${GREEN}Services restarted!${NC}"
+}
+
+function build_containers() {
+    echo -e "${GREEN}Building containers...${NC}"
+    docker-compose build
+    echo -e "${GREEN}Build complete!${NC}"
+}
+
+function view_logs() {
+    if [ -z "$2" ]; then
+        docker-compose logs -f
+    else
+        docker-compose logs -f "$2"
+    fi
+}
+
+function django_shell() {
+    echo -e "${GREEN}Opening Django shell...${NC}"
+    docker-compose exec web python3.11 manage.py shell
+}
+
+function db_shell() {
+    echo -e "${GREEN}Opening database shell...${NC}"
+    docker-compose exec postgres psql -U cdip_dbuser -d cdip_portaldb
+}
+
+function run_migrate() {
+    echo -e "${GREEN}Running migrations...${NC}"
+    docker-compose exec web python3.11 manage.py migrate
+    echo -e "${GREEN}Migrations complete!${NC}"
+}
+
+function make_migrations() {
+    echo -e "${GREEN}Creating migrations...${NC}"
+    docker-compose exec web python3.11 manage.py makemigrations
+}
+
+function run_tests() {
+    echo -e "${GREEN}Running tests...${NC}"
+    if [ -z "$2" ]; then
+        docker-compose exec web pytest
+    else
+        docker-compose exec web pytest "$2"
+    fi
+}
+
+function create_superuser() {
+    echo -e "${GREEN}Creating superuser...${NC}"
+    docker-compose exec web python3.11 manage.py createsuperuser
+}
+
+function clean_all() {
+    echo -e "${RED}WARNING: This will remove all containers and volumes!${NC}"
+    read -p "Are you sure? (yes/no): " -r
+    echo
+    if [[ $REPLY =~ ^[Yy][Ee][Ss]$ ]]; then
+        echo -e "${YELLOW}Cleaning up...${NC}"
+        docker-compose down -v
+        echo -e "${GREEN}Cleanup complete!${NC}"
+    else
+        echo -e "${YELLOW}Cancelled.${NC}"
+    fi
+}
+
+function show_status() {
+    echo -e "${GREEN}Service status:${NC}"
+    docker-compose ps
+}
+
+function initial_setup() {
+    echo -e "${GREEN}Starting initial setup...${NC}"
+
+    # Check if .env exists
+    if [ ! -f "cdip_admin/.env" ]; then
+        echo -e "${YELLOW}Copying .env.local to cdip_admin/.env${NC}"
+        cp .env.local cdip_admin/.env
+    else
+        echo -e "${YELLOW}.env file already exists, skipping copy${NC}"
+    fi
+
+    # Build containers
+    echo -e "${GREEN}Building containers...${NC}"
+    docker-compose build
+
+    # Start services
+    echo -e "${GREEN}Starting services...${NC}"
+    docker-compose up -d
+
+    # Wait for services to be ready
+    echo -e "${YELLOW}Waiting for services to be ready...${NC}"
+    sleep 10
+
+    # Run migrations
+    echo -e "${GREEN}Running migrations...${NC}"
+    docker-compose exec web python3.11 manage.py migrate
+
+    # Create superuser
+    echo -e "${GREEN}Let's create a superuser...${NC}"
+    docker-compose exec web python3.11 manage.py createsuperuser
+
+    echo -e "${GREEN}Setup complete!${NC}"
+    echo ""
+    echo "You can now access:"
+    echo "  - Django app: http://localhost:8888"
+    echo "  - Django admin: http://localhost:8888/admin"
+    echo "  - Keycloak: http://localhost:8080 (admin/admin)"
+    echo "  - Kong Admin: http://localhost:8001"
+    echo "  - Kong Manager: http://localhost:8002"
+}
+
+# Main script logic
+case "$1" in
+    start)
+        start_services
+        ;;
+    stop)
+        stop_services
+        ;;
+    restart)
+        restart_services
+        ;;
+    build)
+        build_containers
+        ;;
+    logs)
+        view_logs "$@"
+        ;;
+    shell)
+        django_shell
+        ;;
+    dbshell)
+        db_shell
+        ;;
+    migrate)
+        run_migrate
+        ;;
+    makemigrations)
+        make_migrations
+        ;;
+    test)
+        run_tests "$@"
+        ;;
+    createsuperuser)
+        create_superuser
+        ;;
+    clean)
+        clean_all
+        ;;
+    status)
+        show_status
+        ;;
+    setup)
+        initial_setup
+        ;;
+    *)
+        print_help
+        ;;
+esac

--- a/dev.sh
+++ b/dev.sh
@@ -124,9 +124,15 @@ function initial_setup() {
     echo -e "${GREEN}Starting initial setup...${NC}"
 
     # Check if .env exists
+    local env_template="cdip_admin/cdip_admin/.env.example"
     if [ ! -f "cdip_admin/.env" ]; then
-        echo -e "${YELLOW}Copying .env.local to cdip_admin/.env${NC}"
-        cp .env.local cdip_admin/.env
+        if [ -f "${env_template}" ]; then
+            echo -e "${YELLOW}Copying ${env_template} to cdip_admin/.env${NC}"
+            cp "${env_template}" cdip_admin/.env
+        else
+            echo -e "${RED}Missing environment template: ${env_template}${NC}"
+            return 1
+        fi
     else
         echo -e "${YELLOW}.env file already exists, skipping copy${NC}"
     fi

--- a/dev.sh
+++ b/dev.sh
@@ -10,6 +10,17 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
+# Use Compose v2 (the `docker compose` plugin) when available; fall back to
+# the legacy `docker-compose` standalone binary if a host only has v1.
+if docker compose version >/dev/null 2>&1; then
+    DC="docker compose"
+elif command -v docker-compose >/dev/null 2>&1; then
+    DC="docker-compose"
+else
+    echo -e "${RED}Neither 'docker compose' (v2 plugin) nor 'docker-compose' (v1) found on PATH.${NC}" >&2
+    exit 1
+fi
+
 function print_help() {
     echo "CDIP Admin Portal - Development Helper Script"
     echo ""
@@ -35,71 +46,71 @@ function print_help() {
 
 function start_services() {
     echo -e "${GREEN}Starting all services...${NC}"
-    docker-compose up -d
+    $DC up -d
     echo -e "${GREEN}Services started!${NC}"
     echo ""
-    docker-compose ps
+    $DC ps
 }
 
 function stop_services() {
     echo -e "${YELLOW}Stopping all services...${NC}"
-    docker-compose stop
+    $DC stop
     echo -e "${GREEN}Services stopped!${NC}"
 }
 
 function restart_services() {
     echo -e "${YELLOW}Restarting all services...${NC}"
-    docker-compose restart
+    $DC restart
     echo -e "${GREEN}Services restarted!${NC}"
 }
 
 function build_containers() {
     echo -e "${GREEN}Building containers...${NC}"
-    docker-compose build
+    $DC build
     echo -e "${GREEN}Build complete!${NC}"
 }
 
 function view_logs() {
     if [ -z "$2" ]; then
-        docker-compose logs -f
+        $DC logs -f
     else
-        docker-compose logs -f "$2"
+        $DC logs -f "$2"
     fi
 }
 
 function django_shell() {
     echo -e "${GREEN}Opening Django shell...${NC}"
-    docker-compose exec web python3.11 manage.py shell
+    $DC exec web python3.11 manage.py shell
 }
 
 function db_shell() {
     echo -e "${GREEN}Opening database shell...${NC}"
-    docker-compose exec postgres psql -U cdip_dbuser -d cdip_portaldb
+    $DC exec postgres psql -U cdip_dbuser -d cdip_portaldb
 }
 
 function run_migrate() {
     echo -e "${GREEN}Running migrations...${NC}"
-    docker-compose exec web python3.11 manage.py migrate
+    $DC exec web python3.11 manage.py migrate
     echo -e "${GREEN}Migrations complete!${NC}"
 }
 
 function make_migrations() {
     echo -e "${GREEN}Creating migrations...${NC}"
-    docker-compose exec web python3.11 manage.py makemigrations
+    $DC exec web python3.11 manage.py makemigrations
 }
 
 function run_tests() {
     echo -e "${GREEN}Running tests...${NC}"
     if [ -z "$2" ]; then
-        docker-compose exec web pytest
+        $DC exec web pytest
     else
-        docker-compose exec web pytest "$2"
+        $DC exec web pytest "$2"
     fi
 }
 
 function create_superuser() {
     echo -e "${GREEN}Creating superuser...${NC}"
-    docker-compose exec web python3.11 manage.py createsuperuser
+    $DC exec web python3.11 manage.py createsuperuser
 }
 
 function clean_all() {
@@ -108,7 +119,7 @@ function clean_all() {
     echo
     if [[ $REPLY =~ ^[Yy][Ee][Ss]$ ]]; then
         echo -e "${YELLOW}Cleaning up...${NC}"
-        docker-compose down -v
+        $DC down -v
         echo -e "${GREEN}Cleanup complete!${NC}"
     else
         echo -e "${YELLOW}Cancelled.${NC}"
@@ -117,7 +128,7 @@ function clean_all() {
 
 function show_status() {
     echo -e "${GREEN}Service status:${NC}"
-    docker-compose ps
+    $DC ps
 }
 
 function initial_setup() {
@@ -139,11 +150,11 @@ function initial_setup() {
 
     # Build containers
     echo -e "${GREEN}Building containers...${NC}"
-    docker-compose build
+    $DC build
 
     # Start services
     echo -e "${GREEN}Starting services...${NC}"
-    docker-compose up -d
+    $DC up -d
 
     # Wait for services to be ready
     echo -e "${YELLOW}Waiting for services to be ready...${NC}"
@@ -151,11 +162,11 @@ function initial_setup() {
 
     # Run migrations
     echo -e "${GREEN}Running migrations...${NC}"
-    docker-compose exec web python3.11 manage.py migrate
+    $DC exec web python3.11 manage.py migrate
 
     # Create superuser
     echo -e "${GREEN}Let's create a superuser...${NC}"
-    docker-compose exec web python3.11 manage.py createsuperuser
+    $DC exec web python3.11 manage.py createsuperuser
 
     echo -e "${GREEN}Setup complete!${NC}"
     echo ""

--- a/dev/README.md
+++ b/dev/README.md
@@ -12,10 +12,24 @@ in the request path; Django trusts what Kong forwards.
 
 ## First run
 
+The kong-oidc plugin needs a base64-encoded 32-byte session secret. Generate
+one and drop it in `.env` at the worktree root (already gitignored, never
+committed):
+
+```bash
+echo "OIDC_SESSION_SECRET=$(openssl rand -base64 32)" >> .env
+```
+
+Then bring up the stack:
+
 ```bash
 ./dev.sh setup     # builds, migrates, seeds the dev superuser
 ./dev.sh start     # docker compose up -d
 ```
+
+If `OIDC_SESSION_SECRET` isn't set, the `kong-bootstrap` container exits
+immediately with a clear error (`OIDC_SESSION_SECRET is required (see
+dev/README.md)`) — that's the prompt to do the step above.
 
 ## Opt-in services
 
@@ -72,15 +86,16 @@ portal home logged in.
 | `../docker-compose.yml` (`keycloak`) | `KC_HOSTNAME_URL=https://keycloak.127.0.0.1.nip.io/auth` (browser-facing); `--import-realm` mounts the dev realm. |
 | `../docker-compose.yml` (`kong-bootstrap`) | One-shot init container, runs `bootstrap-kong.sh`. |
 | `bootstrap-kong.sh` | Idempotent — upserts service, route, and `oidc` plugin via Admin API. Uses a stable plugin id so PUT acts as upsert. |
-| `../keycloak/cdip-dev-realm.json` | Realm `cdip-dev` + clients (`cdip-kong-gateway` confidential, `cdip-admin-portal` legacy) + userinfo mapper for `username ← preferred_username` + test user `dev/dev`. |
+| `../keycloak/cdip-dev-realm.json` | Realm `cdip-dev` + clients (`cdip-kong-gateway` confidential for the kong-oidc plugin, `cdip-admin-portal` legacy Django client, `cdip-oauth2` public SPA client for the React portal) + userinfo mapper that adds a `username` claim sourced from the User's `username` property (matches what `SimpleUserInfoBackend` reads — Keycloak's default userinfo response only includes `preferred_username`) + test user `dev/dev`. |
 
 ## Gotchas (worth knowing before debugging)
 
 1. **`session_secret` must be base64-encoded 32 raw bytes.** kong-oidc uses
-   lua-resty-session which decodes it. The bootstrap script hardcodes a fixed
-   dev value (`D5+sOKjh/...=`) that contains `+`/`/`/`=` characters, so the
-   curls use **`--data-urlencode`** rather than `--data` — the latter would
-   form-encode `+` as space and corrupt the secret on Kong's side. Symptom:
+   lua-resty-session which decodes it. The bootstrap script reads
+   `OIDC_SESSION_SECRET` from the environment (sourced from `.env` via
+   compose) and passes it to Kong with **`--data-urlencode`** rather than
+   `--data` — the latter would form-encode `+`/`/`/`=` characters in the
+   base64 string and corrupt the secret on Kong's side. Symptom:
    `[oidc] Invalid plugin configuration, session secret could not be decoded`.
 
 2. **`KC_HOSTNAME_URL` is what makes the OIDC discovery doc advertise the
@@ -127,7 +142,11 @@ plugin config), the cheapest reset is:
 
 ```bash
 docker compose down keycloak keycloak-db
-docker volume rm dispatcher-deployments_keycloak_db_data   # forces realm re-import
+# Drop the keycloak DB volume so realm import re-runs on next boot.
+# Volume name is <project>_keycloak_db_data — project = the directory name
+# (or $COMPOSE_PROJECT_NAME if set), so we discover it by suffix instead of
+# hardcoding it.
+docker volume ls -q | grep '_keycloak_db_data$' | xargs -r docker volume rm
 docker compose up -d keycloak
 docker compose restart kong
 docker compose run --rm kong-bootstrap

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,103 @@
+# Local development stack
+
+The compose stack mirrors the prod auth flow:
+
+    browser → Caddy (TLS edge) → Kong (kong-oidc plugin) → Django web
+
+Kong's `oidc` plugin authenticates against the local Keycloak, then injects
+`X-Userinfo` (base64 JSON) on the upstream request. Django reads the header
+via `cdip_admin.auth.middleware.OidcRemoteUserMiddleware` and resolves the
+user through `SimpleUserInfoBackend`. No Django-side OIDC client is involved
+in the request path; Django trusts what Kong forwards.
+
+## First run
+
+```bash
+./dev.sh setup     # builds, migrates, seeds the dev superuser
+./dev.sh start     # docker compose up -d
+```
+
+The `kong-bootstrap` one-shot service runs after Kong + Keycloak are healthy
+and registers the `cdip-web` service, the `cdip-web-route` route, and the
+`oidc` plugin via Kong's Admin API. Idempotent — re-run with:
+
+```bash
+docker compose run --rm kong-bootstrap
+```
+
+## Logging in
+
+Browse to <https://web.127.0.0.1.nip.io/> (accept Caddy's self-signed cert).
+You'll be redirected to Keycloak — sign in as `dev` / `dev` (defined in
+`keycloak/cdip-dev-realm.json`). After the callback you should land on the
+portal home logged in.
+
+## Files
+
+| File | Role |
+|---|---|
+| `../Caddyfile` | TLS edge. `web.127.0.0.1.nip.io` proxies to `kong:8000` with `X-Forwarded-Proto: https`. |
+| `../docker-compose.yml` (`kong` env) | `KONG_TRUSTED_IPS=0.0.0.0/0,::/0`, `KONG_REAL_IP_HEADER=X-Forwarded-For` so kong-oidc honors Caddy's forwarded headers when building the OIDC redirect URI. |
+| `../docker-compose.yml` (`keycloak`) | `KC_HOSTNAME_URL=https://keycloak.127.0.0.1.nip.io/auth` (browser-facing); `--import-realm` mounts the dev realm. |
+| `../docker-compose.yml` (`kong-bootstrap`) | One-shot init container, runs `bootstrap-kong.sh`. |
+| `bootstrap-kong.sh` | Idempotent — upserts service, route, and `oidc` plugin via Admin API. Uses a stable plugin id so PUT acts as upsert. |
+| `../keycloak/cdip-dev-realm.json` | Realm `cdip-dev` + clients (`cdip-kong-gateway` confidential, `cdip-admin-portal` legacy) + userinfo mapper for `username ← preferred_username` + test user `dev/dev`. |
+
+## Gotchas (worth knowing before debugging)
+
+1. **`session_secret` must be base64-encoded 32 raw bytes.** kong-oidc uses
+   lua-resty-session which decodes it. The bootstrap script hardcodes a fixed
+   dev value (`D5+sOKjh/...=`) that contains `+`/`/`/`=` characters, so the
+   curls use **`--data-urlencode`** rather than `--data` — the latter would
+   form-encode `+` as space and corrupt the secret on Kong's side. Symptom:
+   `[oidc] Invalid plugin configuration, session secret could not be decoded`.
+
+2. **`KC_HOSTNAME_URL` is what makes the OIDC discovery doc advertise the
+   *public* authorization endpoint** while keeping `token_endpoint` /
+   `userinfo_endpoint` on the internal `http://keycloak:8080` URL. That's
+   exactly what kong-oidc needs: the browser hits the public URL,
+   server-to-server back-channels stay internal. If you only set
+   `KC_HOSTNAME_STRICT=false`, all endpoints come back as internal hostnames
+   and the browser redirect will go to a name it can't resolve.
+
+3. **kong-oidc caches the OIDC discovery doc.** If you change Keycloak's
+   hostname or realm config, **restart Kong** (`docker compose restart kong`)
+   to flush the cache. Restarting Keycloak alone won't propagate.
+
+4. **`username` claim on the userinfo response is required.** Django's
+   `SimpleUserInfoBackend` reads `user_info.get("username")` — Keycloak's
+   default userinfo includes `preferred_username`, *not* `username`. The
+   realm export wires up an `oidc-usermodel-property-mapper` on the
+   `cdip-kong-gateway` client that copies `username ← user.attribute=username`
+   into the userinfo response. Without that mapper, login appears to succeed
+   at Keycloak but Django silently fails to authenticate.
+
+5. **`redirect_uri_path` was removed in newer kong-oidc.** The plugin
+   auto-builds the redirect URI from the current request. The bootstrap
+   script omits this field. Symptom: `400 schema violation
+   (config.redirect_uri_path: unknown field)`.
+
+6. **Curl tests through the auth flow can return spurious 403s.** Django's
+   CSRF middleware rejects POSTs without a Referer (or with a non-HTTPS one).
+   When `curl -L` follows redirects, it preserves the original POST method,
+   so the trailing redirect to `/` after the callback ends up as a `POST /`
+   without a Referer. In a browser the trailing redirect is a GET and the
+   Referer is set, so this is a curl-test artifact, not a real auth bug.
+   Confirm a successful login by issuing a fresh GET with the cookie jar.
+
+7. **Kong needs ~5–8 seconds after `restart` before the proxy listener is
+   fully ready.** The healthcheck flips to up earlier. Add a short sleep when
+   scripting against it.
+
+## Resetting auth state
+
+If anything gets stuck (cached discovery doc, broken session cookie, stale
+plugin config), the cheapest reset is:
+
+```bash
+docker compose down keycloak keycloak-db
+docker volume rm dispatcher-deployments_keycloak_db_data   # forces realm re-import
+docker compose up -d keycloak
+docker compose restart kong
+docker compose run --rm kong-bootstrap
+```

--- a/dev/README.md
+++ b/dev/README.md
@@ -17,6 +17,37 @@ in the request path; Django trusts what Kong forwards.
 ./dev.sh start     # docker compose up -d
 ```
 
+## Opt-in services
+
+Two services are sibling-repo dependent and **can't start without local
+clones of those repos**. They're env-var-configurable and (where possible)
+profile-gated so the default stack always comes up cleanly.
+
+| Service | Sibling repo | Override | Profile-gated? |
+|---|---|---|---|
+| `kong` | `gundi-kp-dynamic-routing` | `KONG_DIR=/abs/path` | No (kong is required for the auth flow) |
+| `portal` | `gundi-portal` (React) | `PORTAL_DIR=/abs/path` | Yes — `--profile portal` |
+
+Set the paths in a `.env` file at the worktree root (already gitignored):
+
+```bash
+cat >> .env <<EOF
+KONG_DIR=/Users/me/padas/gundi-kp-dynamic-routing
+PORTAL_DIR=/Users/me/padas/gundi-portal
+EOF
+```
+
+Bring up the portal explicitly when you want it:
+
+```bash
+docker compose --profile portal up -d portal
+# or set the env once for the whole shell:
+COMPOSE_PROFILES=portal ./dev.sh start
+```
+
+Without the profile, `https://portal.127.0.0.1.nip.io` will return 502 from
+Caddy — informative, not broken.
+
 The `kong-bootstrap` one-shot service runs after Kong + Keycloak are healthy
 and registers the `cdip-web` service, the `cdip-web-route` route, and the
 `oidc` plugin via Kong's Admin API. Idempotent — re-run with:

--- a/dev/bootstrap-kong.sh
+++ b/dev/bootstrap-kong.sh
@@ -17,9 +17,10 @@ KEYCLOAK_DISCOVERY="${KEYCLOAK_DISCOVERY:-http://keycloak:8080/auth/realms/cdip-
 OIDC_CLIENT_ID="${OIDC_CLIENT_ID:-cdip-kong-gateway}"
 OIDC_CLIENT_SECRET="${OIDC_CLIENT_SECRET:-dev-kong-oidc-secret}"
 # kong-oidc requires session_secret to be base64-encoded 32 raw bytes
-# (lua-resty-session decodes it). This is a fixed dev secret — never reused
-# anywhere with real auth value.
-OIDC_SESSION_SECRET="${OIDC_SESSION_SECRET:-D5+sOKjh/60/ysGpZoiGsyUSicdU8+UXQP3L1v2GiAA=}"
+# (lua-resty-session decodes it). Required from the environment — never
+# committed to the repo so secret-scanning hooks (detect-secrets / ggshield)
+# stay quiet. See dev/README.md for how to generate one and put it in .env.
+: "${OIDC_SESSION_SECRET:?OIDC_SESSION_SECRET is required (see dev/README.md)}"
 WEB_HOST="${WEB_HOST:-web.127.0.0.1.nip.io}"
 WEB_UPSTREAM_URL="${WEB_UPSTREAM_URL:-http://web:8888}"
 

--- a/dev/bootstrap-kong.sh
+++ b/dev/bootstrap-kong.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+#
+# bootstrap-kong.sh — wire up the dev Kong gateway to mirror prod's
+# ingress -> kong -> service flow with the kong-oidc plugin authenticating
+# against Keycloak.
+#
+# Idempotent: uses PUT for services/routes (upsert by name) and replaces the
+# oidc plugin on each run so config edits in this script take effect after a
+# `docker compose restart kong-bootstrap`.
+#
+# Run inside the compose network (kong/keycloak/web hostnames are reachable).
+
+set -eu
+
+KONG_ADMIN="${KONG_ADMIN:-http://kong:8001}"
+KEYCLOAK_DISCOVERY="${KEYCLOAK_DISCOVERY:-http://keycloak:8080/auth/realms/cdip-dev/.well-known/openid-configuration}"
+OIDC_CLIENT_ID="${OIDC_CLIENT_ID:-cdip-kong-gateway}"
+OIDC_CLIENT_SECRET="${OIDC_CLIENT_SECRET:-dev-kong-oidc-secret}"
+# kong-oidc requires session_secret to be base64-encoded 32 raw bytes
+# (lua-resty-session decodes it). This is a fixed dev secret — never reused
+# anywhere with real auth value.
+OIDC_SESSION_SECRET="${OIDC_SESSION_SECRET:-D5+sOKjh/60/ysGpZoiGsyUSicdU8+UXQP3L1v2GiAA=}"
+WEB_HOST="${WEB_HOST:-web.127.0.0.1.nip.io}"
+WEB_UPSTREAM_URL="${WEB_UPSTREAM_URL:-http://web:8888}"
+
+echo "[bootstrap-kong] waiting for Kong Admin API at $KONG_ADMIN ..."
+until curl -fsS "$KONG_ADMIN/status" >/dev/null 2>&1; do
+    sleep 2
+done
+echo "[bootstrap-kong] Kong Admin API ready."
+
+echo "[bootstrap-kong] waiting for Keycloak discovery at $KEYCLOAK_DISCOVERY ..."
+until curl -fsS "$KEYCLOAK_DISCOVERY" >/dev/null 2>&1; do
+    sleep 2
+done
+echo "[bootstrap-kong] Keycloak realm import complete."
+
+echo "[bootstrap-kong] upserting service cdip-web -> $WEB_UPSTREAM_URL"
+curl -fsS -o /dev/null -X PUT "$KONG_ADMIN/services/cdip-web" \
+    --data "url=$WEB_UPSTREAM_URL"
+
+echo "[bootstrap-kong] upserting route cdip-web-route on host $WEB_HOST"
+curl -fsS -o /dev/null -X PUT "$KONG_ADMIN/services/cdip-web/routes/cdip-web-route" \
+    --data "hosts[]=$WEB_HOST" \
+    --data "preserve_host=true" \
+    --data "strip_path=false"
+
+# Tear down any existing plugins on this route (e.g. an oidc plugin from an
+# earlier run with a different randomly-assigned id). Filter to UUIDs that
+# correspond to plugins specifically — the API response also contains
+# route.id; DELETE on a non-plugin uuid returns 404 which we ignore.
+echo "[bootstrap-kong] tearing down existing plugins on cdip-web-route"
+curl -fsS "$KONG_ADMIN/routes/cdip-web-route/plugins" 2>/dev/null \
+    | tr ',{}' '\n' | grep -oE '"id":"[0-9a-f-]{36}"' | cut -d'"' -f4 | sort -u \
+    | while read pid; do
+        curl -sS -o /dev/null -X DELETE "$KONG_ADMIN/plugins/$pid" || true
+    done
+
+echo "[bootstrap-kong] upserting oidc plugin (bearer_only=no, browser SSO)"
+# Stable plugin id so PUT acts as an upsert — re-running this script just
+# overwrites the config in place, no find-and-delete needed.
+# bearer_only=no -> kong-oidc redirects unauthenticated browser requests to
+# Keycloak and sets a session cookie; on success it injects X-Userinfo upstream
+# which Django's SimpleUserInfoBackend reads.
+OIDC_PLUGIN_ID="11111111-2222-3333-4444-555555555555"
+# --data-urlencode (not --data) so values with + / = (esp. base64
+# session_secret) survive the form-encode/decode round-trip intact.
+curl -fsS -o /dev/null -X PUT "$KONG_ADMIN/plugins/$OIDC_PLUGIN_ID" \
+    --data-urlencode "name=oidc" \
+    --data-urlencode "route.name=cdip-web-route" \
+    --data-urlencode "config.client_id=$OIDC_CLIENT_ID" \
+    --data-urlencode "config.client_secret=$OIDC_CLIENT_SECRET" \
+    --data-urlencode "config.discovery=$KEYCLOAK_DISCOVERY" \
+    --data-urlencode "config.realm=cdip-dev" \
+    --data-urlencode "config.bearer_only=no" \
+    --data-urlencode "config.session_secret=$OIDC_SESSION_SECRET" \
+    --data-urlencode "config.scope=openid email profile" \
+    --data-urlencode "config.ssl_verify=no" \
+    --data-urlencode "config.token_endpoint_auth_method=client_secret_post"
+
+echo "[bootstrap-kong] done."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,308 @@
+services:
+  # PostgreSQL Database
+  postgres:
+    image: postgis/postgis:12-3.0
+    container_name: cdip-postgres
+    environment:
+      POSTGRES_DB: cdip_portaldb
+      POSTGRES_USER: cdip_dbuser
+      POSTGRES_PASSWORD: cdip_dbpassword
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U cdip_dbuser"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # Redis for Celery
+  redis:
+    image: redis:7-alpine
+    container_name: cdip-redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # Keycloak for Authentication
+  keycloak:
+    image: quay.io/keycloak/keycloak:23.0
+    container_name: cdip-keycloak
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_DB: postgres
+      KC_DB_URL: jdbc:postgresql://keycloak-db:5432/keycloak
+      KC_DB_USERNAME: keycloak
+      KC_DB_PASSWORD: keycloak
+      KC_HOSTNAME_STRICT: "false"
+      KC_HOSTNAME_STRICT_HTTPS: "false"
+      KC_HTTP_ENABLED: "true"
+      KC_HEALTH_ENABLED: "true"
+    command:
+      - start-dev
+      - --proxy=edge
+    ports:
+      - "8080:8080"
+    depends_on:
+      keycloak-db:
+        condition: service_healthy
+    restart: on-failure
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/8080 && echo -e 'GET /health/ready HTTP/1.1\\r\\nHost: localhost:8080\\r\\nConnection: close\\r\\n\\r\\n' >&3 && grep -m 1 '\"status\": *\"UP\"' <&3"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 90s
+
+  # Keycloak Database
+  keycloak-db:
+    image: postgres:12-alpine
+    container_name: cdip-keycloak-db
+    environment:
+      POSTGRES_DB: keycloak
+      POSTGRES_USER: keycloak
+      POSTGRES_PASSWORD: keycloak
+    volumes:
+      - keycloak_db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U keycloak -d keycloak"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # Kong Database
+  kong-db:
+    image: postgres:12-alpine
+    container_name: cdip-kong-db
+    environment:
+      POSTGRES_DB: kong
+      POSTGRES_USER: kong
+      POSTGRES_PASSWORD: kong
+    volumes:
+      - kong_db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U kong -d kong"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # Kong Migrations
+  kong-migrations:
+    build:
+      context: /Users/chrisdo/padas/gundi-kp-dynamic-routing
+      dockerfile: Dockerfile.local
+    container_name: cdip-kong-migrations
+    command: kong migrations bootstrap
+    environment:
+      KONG_DATABASE: postgres
+      KONG_PG_HOST: kong-db
+      KONG_PG_DATABASE: kong
+      KONG_PG_USER: kong
+      KONG_PG_PASSWORD: kong
+    depends_on:
+      kong-db:
+        condition: service_healthy
+    restart: on-failure
+
+  # Kong API Gateway
+  kong:
+    build:
+      context: /Users/chrisdo/padas/gundi-kp-dynamic-routing
+      dockerfile: Dockerfile.local
+    container_name: cdip-kong
+    environment:
+      KONG_DATABASE: postgres
+      KONG_PG_HOST: kong-db
+      KONG_PG_DATABASE: kong
+      KONG_PG_USER: kong
+      KONG_PG_PASSWORD: kong
+      KONG_PROXY_ACCESS_LOG: /dev/stdout
+      KONG_ADMIN_ACCESS_LOG: /dev/stdout
+      KONG_PROXY_ERROR_LOG: /dev/stderr
+      KONG_ADMIN_ERROR_LOG: /dev/stderr
+      KONG_ADMIN_LISTEN: "0.0.0.0:8001"
+      KONG_ADMIN_GUI_URL: "http://localhost:8002"
+    ports:
+      - "8000:8000"  # Proxy port
+      - "8443:8443"  # Proxy SSL port
+      - "8001:8001"  # Admin API port
+      - "8444:8444"  # Admin API SSL port
+      - "8002:8002"  # Kong Manager UI
+    depends_on:
+      kong-db:
+        condition: service_healthy
+      kong-migrations:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD", "kong", "health"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+
+  # Django Application
+  web:
+    build:
+      context: .
+      dockerfile: ./Dockerfile.dev
+    container_name: cdip-web
+    command: python3.11 manage.py runserver 0.0.0.0:8888
+    volumes:
+      - ./cdip_admin:/var/www/app
+      - static_files:/var/www/static
+    ports:
+      - "8888:8888"
+    environment:
+      DEBUG: "True"
+      SECRET_KEY: "local-dev-secret-key-change-in-production"
+      DB_NAME: cdip_portaldb
+      DB_USER: cdip_dbuser
+      DB_PASSWORD: cdip_dbpassword
+      DB_HOST: postgres
+      DB_PORT: "5432"
+      REDIS_HOST: redis
+      REDIS_PORT: "6379"
+      CELERY_BROKER_URL: "redis://redis:6379/0"
+      KEYCLOAK_SERVER: "http://keycloak:8080"
+      KEYCLOAK_REALM: "cdip-dev"
+      KEYCLOAK_CLIENT_ID: "cdip-admin-portal"
+      KEYCLOAK_CLIENT_SECRET: "local-dev-secret"
+      KEYCLOAK_ADMIN_CLIENT_ID: "admin-cli"
+      KEYCLOAK_ADMIN_CLIENT_SECRET: "local-dev-admin-secret"
+      KONG_PROXY_URL: "http://kong:8001"
+      ALLOWED_HOSTS: "localhost,127.0.0.1,web"
+      SECURE_PROXY_SSL_HEADER: ""
+      GCP_ENVIRONMENT_ENABLED: "False"
+      TRACING_ENABLED: "False"
+      PUBSUB_ENABLED: "False"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    stdin_open: true
+    tty: true
+
+  # Celery Worker
+  celery:
+    build:
+      context: .
+      dockerfile: ./Dockerfile.dev
+    container_name: cdip-celery
+    command: celery -A cdip_admin worker -l info
+    volumes:
+      - ./cdip_admin:/var/www/app
+    environment:
+      DEBUG: "True"
+      SECRET_KEY: "local-dev-secret-key-change-in-production"
+      DB_NAME: cdip_portaldb
+      DB_USER: cdip_dbuser
+      DB_PASSWORD: cdip_dbpassword
+      DB_HOST: postgres
+      DB_PORT: "5432"
+      REDIS_HOST: redis
+      REDIS_PORT: "6379"
+      CELERY_BROKER_URL: "redis://redis:6379/0"
+      KEYCLOAK_SERVER: "http://keycloak:8080"
+      KEYCLOAK_REALM: "cdip-dev"
+      KEYCLOAK_CLIENT_ID: "cdip-admin-portal"
+      KEYCLOAK_CLIENT_SECRET: "local-dev-secret"
+      KEYCLOAK_ADMIN_CLIENT_ID: "admin-cli"
+      KEYCLOAK_ADMIN_CLIENT_SECRET: "local-dev-admin-secret"
+      GCP_ENVIRONMENT_ENABLED: "False"
+      TRACING_ENABLED: "False"
+      PUBSUB_ENABLED: "False"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  # Celery Beat (Scheduler)
+  celery-beat:
+    build:
+      context: .
+      dockerfile: ./Dockerfile.dev
+    container_name: cdip-celery-beat
+    command: celery -A cdip_admin beat -l info
+    volumes:
+      - ./cdip_admin:/var/www/app
+    environment:
+      DEBUG: "True"
+      SECRET_KEY: "local-dev-secret-key-change-in-production"
+      DB_NAME: cdip_portaldb
+      DB_USER: cdip_dbuser
+      DB_PASSWORD: cdip_dbpassword
+      DB_HOST: postgres
+      DB_PORT: "5432"
+      REDIS_HOST: redis
+      REDIS_PORT: "6379"
+      CELERY_BROKER_URL: "redis://redis:6379/0"
+      GCP_ENVIRONMENT_ENABLED: "False"
+      TRACING_ENABLED: "False"
+      PUBSUB_ENABLED: "False"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  # Gundi Portal (React frontend)
+  portal:
+    build:
+      context: /Users/chrisdo/padas/gundi-portal
+      dockerfile: Dockerfile
+    container_name: cdip-portal
+    volumes:
+      - /Users/chrisdo/padas/gundi-portal/src:/app/src
+      - /Users/chrisdo/padas/gundi-portal/public:/app/public
+      - portal_node_modules:/app/node_modules
+    ports:
+      - "3000:3000"
+    environment:
+      HOST: "0.0.0.0"
+      REACT_APP_BASE_URL_LOCAL: "https://web.127.0.0.1.nip.io"
+      REACT_APP_OIDC_REALM: "cdip-dev"
+      REACT_APP_OIDC_CLIENT_ID: "cdip-oauth2"
+      REACT_APP_OIDC_AUTH_URL: "https://keycloak.127.0.0.1.nip.io/auth"
+      CHOKIDAR_USEPOLLING: "true"
+      WATCHPACK_POLLING: "true"
+    depends_on:
+      - web
+      - keycloak
+
+  # Caddy Reverse Proxy with Automatic HTTPS
+  caddy:
+    image: caddy:2-alpine
+    container_name: cdip-caddy
+    ports:
+      - "443:443"   # HTTPS
+      - "80:80"     # HTTP (redirects to HTTPS)
+      - "2019:2019" # Caddy admin API
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - keycloak
+      - kong
+      - web
+      - portal
+    restart: unless-stopped
+
+volumes:
+  postgres_data:
+  redis_data:
+  keycloak_db_data:
+  kong_db_data:
+  static_files:
+  caddy_data:
+  caddy_config:
+  portal_node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -288,9 +288,9 @@ services:
     image: caddy:2-alpine
     container_name: cdip-caddy
     ports:
-      - "443:443"   # HTTPS
-      - "80:80"     # HTTP (redirects to HTTPS)
-      - "2019:2019" # Caddy admin API
+      - "443:443"             # HTTPS
+      - "80:80"               # HTTP (redirects to HTTPS)
+      - "127.0.0.1:2019:2019" # Caddy admin API (localhost only — exposes config rewrite)
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
       - caddy_data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -291,8 +291,16 @@ services:
       redis:
         condition: service_healthy
 
-  # Gundi Portal (React frontend)
+  # Gundi Portal (React frontend) — opt-in.
+  # Lives in a separate sibling repo (gundi-portal). Default-disabled so the
+  # stack still comes up cleanly when that repo isn't checked out next to this
+  # one. To enable, point PORTAL_DIR at your local clone (in .env or env) and
+  # opt into the profile:
+  #   COMPOSE_PROFILES=portal docker compose up -d portal
+  # or:
+  #   docker compose --profile portal up -d portal
   portal:
+    profiles: ["portal"]
     build:
       context: ${PORTAL_DIR:-../gundi-portal}
       dockerfile: Dockerfile
@@ -331,7 +339,9 @@ services:
       - keycloak
       - kong
       - web
-      - portal
+      # portal is opt-in via the "portal" profile — leaving it out of
+      # depends_on so caddy comes up regardless. The portal.* Caddy block
+      # will 502 until you start the portal explicitly.
     restart: unless-stopped
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,9 @@ services:
       KC_HOSTNAME_STRICT_HTTPS: "false"
       KC_HTTP_ENABLED: "true"
       KC_HEALTH_ENABLED: "true"
+      # The portal builds Keycloak URLs as ${KEYCLOAK_SERVER}/auth/... so
+      # serve Keycloak under the /auth prefix to match.
+      KC_HTTP_RELATIVE_PATH: "/auth"
     command:
       - start-dev
       - --proxy=edge
@@ -56,7 +59,7 @@ services:
         condition: service_healthy
     restart: on-failure
     healthcheck:
-      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/8080 && echo -e 'GET /health/ready HTTP/1.1\\r\\nHost: localhost:8080\\r\\nConnection: close\\r\\n\\r\\n' >&3 && grep -m 1 '\"status\": *\"UP\"' <&3"]
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/8080 && echo -e 'GET /auth/health/ready HTTP/1.1\\r\\nHost: localhost:8080\\r\\nConnection: close\\r\\n\\r\\n' >&3 && grep -m 1 '\"status\": *\"UP\"' <&3"]
       interval: 30s
       timeout: 10s
       retries: 10
@@ -97,7 +100,7 @@ services:
   # Kong Migrations
   kong-migrations:
     build:
-      context: /Users/chrisdo/padas/gundi-kp-dynamic-routing
+      context: ${KONG_DIR:-../gundi-kp-dynamic-routing}
       dockerfile: Dockerfile.local
     container_name: cdip-kong-migrations
     command: kong migrations bootstrap
@@ -115,7 +118,7 @@ services:
   # Kong API Gateway
   kong:
     build:
-      context: /Users/chrisdo/padas/gundi-kp-dynamic-routing
+      context: ${KONG_DIR:-../gundi-kp-dynamic-routing}
       dockerfile: Dockerfile.local
     container_name: cdip-kong
     environment:
@@ -177,7 +180,7 @@ services:
       KEYCLOAK_ADMIN_CLIENT_ID: "admin-cli"
       KEYCLOAK_ADMIN_CLIENT_SECRET: "local-dev-admin-secret"
       KONG_PROXY_URL: "http://kong:8001"
-      ALLOWED_HOSTS: "localhost,127.0.0.1,web"
+      ALLOWED_HOSTS: "localhost,127.0.0.1,web,web.127.0.0.1.nip.io"
       SECURE_PROXY_SSL_HEADER: ""
       GCP_ENVIRONMENT_ENABLED: "False"
       TRACING_ENABLED: "False"
@@ -257,12 +260,12 @@ services:
   # Gundi Portal (React frontend)
   portal:
     build:
-      context: /Users/chrisdo/padas/gundi-portal
+      context: ${PORTAL_DIR:-../gundi-portal}
       dockerfile: Dockerfile
     container_name: cdip-portal
     volumes:
-      - /Users/chrisdo/padas/gundi-portal/src:/app/src
-      - /Users/chrisdo/padas/gundi-portal/public:/app/public
+      - ${PORTAL_DIR:-../gundi-portal}/src:/app/src
+      - ${PORTAL_DIR:-../gundi-portal}/public:/app/public
       - portal_node_modules:/app/node_modules
     ports:
       - "3000:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,9 @@ services:
         condition: service_healthy
     restart: on-failure
     healthcheck:
-      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/8080 && echo -e 'GET /auth/health/ready HTTP/1.1\\r\\nHost: localhost:8080\\r\\nConnection: close\\r\\n\\r\\n' >&3 && grep -m 1 '\"status\": *\"UP\"' <&3"]
+      # CMD-SHELL routes through /bin/sh which doesn't support /dev/tcp; invoke
+      # bash explicitly so the redirection works in the Keycloak (Quarkus) image.
+      test: ["CMD", "bash", "-lc", "exec 3<>/dev/tcp/localhost/8080 && echo -e 'GET /auth/health/ready HTTP/1.1\\r\\nHost: localhost:8080\\r\\nConnection: close\\r\\n\\r\\n' >&3 && grep -m 1 '\"status\": *\"UP\"' <&3"]
       interval: 30s
       timeout: 10s
       retries: 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,12 @@ services:
       KC_DB_PASSWORD: keycloak
       KC_HOSTNAME_STRICT: "false"
       KC_HOSTNAME_STRICT_HTTPS: "false"
+      # Public URL the browser hits (via Caddy). Without this, Keycloak's
+      # discovery doc advertises authorization_endpoint as http://keycloak:8080
+      # (the internal docker hostname) and the browser-side redirect from kong-oidc
+      # fails to resolve.
+      KC_HOSTNAME_URL: "https://keycloak.127.0.0.1.nip.io/auth"
+      KC_HOSTNAME_ADMIN_URL: "https://keycloak.127.0.0.1.nip.io/auth"
       KC_HTTP_ENABLED: "true"
       KC_HEALTH_ENABLED: "true"
       # The portal builds Keycloak URLs as ${KEYCLOAK_SERVER}/auth/... so
@@ -52,8 +58,11 @@ services:
     command:
       - start-dev
       - --proxy=edge
+      - --import-realm
     ports:
       - "8080:8080"
+    volumes:
+      - ./keycloak/cdip-dev-realm.json:/opt/keycloak/data/import/cdip-dev-realm.json:ro
     depends_on:
       keycloak-db:
         condition: service_healthy
@@ -135,6 +144,13 @@ services:
       KONG_ADMIN_ERROR_LOG: /dev/stderr
       KONG_ADMIN_LISTEN: "0.0.0.0:8001"
       KONG_ADMIN_GUI_URL: "http://localhost:8002"
+      # Caddy sits in front and terminates TLS. Trust its X-Forwarded-* so
+      # kong-oidc builds redirect URIs against the public https host the
+      # browser actually used (https://web.127.0.0.1.nip.io) — not the
+      # internal http://kong:8000.
+      KONG_TRUSTED_IPS: "0.0.0.0/0,::/0"
+      KONG_REAL_IP_HEADER: "X-Forwarded-For"
+      KONG_REAL_IP_RECURSIVE: "on"
     ports:
       - "8000:8000"  # Proxy port
       - "8443:8443"  # Proxy SSL port
@@ -151,6 +167,22 @@ services:
       interval: 10s
       timeout: 10s
       retries: 10
+
+  # One-shot: registers cdip-web service/route and the oidc plugin on Kong
+  # via the Admin API. Idempotent — safe to restart this service to re-apply
+  # config from dev/bootstrap-kong.sh.
+  kong-bootstrap:
+    image: curlimages/curl:8.10.1
+    container_name: cdip-kong-bootstrap
+    depends_on:
+      kong:
+        condition: service_healthy
+      keycloak:
+        condition: service_healthy
+    volumes:
+      - ./dev/bootstrap-kong.sh:/bootstrap-kong.sh:ro
+    entrypoint: ["sh", "/bootstrap-kong.sh"]
+    restart: "no"
 
   # Django Application
   web:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -179,6 +179,10 @@ services:
         condition: service_healthy
       keycloak:
         condition: service_healthy
+    environment:
+      # Kong-oidc session_secret — required, base64 of 32 random bytes.
+      # Set in .env at the worktree root; never committed.
+      OIDC_SESSION_SECRET: ${OIDC_SESSION_SECRET}
     volumes:
       - ./dev/bootstrap-kong.sh:/bootstrap-kong.sh:ro
     entrypoint: ["sh", "/bootstrap-kong.sh"]

--- a/keycloak/cdip-dev-realm.json
+++ b/keycloak/cdip-dev-realm.json
@@ -81,6 +81,28 @@
       "standardFlowEnabled": true,
       "directAccessGrantsEnabled": true,
       "protocol": "openid-connect"
+    },
+    {
+      "clientId": "cdip-oauth2",
+      "name": "CDIP React Portal",
+      "description": "Public SPA client used by the React portal (REACT_APP_OIDC_CLIENT_ID).",
+      "enabled": true,
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "redirectUris": [
+        "https://portal.127.0.0.1.nip.io/*",
+        "http://localhost:3000/*"
+      ],
+      "webOrigins": [
+        "https://portal.127.0.0.1.nip.io",
+        "http://localhost:3000"
+      ],
+      "protocol": "openid-connect",
+      "attributes": {
+        "pkce.code.challenge.method": "S256",
+        "post.logout.redirect.uris": "https://portal.127.0.0.1.nip.io/*##http://localhost:3000/*"
+      }
     }
   ],
   "users": [

--- a/keycloak/cdip-dev-realm.json
+++ b/keycloak/cdip-dev-realm.json
@@ -1,0 +1,106 @@
+{
+  "realm": "cdip-dev",
+  "enabled": true,
+  "displayName": "CDIP Dev",
+  "registrationAllowed": false,
+  "resetPasswordAllowed": true,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "sslRequired": "external",
+  "accessTokenLifespan": 1800,
+  "ssoSessionIdleTimeout": 43200,
+  "ssoSessionMaxLifespan": 86400,
+  "clients": [
+    {
+      "clientId": "cdip-kong-gateway",
+      "name": "CDIP Kong Gateway",
+      "description": "OIDC client used by the kong-oidc plugin to authenticate browser sessions and validate API bearer tokens.",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "dev-kong-oidc-secret",
+      "redirectUris": [
+        "https://web.127.0.0.1.nip.io/*",
+        "http://localhost:8000/*"
+      ],
+      "webOrigins": [
+        "https://web.127.0.0.1.nip.io"
+      ],
+      "publicClient": false,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "https://web.127.0.0.1.nip.io/*"
+      },
+      "protocolMappers": [
+        {
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "client_id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "clientId": "cdip-admin-portal",
+      "name": "CDIP Admin Portal (legacy direct-Django client)",
+      "description": "Kept for the legacy social-auth path referenced in settings; the active flow goes through cdip-kong-gateway.",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "local-dev-secret",
+      "redirectUris": [
+        "https://web.127.0.0.1.nip.io/*"
+      ],
+      "webOrigins": [
+        "https://web.127.0.0.1.nip.io"
+      ],
+      "publicClient": false,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "protocol": "openid-connect"
+    }
+  ],
+  "users": [
+    {
+      "username": "dev",
+      "email": "dev@local.dev",
+      "emailVerified": true,
+      "enabled": true,
+      "firstName": "Dev",
+      "lastName": "User",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "dev",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "default-roles-cdip-dev"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR is meant to reveal Dispatcher Deployment failures, including by setting a Connection as unhealthy when a dispatcher is undeployable.

The next story will be to make the deployment process resilient to disturbances like failed deployments or quota limits.

## Summary

This PR contains **two scopes** layered on the same branch (the prior commit `3e503a8c` introduced the dev-stack tooling; the deployment-tracking work was added on top):

### Dispatcher deployment failure tracking — primary feature

- **Classify deployment failures** — `deploy_serverless_dispatcher` now categorizes errors as `quota_exhausted` / `transient` / `config_error` / `unknown` and persists the full traceback in a new `last_error` TextField (the existing `status_details` is capped at 500 chars and was truncating stack traces).
- **Surface failures in connection health** — every deployment failure writes an `origin=DISPATCHER`, level=`ERROR` `ActivityLog` tied to the v2 Integration, with a distinct slug for the quota case (`dispatcher_quota_exhausted`). Existing health/connection plumbing picks these up automatically.
- **Mark integrations UNHEALTHY immediately** when their dispatcher is in `ERROR` — `calculate_integration_status` short-circuits with quota-aware `status_details` so a single quota failure doesn't have to wait 3 activity-log errors to surface.
- **Stop accumulating orphaned topics on quota retries** — when Cloud Run hits 429, the topic created in that run is deleted so retries don't pile up dangling PubSub topics in GCP.
- **Operator visibility in admin** — new `failure_reason`, `attempt_count`, `last_attempt_at` columns and a `failure_reason` filter, so "all deployments blocked on quota" is one click.

### Local development stack — inherited from prior commit on this branch

The PR also carries `Caddyfile`, `Dockerfile.dev`, `docker-compose.yml`, and `dev.sh` from commit `3e503a8c`. These set up a local `docker-compose` stack (Postgres / Redis / Keycloak / Kong / Portal / Caddy) so the failure-tracking work could be tested end-to-end without standing up GCP. Several review comments target portability of these files (absolute `/Users/chrisdo` paths, missing Keycloak relative path, ALLOWED_HOSTS, dev.sh env template). Those fixes are included.

If a separate PR for the dev stack is preferred, I can split the branch — but since both scopes are already on `dispatcher-deployments-refresh` and the dev stack was the means of validating the feature, keeping them together is the simpler ship.

## Why

When the GCP region's Cloud Run service ceiling (1000) is hit, deployments quietly land in `ERROR` with a truncated message in `status_details`, the topic stays orphaned in GCP, and the connection still shows healthy until 3 activity-log errors accumulate. Operators don't see the bottleneck and retries make the orphan-topic problem worse.

## What's NOT in this slice (deliberately)

- No autoretry/backoff inside the task.
- No reconciliation Celery beat task to re-drive stuck/failed rows.
- No Cloud Run quota pre-flight check.
- No region failover.

These are the next slice; this one closes the orphaned-topic accumulation, the truncated-error blind spot, and the visibility gap with minimal blast radius.

## Test plan

- [x] Classifier unit tests cover `ResourceExhausted`, `TooManyRequests`, the plain-`Exception`-with-quota-message form (real-world LRO shape), `InvalidArgument`/`PermissionDenied` (config), `DeadlineExceeded`/`ServiceUnavailable` (transient), and unknown.
- [x] Task-level tests: 429 → `ERROR + QUOTA_EXHAUSTED`, full traceback in `last_error`, topic deleted, no subscription created.
- [x] Topic cleanup is skipped when the topic already existed (`AlreadyExists`).
- [x] `ActivityLog` written on quota failure with origin=`DISPATCHER`, level=`ERROR`, slug=`dispatcher_quota_exhausted`, structured `details`.
- [x] `ActivityLog` written on non-quota failures with slug=`dispatcher_deploy_failed`.
- [x] `calculate_integration_status` returns `UNHEALTHY` with quota-aware `status_details` when dispatcher is in `ERROR/QUOTA_EXHAUSTED`.
- [x] `calculate_integration_status` returns `HEALTHY` when dispatcher is `COMPLETE` (no false positives from the new short-circuit).
- [x] Full `deployments/` test suite: 47 passed, 1 skipped — no regressions in existing automatic-deployment / management-command tests.
- [ ] Manual: trigger a real quota error in dev, confirm admin filter shows the row and the connection flips to UNHEALTHY in the API.

## Migration

`deployments/migrations/0009_deployment_failure_tracking.py` adds `failure_reason`, `last_error`, `attempt_count`, `last_attempt_at`. All `AddField` with safe defaults — no data backfill required, safe rollback.

## Review comments addressed

| # | Comment | Fix | Commit |
|---|---|---|---|
| C1 | "Error deploying function" misleading for Cloud Run | Renamed to "Error deploying dispatcher" | `17d684db` |
| C2 | Dev-stack scope vs PR description | This PR description update | (this edit) |
| C3 | Kong absolute `/Users/chrisdo` path | `${KONG_DIR:-../gundi-kp-dynamic-routing}` | `17d684db` |
| C4 | Keycloak `/auth` relative path missing | Added `KC_HTTP_RELATIVE_PATH=/auth` + healthcheck update | `17d684db` |
| C5 | `ALLOWED_HOSTS` missing nip.io | Added `web.127.0.0.1.nip.io` | `17d684db` |
| C6 | `dev.sh` references missing `.env.local` | Use `cdip_admin/cdip_admin/.env.example` | `17d684db` |
| C7 | `getattr` on OneToOne descriptor unsafe | `DispatcherDeployment.objects.filter(...).first()` | `17d684db` |
| C8 | `last_error` only stores `str(e)` | Now stores `traceback.format_exc()` | `17d684db` |
| C9 | Portal absolute `/Users/chrisdo` path | `${PORTAL_DIR:-../gundi-portal}` for context + volumes | `17d684db` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)