### PR TITLE
fix(ci): bump gundi-workflows references from v2 to v5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
           echo "repository=us-central1-docker.pkg.dev/cdip-78ca/gundi/admin-portal" >> $GITHUB_OUTPUT
 
   build:
-    uses: PADAS/gundi-workflows/.github/workflows/build_docker.yml@v2
+    uses: PADAS/gundi-workflows/.github/workflows/build_docker.yml@v5
     needs: vars
     with:
       environment: stage
@@ -30,7 +30,7 @@ jobs:
       tag: ${{ needs.vars.outputs.tag }}
 
   deploy_dev:
-    uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v2
+    uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v5
     if: startsWith(github.ref, 'refs/heads/main')
     needs: [vars, build]
     with:
@@ -42,7 +42,7 @@ jobs:
     secrets: inherit
 
   deploy_stage:
-    uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v2
+    uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v5
     if: startsWith(github.ref, 'refs/heads/release')
     needs: [vars, build]
     with:
@@ -54,7 +54,7 @@ jobs:
     secrets: inherit
 
   deploy_dev_legacy:
-    uses: PADAS/gundi-workflows/.github/workflows/update_k8s_image.yml@v2
+    uses: PADAS/gundi-workflows/.github/workflows/update_k8s_image.yml@v5
     if: false  # Temporarily disabled
     # if: startsWith(github.ref, 'refs/heads/release')
     needs: [vars, build]
@@ -76,7 +76,7 @@ jobs:
     secrets: inherit
 
   deploy_prod:
-    uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v2
+    uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v5
     if: startsWith(github.ref, 'refs/heads/release')
     needs: [vars, build, deploy_stage]
     with:
@@ -88,7 +88,7 @@ jobs:
     secrets: inherit
 
   deploy_prod_legacy:
-    uses: PADAS/gundi-workflows/.github/workflows/update_k8s_image.yml@v2
+    uses: PADAS/gundi-workflows/.github/workflows/update_k8s_image.yml@v5
     if: startsWith(github.ref, 'refs/heads/release')
     needs: [vars, build, deploy_stage]
     strategy:


### PR DESCRIPTION
## Summary

Bumps all \`gundi-workflows\` references from \`@v2\` to \`@v5\` to pick up the Connect Gateway fix for GKE cluster access.

## Changes

### Changed
- \`.github/workflows/main.yml\`: all 6 \`gundi-workflows\` references updated from \`@v2\` to \`@v5\`

## Technical Details

\`v5\` of \`gundi-workflows\` switches \`deploy_k8s.yml\` and \`update_k8s_image.yml\` to use GKE Fleet Connect Gateway instead of direct cluster endpoint access. This was required after master authorized networks were restricted on Gundi GKE clusters, blocking GitHub Actions runner IPs.

IAM prerequisite (already applied via serca-iac PR #459): \`gkehub.gatewayEditor\` on \`serca-tools\` granted to \`cdip-gh-oidc\` in all environments.

## Files Changed

**1 file changed, 6 insertions(+), 6 deletions(-)**