### PR TITLE
fix(ci): bump gundi-workflows references from v5 to v6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
           echo "repository=us-central1-docker.pkg.dev/cdip-78ca/gundi/admin-portal" >> $GITHUB_OUTPUT
 
   build:
-    uses: PADAS/gundi-workflows/.github/workflows/build_docker.yml@v5
+    uses: PADAS/gundi-workflows/.github/workflows/build_docker.yml@v6
     needs: vars
     with:
       environment: stage
@@ -30,7 +30,7 @@ jobs:
       tag: ${{ needs.vars.outputs.tag }}
 
   deploy_dev:
-    uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v5
+    uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v6
     if: startsWith(github.ref, 'refs/heads/main')
     needs: [vars, build]
     with:
@@ -42,7 +42,7 @@ jobs:
     secrets: inherit
 
   deploy_stage:
-    uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v5
+    uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v6
     if: startsWith(github.ref, 'refs/heads/release')
     needs: [vars, build]
     with:
@@ -54,7 +54,7 @@ jobs:
     secrets: inherit
 
   deploy_dev_legacy:
-    uses: PADAS/gundi-workflows/.github/workflows/update_k8s_image.yml@v5
+    uses: PADAS/gundi-workflows/.github/workflows/update_k8s_image.yml@v6
     if: false  # Temporarily disabled
     # if: startsWith(github.ref, 'refs/heads/release')
     needs: [vars, build]
@@ -76,7 +76,7 @@ jobs:
     secrets: inherit
 
   deploy_prod:
-    uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v5
+    uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v6
     if: startsWith(github.ref, 'refs/heads/release')
     needs: [vars, build, deploy_stage]
     with:
@@ -88,7 +88,7 @@ jobs:
     secrets: inherit
 
   deploy_prod_legacy:
-    uses: PADAS/gundi-workflows/.github/workflows/update_k8s_image.yml@v5
+    uses: PADAS/gundi-workflows/.github/workflows/update_k8s_image.yml@v6
     if: startsWith(github.ref, 'refs/heads/release')
     needs: [vars, build, deploy_stage]
     strategy:


### PR DESCRIPTION
## Summary

Bumps \`gundi-workflows\` references from \`@v5\` to \`@v6\` to pick up the corrected Connect Gateway credential setup.

## Changes

### Changed
- \`.github/workflows/main.yml\`: all 6 \`gundi-workflows\` references updated from \`@v5\` to \`@v6\`

## Technical Details

\`v5\` used \`google-github-actions/get-gke-credentials\` with \`location: global\`, which failed with _"location global does not exist"_ — the action interprets \`location\` as a GKE cluster region, not a fleet membership location.

\`v6\` replaces that step with a direct \`gcloud container fleet memberships get-credentials\` call, which has no location ambiguity and is consistent with how Connect Gateway is used locally.