### PR TITLE
fix(ci): bump gundi-workflows references to v7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
           echo "repository=us-central1-docker.pkg.dev/cdip-78ca/gundi/admin-portal" >> $GITHUB_OUTPUT
 
   build:
-    uses: PADAS/gundi-workflows/.github/workflows/build_docker.yml@v6
+    uses: PADAS/gundi-workflows/.github/workflows/build_docker.yml@v7
     needs: vars
     with:
       environment: stage
@@ -30,7 +30,7 @@ jobs:
       tag: ${{ needs.vars.outputs.tag }}
 
   deploy_dev:
-    uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v6
+    uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v7
     if: startsWith(github.ref, 'refs/heads/main')
     needs: [vars, build]
     with:
@@ -42,7 +42,7 @@ jobs:
     secrets: inherit
 
   deploy_stage:
-    uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v6
+    uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v7
     if: startsWith(github.ref, 'refs/heads/release')
     needs: [vars, build]
     with:
@@ -54,7 +54,7 @@ jobs:
     secrets: inherit
 
   deploy_dev_legacy:
-    uses: PADAS/gundi-workflows/.github/workflows/update_k8s_image.yml@v6
+    uses: PADAS/gundi-workflows/.github/workflows/update_k8s_image.yml@v7
     if: false  # Temporarily disabled
     # if: startsWith(github.ref, 'refs/heads/release')
     needs: [vars, build]
@@ -76,7 +76,7 @@ jobs:
     secrets: inherit
 
   deploy_prod:
-    uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v6
+    uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v7
     if: startsWith(github.ref, 'refs/heads/release')
     needs: [vars, build, deploy_stage]
     with:
@@ -88,7 +88,7 @@ jobs:
     secrets: inherit
 
   deploy_prod_legacy:
-    uses: PADAS/gundi-workflows/.github/workflows/update_k8s_image.yml@v6
+    uses: PADAS/gundi-workflows/.github/workflows/update_k8s_image.yml@v7
     if: startsWith(github.ref, 'refs/heads/release')
     needs: [vars, build, deploy_stage]
     strategy:


### PR DESCRIPTION
## Summary

Bumps \`gundi-workflows\` references from \`@v6\` to \`@v7\` to install the \`gke-gcloud-auth-plugin\` required by kubectl when using Connect Gateway credentials.

## Changes

### Changed
- \`.github/workflows/main.yml\`: all 6 \`gundi-workflows\` references updated from \`@v6\` to \`@v7\`

## Technical Details

\`v6\` established the Connect Gateway kubeconfig correctly but kubectl then failed with _"gke-gcloud-auth-plugin not found"_ — the plugin is required for any \`kubectl\` or \`helm\` call that uses GKE credentials. \`v7\` installs it via \`setup-gcloud install_components: gke-gcloud-auth-plugin\`.