### PR TITLE
chore(ci): disable deploy_dev for gundi-dev (DASOPS-1995)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,8 +30,11 @@ jobs:
       tag: ${{ needs.vars.outputs.tag }}
 
   deploy_dev:
+    # Disabled: gundi-dev migrated to ArgoCD via DASOPS-1995.
+    # Image bumps for dev now go through a values commit in
+    # PADAS/serca-argocd-apps:gundi/admin-portal/values-gundi-dev.yaml.
     uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v7
-    if: startsWith(github.ref, 'refs/heads/main')
+    if: false
     needs: [vars, build]
     with:
       environment: dev


### PR DESCRIPTION
## Summary

The `gundi-dev` cluster is being migrated to centralized ArgoCD (DASOPS-1995). Disabling the `deploy_dev` job in this workflow so it stops running `helm upgrade` against gundi-dev on every push to `main` — that would fight ArgoCD's `selfHeal`.

## Changes

- `deploy_dev` job: `if: false` with comment pointing to DASOPS-1995 and the new values location (`PADAS/serca-argocd-apps:gundi/admin-portal/values-gundi-dev.yaml`).

`deploy_stage` and `deploy_prod` are untouched — those envs still deploy via this pipeline until per-env DASOPS-1995 sub-tasks land.

## Coordination

This must merge in the same window as the corresponding ArgoCD PRs (`PADAS/serca-argocd-apps` and `PADAS/serca-argocd`).

After merge, image bumps to dev will go through a values commit in `serca-argocd-apps`. Auto-PR integration for that flow is a separate follow-up sub-task.

---
**Jira**: https://allenai.atlassian.net/browse/DASOPS-1995