### PR TITLE
fix: PATCH /v2/integrations/ rejects nested configurations (GUNDI-5313)

### DIFF
--- a/cdip_admin/api/v2/serializers.py
+++ b/cdip_admin/api/v2/serializers.py
@@ -487,6 +487,14 @@ class IntegrationConfigurationCreateUpdateSerializer(serializers.ModelSerializer
     class Meta:
         model = IntegrationConfiguration
         fields = ["id", "integration", "action", "data"]
+        # The model's UniqueConstraint(fields=["integration", "action"]) makes
+        # DRF auto-generate a UniqueTogetherValidator, which enforces both
+        # fields as required regardless of the explicit required=False above.
+        # The parent IntegrationCreateUpdateSerializer injects `integration`
+        # from the URL after validation, and `update_or_create(id=...)`
+        # plus the DB-level UniqueConstraint enforce uniqueness, so the
+        # serializer-level check is redundant.
+        validators = []
 
 
 class IntegrationCreateUpdateSerializer(serializers.ModelSerializer):

--- a/cdip_admin/api/v2/serializers.py
+++ b/cdip_admin/api/v2/serializers.py
@@ -525,6 +525,7 @@ class IntegrationCreateUpdateSerializer(serializers.ModelSerializer):
         """
         Validate the configurations
         """
+        seen_action_ids = set()
         for configuration in data.get("configurations", []):
             if self.instance and "id" in configuration:  # Integration Update
                 action = IntegrationConfiguration.objects.get(id=configuration["id"]).action
@@ -532,6 +533,24 @@ class IntegrationCreateUpdateSerializer(serializers.ModelSerializer):
                 if "action" not in configuration:
                     raise drf_exceptions.ValidationError("The action id is required.")
                 action = configuration["action"]
+                # On PATCH, a new (no-id) item for an action that already
+                # has a configuration would collide with the (integration,
+                # action) UniqueConstraint at the DB layer and surface as
+                # a 500. Surface it as a friendly 400 here. The validator-
+                # level UniqueTogetherValidator that would normally catch
+                # this is disabled in IntegrationConfigurationCreateUpdate
+                # Serializer.Meta because it incorrectly required the
+                # `integration` field that the URL implies.
+                if self.instance and self.instance.configurations.filter(action=action).exists():
+                    raise drf_exceptions.ValidationError(
+                        f"A configuration for action '{action.value}' already exists on this "
+                        f"integration. Include 'id' in the payload to update it."
+                    )
+            if action.id in seen_action_ids:
+                raise drf_exceptions.ValidationError(
+                    f"Duplicate configurations for action '{action.value}' in the request."
+                )
+            seen_action_ids.add(action.id)
             configuration_schema = action.schema
             if configuration_schema and not configuration:  # Blank or None
                 raise drf_exceptions.ValidationError("The configuration can't be null or empty")

--- a/cdip_admin/api/v2/tests/test_integrations_api.py
+++ b/cdip_admin/api/v2/tests/test_integrations_api.py
@@ -1527,6 +1527,52 @@ def test_patch_integration_config_with_portal_payload_shape(
     assert lotek_auth_config.data == {"username": "user@lotek.com", "password": "NewPassword"}
 
 
+def test_patch_integration_config_rejects_new_item_for_existing_action(
+        api_client, org_admin_user, organization, provider_lotek_panthera,
+        lotek_action_auth,
+):
+    # A PATCH that adds a new (no-id) configuration for an action that
+    # already has a config would otherwise hit the (integration, action)
+    # DB UniqueConstraint mid-update and surface as a 500. Should be a 400.
+    api_client.force_authenticate(org_admin_user)
+    response = api_client.patch(
+        reverse("integrations-detail", kwargs={"pk": provider_lotek_panthera.id}),
+        data={
+            "configurations": [
+                {
+                    "action": str(lotek_action_auth.id),
+                    "data": {"username": "x", "password": "y"},
+                },
+            ],
+        },
+        format="json",
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "already exists" in str(response.json())
+
+
+def test_patch_integration_config_rejects_duplicate_actions_in_payload(
+        api_client, org_admin_user, organization, provider_lotek_panthera,
+        lotek_action_auth, lotek_action_list_devices,
+):
+    # Two items targeting the same action in one request would silently
+    # last-write-wins (in the natural-key sense) or hit IntegrityError.
+    # Should be a 400.
+    api_client.force_authenticate(org_admin_user)
+    response = api_client.patch(
+        reverse("integrations-detail", kwargs={"pk": provider_lotek_panthera.id}),
+        data={
+            "configurations": [
+                {"action": str(lotek_action_list_devices.id), "data": {"group_id": "1"}},
+                {"action": str(lotek_action_list_devices.id), "data": {"group_id": "2"}},
+            ],
+        },
+        format="json",
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Duplicate" in str(response.json())
+
+
 def _test_get_integration_api_key(
         api_client, user, integration
 ):

--- a/cdip_admin/api/v2/tests/test_integrations_api.py
+++ b/cdip_admin/api/v2/tests/test_integrations_api.py
@@ -1499,6 +1499,34 @@ def test_update_or_create_integration_config_as_org_admin(
     )
 
 
+def test_patch_integration_config_with_portal_payload_shape(
+        api_client, org_admin_user, organization, provider_lotek_panthera,
+        lotek_action_auth,
+):
+    # The portal omits `integration` from each configuration item (it is
+    # implied by the URL). Regression test for the UniqueTogetherValidator
+    # auto-generated from the model's UniqueConstraint(integration, action)
+    # rejecting the request with `{"integration": ["This field is required."]}`.
+    lotek_auth_config = lotek_action_auth.configurations_by_action.get(integration=provider_lotek_panthera)
+    api_client.force_authenticate(org_admin_user)
+    response = api_client.patch(
+        reverse("integrations-detail", kwargs={"pk": provider_lotek_panthera.id}),
+        data={
+            "configurations": [
+                {
+                    "id": str(lotek_auth_config.id),
+                    "action": str(lotek_action_auth.id),
+                    "data": {"username": "user@lotek.com", "password": "NewPassword"},
+                },
+            ],
+        },
+        format="json",
+    )
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    lotek_auth_config.refresh_from_db()
+    assert lotek_auth_config.data == {"username": "user@lotek.com", "password": "NewPassword"}
+
+
 def _test_get_integration_api_key(
         api_client, user, integration
 ):


### PR DESCRIPTION
## Summary
- Drops the auto-generated `UniqueTogetherValidator` from `IntegrationConfigurationCreateUpdateSerializer`. The `UniqueConstraint(integration, action)` added in #406 caused DRF to attach a validator that forces both fields to be required, regardless of their declared `required=False`. This broke `PATCH /v2/integrations/{id}/` from the portal, which omits `integration` on each nested configuration item because the integration is implied by the URL.
- Adds a regression test mirroring the portal payload shape (`{id, action, data}`).

## Root cause
PR #406 added:

```python
# cdip_admin/integrations/models/v2/models.py
class IntegrationConfiguration(...):
    class Meta:
        constraints = [
            models.UniqueConstraint(fields=["integration", "action"], ...),
        ]
```

DRF's `ModelSerializer` auto-introspects `UniqueConstraint` and attaches a `UniqueTogetherValidator`. Its `enforce_required_fields()` explicitly overrides any `required=False` declaration when `serializer.instance is None` — which is always the case for nested `many=True` children, since DRF does not auto-bind nested children to existing rows by their `id`. The result is `{"configurations":[{"integration":["This field is required."]}]}` on every portal PATCH.

Uniqueness is still enforced by (a) the DB-level `UniqueConstraint`, (b) `IntegrationCreateUpdateSerializer.update()`'s `update_or_create(id=...)` with the integration injected from the URL, and (c) `create()` using the inferred integration. The serializer-level validator was redundant.

## Test plan
- [x] New regression test `test_patch_integration_config_with_portal_payload_shape` passes with fix, fails without.
- [x] Existing tests `test_update_integration_config_as_org_admin`, `test_update_integration_config_as_superuser`, and `test_update_or_create_integration_config_as_org_admin` pass (they were silently broken on `main` — see note below).
- [x] All 13 config/create-related tests in `test_integrations_api.py` pass with the fix.

## Note: CI gap
The existing test `test_update_integration_config_as_org_admin` (`cdip_admin/api/v2/tests/test_integrations_api.py:1407`) already sent a payload of the failing shape. It should have caught #406, but `.github/workflows/main.yml` doesn't run pytest — it only builds a docker image and deploys to GKE. Worth a separate ticket to wire pytest into CI.

## Related
- Jira: [GUNDI-5313](https://allenai.atlassian.net/browse/GUNDI-5313)
- Caused by: #406 (auto-repair missing IntegrationConfiguration rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[GUNDI-5313]: https://allenai.atlassian.net/browse/GUNDI-5313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ