### PR TITLE
fix: address Copilot review comments from PR #412

### DIFF
--- a/cdip_admin/api/v2/serializers.py
+++ b/cdip_admin/api/v2/serializers.py
@@ -528,7 +528,17 @@ class IntegrationCreateUpdateSerializer(serializers.ModelSerializer):
         seen_action_ids = set()
         for configuration in data.get("configurations", []):
             if self.instance and "id" in configuration:  # Integration Update
-                action = IntegrationConfiguration.objects.get(id=configuration["id"]).action
+                # Scope the lookup to this integration's configurations so
+                # an id from a different integration doesn't get repointed
+                # (and a missing id surfaces as a 400, not a 500 from
+                # DoesNotExist).
+                try:
+                    existing_config = self.instance.configurations.get(id=configuration["id"])
+                except IntegrationConfiguration.DoesNotExist:
+                    raise drf_exceptions.ValidationError(
+                        f"Configuration '{configuration['id']}' was not found on this integration."
+                    )
+                action = existing_config.action
             else:  # Create a new integration or new config
                 if "action" not in configuration:
                     raise drf_exceptions.ValidationError("The action id is required.")
@@ -597,6 +607,14 @@ class IntegrationCreateUpdateSerializer(serializers.ModelSerializer):
         # Update or Create nested configurations if provided
         for config_data in configurations:  # Usually less than 5-10 configs
             config_data["integration"] = self.instance
+            if config_data.get("id"):
+                # When updating by id, the row's `action` is immutable —
+                # repointing it would (a) collide with the (integration,
+                # action) UniqueConstraint, and (b) bypass the schema
+                # validation in validate() which keyed off the existing
+                # action. The portal sometimes echoes `action` back for
+                # client convenience; ignore it on id-updates.
+                config_data.pop("action", None)
             IntegrationConfiguration.objects.update_or_create(
                 id=config_data.get("id"),
                 defaults=config_data

--- a/cdip_admin/api/v2/tests/test_integrations_api.py
+++ b/cdip_admin/api/v2/tests/test_integrations_api.py
@@ -1548,7 +1548,7 @@ def test_patch_integration_config_rejects_new_item_for_existing_action(
         format="json",
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert "already exists" in str(response.json())
+    assert "already exists" in response.json()["non_field_errors"][0]
 
 
 def test_patch_integration_config_rejects_duplicate_actions_in_payload(
@@ -1570,7 +1570,84 @@ def test_patch_integration_config_rejects_duplicate_actions_in_payload(
         format="json",
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert "Duplicate" in str(response.json())
+    assert "Duplicate" in response.json()["non_field_errors"][0]
+
+
+def test_patch_integration_config_rejects_unknown_config_id(
+        api_client, org_admin_user, organization, provider_lotek_panthera,
+):
+    # A PATCH referencing a configuration id that doesn't exist on this
+    # integration should return 400, not 500 from DoesNotExist.
+    api_client.force_authenticate(org_admin_user)
+    response = api_client.patch(
+        reverse("integrations-detail", kwargs={"pk": provider_lotek_panthera.id}),
+        data={
+            "configurations": [
+                {
+                    "id": "00000000-0000-0000-0000-000000000000",
+                    "data": {"username": "x", "password": "y"},
+                },
+            ],
+        },
+        format="json",
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "not found" in response.json()["non_field_errors"][0]
+
+
+def test_patch_integration_config_rejects_id_from_different_integration(
+        api_client, org_admin_user, organization, provider_lotek_panthera, provider_ats,
+):
+    # A PATCH referencing a configuration id that belongs to a different
+    # integration must not repoint that row — it should 400 cleanly.
+    other_config = provider_ats.configurations.first()
+    assert other_config is not None
+    api_client.force_authenticate(org_admin_user)
+    response = api_client.patch(
+        reverse("integrations-detail", kwargs={"pk": provider_lotek_panthera.id}),
+        data={
+            "configurations": [
+                {"id": str(other_config.id), "data": {"hijacked": True}},
+            ],
+        },
+        format="json",
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "not found" in response.json()["non_field_errors"][0]
+    # The other integration's config must remain untouched.
+    other_config.refresh_from_db()
+    assert other_config.integration_id == provider_ats.id
+    assert other_config.data != {"hijacked": True}
+
+
+def test_patch_integration_config_ignores_action_on_id_update(
+        api_client, org_admin_user, organization, provider_lotek_panthera,
+        lotek_action_auth, lotek_action_pull_positions,
+):
+    # The portal sometimes echoes back `action` alongside `id` for client
+    # convenience. The row's action must not be repointed via update_or_create
+    # defaults — that would collide with the (integration, action) constraint.
+    lotek_auth_config = lotek_action_auth.configurations_by_action.get(integration=provider_lotek_panthera)
+    api_client.force_authenticate(org_admin_user)
+    response = api_client.patch(
+        reverse("integrations-detail", kwargs={"pk": provider_lotek_panthera.id}),
+        data={
+            "configurations": [
+                {
+                    "id": str(lotek_auth_config.id),
+                    # Try to repoint at a different action — must be ignored.
+                    "action": str(lotek_action_pull_positions.id),
+                    "data": {"username": "u", "password": "p"},
+                },
+            ],
+        },
+        format="json",
+    )
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    lotek_auth_config.refresh_from_db()
+    # The row's action stayed put; only data updated.
+    assert lotek_auth_config.action_id == lotek_action_auth.id
+    assert lotek_auth_config.data == {"username": "u", "password": "p"}
 
 
 def _test_get_integration_api_key(


### PR DESCRIPTION
## Summary
Addresses three Copilot review comments on #412 (release-20260508 → main). Merges into `release-20260508` so the fixes flow into #412 automatically.

### 1. Scope `id` lookup to the integration (was a 500/leak risk)
`IntegrationConfiguration.objects.get(id=...)` in `validate()` wasn't scoped to the integration being patched.
- Nonexistent id → `DoesNotExist` → unhandled 500.
- Id belonging to a **different** integration → accepted, then later repointed by `update_or_create`'s defaults (i.e., one integration could mutate another's config row).

Fix: scope to `self.instance.configurations` and raise a clean 400 with `"Configuration '...' was not found on this integration."`.

### 2. Freeze `action` on id-updates
`update()` was passing the full `config_data` (including any payload `action`) as `defaults` to `update_or_create`. When `id` was present, that could repoint the row's action — colliding with the `(integration, action)` `UniqueConstraint` and bypassing the schema validation in `validate()` (which keyed off the existing action).

Fix: pop `action` from defaults when `id` is present. The portal sometimes echoes `action` back for client convenience — it's now correctly ignored on id-updates.

### 3. Tighten test assertions
Replaced `assert "..." in str(response.json())` with `assert "..." in response.json()["non_field_errors"][0]`.

## Test plan
- [x] `test_patch_integration_config_rejects_unknown_config_id` — bogus id → 400 (not 500)
- [x] `test_patch_integration_config_rejects_id_from_different_integration` — id from another integration → 400, original config untouched
- [x] `test_patch_integration_config_ignores_action_on_id_update` — payload `action` alongside `id` is ignored; row's action stays put
- [x] All 18 integration-config tests pass (`pytest -k "config or create_er or create_lotek or test_update_or_create or rejects_* or ignores_*"`)

## Related
- Parent PR: #412 (release-20260508 → main)
- Hotfix PR: #411 (already merged into release-20260508)
- Jira: [GUNDI-5313](https://allenai.atlassian.net/browse/GUNDI-5313)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[GUNDI-5313]: https://allenai.atlassian.net/browse/GUNDI-5313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ