### PR TITLE
feat(ci): flip deploy_stage to ArgoCD image-bump workflow (DASOPS-1995)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,15 +44,17 @@ jobs:
     secrets: inherit
 
   deploy_stage:
-    uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v7
+    # gundi-stage is reconciled by ArgoCD. This job bumps the image tag in
+    # PADAS/serca-argocd-apps:gundi/admin-portal/values-gundi-stage.yaml and lets
+    # ArgoCD's automated selfHeal pick up the change.
+    uses: PADAS/gundi-workflows/.github/workflows/deploy_argocd.yml@v8
     if: startsWith(github.ref, 'refs/heads/release')
     needs: [vars, build]
     with:
-      environment: stage
-      chart_name: admin-portal
-      chart_version: '1.3.6'
-      repository: ${{ needs.vars.outputs.repository }}
-      tag: ${{ needs.vars.outputs.tag }}
+      app-name: admin-portal
+      environment: gundi-stage
+      image-repository: ${{ needs.vars.outputs.repository }}
+      image-tag: ${{ needs.vars.outputs.tag }}
     secrets: inherit
 
   deploy_dev_legacy:


### PR DESCRIPTION
## Summary

Stage counterpart of #414. Flips `deploy_stage` from `deploy_k8s.yml@v7` (manual `helm upgrade`) to the new `deploy_argocd.yml@v8` reusable workflow. On push to `release-*`, the job now bumps `image.tag` in `PADAS/serca-argocd-apps:gundi/admin-portal/values-gundi-stage.yaml` and lets ArgoCD's `selfHeal` pick up the change.

## Changes

- `.github/workflows/main.yml` — `deploy_stage` block now calls `deploy_argocd.yml@v8` with `app-name: admin-portal`, `environment: gundi-stage`.

`deploy_prod` is **untouched** — stays on `deploy_k8s.yml@v7` until prod cutover. Per memory, prod needs Kong secrets `value → valueFrom` migration (via Terraform) before the ArgoCD cutover.

## Prerequisites

1. Wave 2a merged: `PADAS/serca-argocd-apps#187` (stage values) + `PADAS/serca-argocd#196` (AppSet append).
2. `gundi-workflows/deploy_argocd.yml@v8` exists (already published during dev rollout).
3. `ARGOCD_APPS_SSH_KEY` secret on this repo (already provisioned during dev rollout — per-repo, env-agnostic).

## Verification

After merge, push a release-* tag and observe:
- `deploy_stage` runs green.
- A new commit lands on `PADAS/serca-argocd-apps:main` bumping `gundi/admin-portal/values-gundi-stage.yaml`.
- `kubectl --context serca-tools get app admin-portal-gundi-stage -n argocd` flips `OutOfSync` → `Synced`.
- `admin-portal` pod rolls on `gundi-stage`.

---
**Jira**: https://allenai.atlassian.net/browse/DASOPS-1995