### PR TITLE
feat(ci): flip deploy_prod to ArgoCD image-bump workflow (DASOPS-1995)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,15 +80,17 @@ jobs:
     secrets: inherit
 
   deploy_prod:
-    uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v7
+    # gundi-prod is reconciled by ArgoCD. This job bumps the image tag in
+    # PADAS/serca-argocd-apps:gundi/admin-portal/values-gundi-prod.yaml and lets
+    # ArgoCD's automated selfHeal pick up the change.
+    uses: PADAS/gundi-workflows/.github/workflows/deploy_argocd.yml@v8
     if: startsWith(github.ref, 'refs/heads/release')
     needs: [vars, build, deploy_stage]
     with:
-      environment: prod
-      chart_name: admin-portal
-      chart_version: '1.3.6'
-      repository: ${{ needs.vars.outputs.repository }}
-      tag: ${{ needs.vars.outputs.tag }}
+      app-name: admin-portal
+      environment: gundi-prod
+      image-repository: ${{ needs.vars.outputs.repository }}
+      image-tag: ${{ needs.vars.outputs.tag }}
     secrets: inherit
 
   deploy_prod_legacy:


### PR DESCRIPTION
## Summary

Prod counterpart of #414 (dev) and #415 (stage). Flips `deploy_prod` from `deploy_k8s.yml@v7` (helm upgrade) to `deploy_argocd.yml@v8` (image bump in `serca-argocd-apps:gundi/admin-portal/values-gundi-prod.yaml`). Completes the dev/stage/prod migration to the ArgoCD pattern.

## Changes

- `.github/workflows/main.yml` — `deploy_prod` block: `app-name: admin-portal`, `environment: gundi-prod`, `needs: [vars, build, deploy_stage]` (still gated on stage success).

`deploy_prod_legacy` (cdip-v1 namespace matrix) is **untouched** — legacy path out of scope.

## Prerequisites

1. `PADAS/serca-argocd-apps#188` (prod values) + `PADAS/serca-argocd#197` (AppSet append) merged + ArgoCD adoption verified.
2. `deploy_argocd.yml@v8` and `ARGOCD_APPS_SSH_KEY` already in place from dev rollout.

## Verification

After merge, the next `release-*` push triggers (`deploy_stage` first, then) `deploy_prod`. Expect:
- New commit on `PADAS/serca-argocd-apps:main` bumping `gundi/admin-portal/values-gundi-prod.yaml`.
- `admin-portal-gundi-prod` flips `OutOfSync` → `Synced`.
- `admin-portal` rolling deploy on `gundi-prod` (within HPA `[4,20]` range).

---
**Jira**: https://allenai.atlassian.net/browse/DASOPS-1995