### PR TITLE
feat(DASOPS-2057): push to serca-artifact-registry and mirror Dockerfile base image (dev)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,12 +14,14 @@ jobs:
     outputs:
       tag: ${{ steps.vars.outputs.tag }}
       repository: ${{ steps.vars.outputs.repository }}
+      serca_repository: ${{ steps.vars.outputs.serca_repository }}
     steps:
       - uses: actions/checkout@v4
       - id: vars
         run: |
           echo "tag=${{ github.head_ref || github.ref_name }}-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           echo "repository=us-central1-docker.pkg.dev/cdip-78ca/gundi/admin-portal" >> $GITHUB_OUTPUT
+          echo "serca_repository=europe-west3-docker.pkg.dev/serca-artifact-registry/gundi/admin-portal" >> $GITHUB_OUTPUT
 
   build:
     uses: PADAS/gundi-workflows/.github/workflows/build_docker.yml@v7
@@ -29,17 +31,25 @@ jobs:
       repository: ${{ needs.vars.outputs.repository }}
       tag: ${{ needs.vars.outputs.tag }}
 
+  build_serca:
+    uses: PADAS/gundi-workflows/.github/workflows/build_docker.yml@v9
+    needs: vars
+    with:
+      workload_identity_provider: "projects/563316706574/locations/global/workloadIdentityPools/github-actions/providers/github-oidc"
+      repository: ${{ needs.vars.outputs.serca_repository }}
+      tag: ${{ needs.vars.outputs.tag }}
+
   deploy_dev:
     # gundi-dev is reconciled by ArgoCD. This job bumps the image tag in
     # PADAS/serca-argocd-apps:gundi/admin-portal/values-gundi-dev.yaml and lets
     # ArgoCD's automated selfHeal pick up the change.
     uses: PADAS/gundi-workflows/.github/workflows/deploy_argocd.yml@v8
     if: startsWith(github.ref, 'refs/heads/main')
-    needs: [vars, build]
+    needs: [vars, build_serca]
     with:
       app-name: admin-portal
       environment: gundi-dev
-      image-repository: ${{ needs.vars.outputs.repository }}
+      image-repository: ${{ needs.vars.outputs.serca_repository }}
       image-tag: ${{ needs.vars.outputs.tag }}
     secrets: inherit
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM europe-west3-docker.pkg.dev/serca-artifact-registry/virtual-docker/ubuntu:22.04
 MAINTAINER chrisdo@vulcan.com
 
 # Install basic tools first


### PR DESCRIPTION
## Summary

Add a parallel build to push the admin-portal image to `serca-artifact-registry/gundi/admin-portal` using Direct WIF, update `deploy_dev` to use the new registry, and switch the Dockerfile base image through the virtual-docker mirror.

## Changes

### Added
- `serca_repository` output to `vars` job (`europe-west3-docker.pkg.dev/serca-artifact-registry/gundi/admin-portal`)
- `build_serca` job: builds and pushes to serca-artifact-registry via Direct WIF (no `environment:`, no `service_account:`)

### Changed
- `deploy_dev` now depends on `build_serca` and passes `serca_repository` as `image-repository` — critical because `deploy_argocd.yml@v8` updates both `image.repository` and `image.tag` via yq on every run
- `docker/Dockerfile` `FROM` now uses `virtual-docker` mirror to avoid DockerHub rate limits
- `deploy_stage`/`deploy_prod` unchanged (still use cdip-78ca during transition)

## Technical Details

`deploy_argocd.yml@v8` writes both `image.repository` and `image.tag` into the ArgoCD values file on every deploy via yq. If `image-repository` still pointed to cdip-78ca, every main branch push would revert the registry back. Updating it here ensures the dev values file stabilizes on serca-artifact-registry.

## Files Changed

**2 files changed, 13 insertions(+), 3 deletions(-)**

---
**Jira**: https://padas.atlassian.net/browse/DASOPS-2057