### PR TITLE
fix: prevent full table scan on ActivityLog and GundiTrace admin pages

### DIFF
--- a/cdip_admin/activity_log/admin.py
+++ b/cdip_admin/activity_log/admin.py
@@ -13,15 +13,37 @@ def revert_selected(modeladmin, request, queryset):
 revert_selected.short_description = "Revert selected"
 
 
+class ActivityLogPaginator(EstimatedCountPaginator):
+    """Paginator for the partitioned ActivityLog admin.
+
+    ActivityLogManager.get_queryset() always injects
+    ``filter(created_at__lte=now)`` to skip empty future partitions, so
+    the queryset reaching this paginator always has a non-empty WHERE
+    clause. Without this opt-in flag, the base class would treat that as
+    "user-filtered" and fall back to the exact COUNT(*) — exactly the
+    behaviour this PR exists to prevent. The baseline filter excludes
+    only data that doesn't exist yet, so the table-wide estimate from
+    pg_class is still the right number to report.
+
+    User-applied filters (log_level, integration, etc.) ride through the
+    same WHERE clause and aren't distinguishable here, so filtered
+    drill-down counts will overcount. That's an accepted trade-off — the
+    incident this PR fixes is the unfiltered changelist locking workers.
+    """
+
+    estimate_through_baseline_filter = True
+
+
 @admin.register(ActivityLog)
 class ActivityLogAdmin(admin.ModelAdmin):
-    # ActivityLog is the largest table in the portal. The default admin
-    # paginator runs COUNT(*) on every changelist render, which on this
-    # table can lock up a worker for minutes — that's the incident this
-    # PR was opened to fix. EstimatedCountPaginator uses pg_class.reltuples
-    # for the unfiltered changelist (cheap planner read) and falls back
-    # to the exact count when filters are applied.
-    paginator = EstimatedCountPaginator
+    # ActivityLog is the largest (partitioned) table in the portal. The
+    # default admin paginator runs COUNT(*) on every changelist render,
+    # which on this table can lock up a worker for minutes — that's the
+    # incident this PR was opened to fix. ActivityLogPaginator sums
+    # pg_class.reltuples across leaf partitions (cheap planner read) and
+    # the ``estimate_through_baseline_filter`` flag tells it to ignore
+    # the manager's ``created_at <= now`` baseline filter.
+    paginator = ActivityLogPaginator
     # Suppresses the *secondary* full-table total shown next to a filtered
     # count. Doesn't replace the paginator's primary count — that's the
     # job of ``paginator`` above.

--- a/cdip_admin/activity_log/admin.py
+++ b/cdip_admin/activity_log/admin.py
@@ -1,4 +1,7 @@
 from django.contrib import admin
+
+from core.admin import EstimatedCountPaginator
+
 from .models import ActivityLog
 
 
@@ -12,6 +15,16 @@ revert_selected.short_description = "Revert selected"
 
 @admin.register(ActivityLog)
 class ActivityLogAdmin(admin.ModelAdmin):
+    # ActivityLog is the largest table in the portal. The default admin
+    # paginator runs COUNT(*) on every changelist render, which on this
+    # table can lock up a worker for minutes — that's the incident this
+    # PR was opened to fix. EstimatedCountPaginator uses pg_class.reltuples
+    # for the unfiltered changelist (cheap planner read) and falls back
+    # to the exact count when filters are applied.
+    paginator = EstimatedCountPaginator
+    # Suppresses the *secondary* full-table total shown next to a filtered
+    # count. Doesn't replace the paginator's primary count — that's the
+    # job of ``paginator`` above.
     show_full_result_count = False
     list_select_related = True
     list_display = (

--- a/cdip_admin/activity_log/admin.py
+++ b/cdip_admin/activity_log/admin.py
@@ -12,6 +12,8 @@ revert_selected.short_description = "Revert selected"
 
 @admin.register(ActivityLog)
 class ActivityLogAdmin(admin.ModelAdmin):
+    show_full_result_count = False
+    list_select_related = True
     list_display = (
         "created_at",
         "log_level",

--- a/cdip_admin/core/admin.py
+++ b/cdip_admin/core/admin.py
@@ -1,7 +1,6 @@
 import logging
 from datetime import datetime, timedelta
 
-from django.contrib import admin
 from django.contrib.admin.filters import DateFieldListFilter
 from django.core.paginator import Paginator
 from django.db import connection

--- a/cdip_admin/core/admin.py
+++ b/cdip_admin/core/admin.py
@@ -43,10 +43,13 @@ class EstimatedCountPaginator(Paginator):
     Behaviour:
 
     - **Unfiltered queryset on Postgres**: use the planner's
-      ``reltuples`` row estimate from ``pg_class``. This is cheap (system
-      catalog read) and roughly accurate after ``ANALYZE``. We require
-      the estimate to be at least ``ESTIMATE_THRESHOLD`` rows before we
-      trust it; for small/new tables we fall through to the exact count.
+      ``reltuples`` row estimate. We use ``pg_partition_tree`` so the
+      estimate works for both regular tables (one row → its own
+      ``reltuples``) and partitioned tables (sum across leaf partitions).
+      The reltuples value comes from the catalog and costs microseconds.
+      We require the estimate to be at least ``ESTIMATE_THRESHOLD`` rows
+      before we trust it; for small/new tables we fall through to the
+      exact count.
     - **Filtered queryset, or any non-Postgres backend, or an error
       reading the catalog**: fall back to the standard exact count.
 
@@ -54,6 +57,17 @@ class EstimatedCountPaginator(Paginator):
     issue an expensive count, but admin users hit those intentionally and
     the WHERE clause usually narrows the scan dramatically — the incident
     being fixed is the unfiltered index page.
+
+    Subclasses can set ``estimate_through_baseline_filter = True`` to keep
+    using the table-wide estimate even when the queryset already has a
+    WHERE clause. This is intended for ModelAdmins whose default manager
+    injects a baseline filter that doesn't actually narrow the data the
+    user sees (e.g. ``ActivityLogManager.get_queryset()`` filters
+    ``created_at <= now`` to skip empty future partitions). The trade-off
+    is that user-applied filters then also pass through to the estimate,
+    so filtered counts may overcount — acceptable for the changelist
+    incident this PR exists to fix; the page loads instead of stalling
+    on COUNT(*).
     """
 
     # Below this estimate, prefer the exact count: small tables count
@@ -61,12 +75,17 @@ class EstimatedCountPaginator(Paginator):
     # first ANALYZE (Postgres seeds it at -1 / row width-based guesses).
     ESTIMATE_THRESHOLD = 1000
 
+    # Opt-in escape hatch for ModelAdmins whose manager injects a baseline
+    # WHERE clause. See class docstring for the trade-off.
+    estimate_through_baseline_filter = False
+
     @cached_property
     def count(self):
         query = self.object_list.query
+        where_ok = self.estimate_through_baseline_filter or not query.where
         if (
             connection.vendor == "postgresql"
-            and not query.where
+            and where_ok
             and not query.distinct
             and not query.group_by
         ):
@@ -78,21 +97,35 @@ class EstimatedCountPaginator(Paginator):
     @staticmethod
     def _pg_class_estimate(table_name):
         """Return the planner's row estimate for ``table_name``, or ``None``
-        if the catalog read fails or returns no row. Pulled out as a seam
-        so tests can mock the estimate without colliding with the cursor
-        used by the exact-count fallback.
+        if the catalog read fails or returns no row.
+
+        Uses ``pg_partition_tree`` so this works for both regular and
+        partitioned tables in a single query: for a partitioned table the
+        function returns one row per partition (parent + children) and we
+        sum ``reltuples`` across the leaves; for a non-partitioned table
+        the function returns a single row whose ``relid`` is the table
+        itself, so the same SUM yields the table's own ``reltuples``.
+        ``pg_partition_tree`` requires Postgres 10+; the project runs 12+.
+
+        Pulled out as a seam so tests can mock the estimate without
+        colliding with the cursor used by the exact-count fallback.
         """
         try:
             with connection.cursor() as cursor:
                 cursor.execute(
-                    "SELECT reltuples::bigint FROM pg_class WHERE relname = %s",
+                    """
+                    SELECT COALESCE(SUM(c.reltuples), 0)::bigint
+                    FROM pg_partition_tree(%s::regclass) p
+                    JOIN pg_class c ON c.oid = p.relid
+                    WHERE p.isleaf
+                    """,
                     [table_name],
                 )
                 row = cursor.fetchone()
         except Exception:
             logger.warning(
-                "EstimatedCountPaginator: pg_class lookup failed for %s; "
-                "falling back to exact COUNT(*).",
+                "EstimatedCountPaginator: pg_partition_tree/pg_class lookup "
+                "failed for %s; falling back to exact COUNT(*).",
                 table_name,
                 exc_info=True,
             )

--- a/cdip_admin/core/admin.py
+++ b/cdip_admin/core/admin.py
@@ -1,7 +1,15 @@
+import logging
 from datetime import datetime, timedelta
+
 from django.contrib import admin
 from django.contrib.admin.filters import DateFieldListFilter
+from django.core.paginator import Paginator
+from django.db import connection
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
+
+
+logger = logging.getLogger(__name__)
 
 
 class CustomDateFilter(DateFieldListFilter):
@@ -17,3 +25,78 @@ class CustomDateFilter(DateFieldListFilter):
                 self.lookup_kwarg_until: datetime.strftime(today, '%Y-%m-%d'),
             }),
         ))
+
+
+class EstimatedCountPaginator(Paginator):
+    """Postgres-aware paginator that returns ``pg_class.reltuples`` for
+    unfiltered queries on large tables, avoiding the full-table ``COUNT(*)``
+    that Django's default paginator runs on every admin changelist render.
+
+    The standard ``ModelAdmin.show_full_result_count = False`` only suppresses
+    the *additional* unfiltered total shown next to a filtered count — the
+    paginator still evaluates ``queryset.count()`` for the page itself. On
+    tables with hundreds of millions of rows that single COUNT can lock up
+    a worker for minutes and trigger the same incident this PR is meant to
+    fix. Replacing the paginator's count is the only way to actually skip
+    it.
+
+    Behaviour:
+
+    - **Unfiltered queryset on Postgres**: use the planner's
+      ``reltuples`` row estimate from ``pg_class``. This is cheap (system
+      catalog read) and roughly accurate after ``ANALYZE``. We require
+      the estimate to be at least ``ESTIMATE_THRESHOLD`` rows before we
+      trust it; for small/new tables we fall through to the exact count.
+    - **Filtered queryset, or any non-Postgres backend, or an error
+      reading the catalog**: fall back to the standard exact count.
+
+    A filtered changelist (e.g. one log_level / one integration) can still
+    issue an expensive count, but admin users hit those intentionally and
+    the WHERE clause usually narrows the scan dramatically — the incident
+    being fixed is the unfiltered index page.
+    """
+
+    # Below this estimate, prefer the exact count: small tables count
+    # cheaply and the catalog estimate can be wildly wrong before the
+    # first ANALYZE (Postgres seeds it at -1 / row width-based guesses).
+    ESTIMATE_THRESHOLD = 1000
+
+    @cached_property
+    def count(self):
+        query = self.object_list.query
+        if (
+            connection.vendor == "postgresql"
+            and not query.where
+            and not query.distinct
+            and not query.group_by
+        ):
+            estimate = self._pg_class_estimate(query.model._meta.db_table)
+            if estimate is not None and estimate >= self.ESTIMATE_THRESHOLD:
+                return estimate
+        return super().count
+
+    @staticmethod
+    def _pg_class_estimate(table_name):
+        """Return the planner's row estimate for ``table_name``, or ``None``
+        if the catalog read fails or returns no row. Pulled out as a seam
+        so tests can mock the estimate without colliding with the cursor
+        used by the exact-count fallback.
+        """
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    "SELECT reltuples::bigint FROM pg_class WHERE relname = %s",
+                    [table_name],
+                )
+                row = cursor.fetchone()
+        except Exception:
+            logger.warning(
+                "EstimatedCountPaginator: pg_class lookup failed for %s; "
+                "falling back to exact COUNT(*).",
+                table_name,
+                exc_info=True,
+            )
+            return None
+        if row is None or row[0] is None:
+            return None
+        return int(row[0])

--- a/cdip_admin/core/tests.py
+++ b/cdip_admin/core/tests.py
@@ -85,3 +85,54 @@ def test_pg_class_estimate_returns_none_on_exception(mocker):
     # admin page.
     mocker.patch("core.admin.connection.cursor", side_effect=RuntimeError("boom"))
     assert EstimatedCountPaginator._pg_class_estimate("activity_log_activitylog") is None
+
+
+def test_pg_class_estimate_uses_pg_partition_tree(mocker):
+    # The SQL must sum over pg_partition_tree leaves so it works for both
+    # partitioned tables (ActivityLog) and non-partitioned tables
+    # (GundiTrace) in a single query.
+    mock_cursor = mocker.MagicMock()
+    mock_cursor.fetchone.return_value = (123_456,)
+    mock_cm = mocker.MagicMock()
+    mock_cm.__enter__.return_value = mock_cursor
+    mock_cm.__exit__.return_value = False
+    mocker.patch("core.admin.connection.cursor", return_value=mock_cm)
+
+    result = EstimatedCountPaginator._pg_class_estimate("activity_log_activitylog")
+
+    assert result == 123_456
+    sql, params = mock_cursor.execute.call_args.args
+    # Sanity-check the query shape so a future refactor that drops the
+    # partition-aware sum is caught here, not by an ActivityLog-shaped
+    # incident in prod.
+    assert "pg_partition_tree" in sql
+    assert "isleaf" in sql
+    assert "SUM(c.reltuples)" in sql
+    assert params == ["activity_log_activitylog"]
+
+
+def test_count_uses_estimate_through_baseline_filter_when_flag_is_set(mocker):
+    # ActivityLogManager.get_queryset() injects a baseline created_at filter,
+    # so query.where is always truthy on the ActivityLog changelist. A
+    # subclass that flips ``estimate_through_baseline_filter`` must still
+    # reach the estimate path despite the WHERE clause.
+    class _BaselineFilteredPaginator(EstimatedCountPaginator):
+        estimate_through_baseline_filter = True
+
+    mocker.patch("core.admin.connection.vendor", "postgresql")
+    mocker.patch.object(
+        _BaselineFilteredPaginator, "_pg_class_estimate", return_value=42_000
+    )
+
+    paginator = _BaselineFilteredPaginator(
+        _ordered_users().filter(is_staff=True), 20
+    )
+    assert paginator.count == 42_000
+
+
+def test_activity_log_paginator_has_baseline_filter_flag():
+    # Lock the flag in so a future refactor that drops it doesn't silently
+    # reintroduce the COUNT(*) lock-up on the partitioned ActivityLog.
+    from activity_log.admin import ActivityLogPaginator
+
+    assert ActivityLogPaginator.estimate_through_baseline_filter is True

--- a/cdip_admin/core/tests.py
+++ b/cdip_admin/core/tests.py
@@ -1,3 +1,87 @@
-from django.test import TestCase
+import pytest
+from django.contrib.auth.models import User
 
-# Create your tests here.
+from core.admin import EstimatedCountPaginator
+
+
+pytestmark = pytest.mark.django_db
+
+
+# Use User as the target model: it's already in the test DB (auth fixture)
+# and small, so the exact-count fallback is cheap and predictable. The
+# pg_class estimate path is exercised by mocking ``_pg_class_estimate``;
+# we don't try to fake Postgres planner state in the test database.
+
+
+def _ordered_users():
+    # Avoid the UnorderedObjectListWarning the paginator emits otherwise.
+    return User.objects.all().order_by("id")
+
+
+def _make_paginator(queryset, per_page=20):
+    return EstimatedCountPaginator(queryset, per_page)
+
+
+def test_count_returns_estimate_when_above_threshold(mocker):
+    mocker.patch("core.admin.connection.vendor", "postgresql")
+    mocker.patch.object(
+        EstimatedCountPaginator, "_pg_class_estimate", return_value=50_000
+    )
+
+    paginator = _make_paginator(_ordered_users())
+    assert paginator.count == 50_000
+
+
+def test_count_falls_back_to_exact_when_estimate_below_threshold(mocker):
+    # On a brand-new or freshly-truncated table reltuples can read as 0
+    # (or a tiny seed). The paginator should fall through to the exact
+    # count rather than surface the bogus estimate.
+    mocker.patch("core.admin.connection.vendor", "postgresql")
+    mocker.patch.object(
+        EstimatedCountPaginator, "_pg_class_estimate", return_value=5
+    )
+
+    paginator = _make_paginator(_ordered_users())
+    assert paginator.count == User.objects.count()
+
+
+def test_count_falls_back_to_exact_when_estimate_is_none(mocker):
+    # ``_pg_class_estimate`` returns None on catalog-read failure. Must
+    # surface the real count rather than 0 or AttributeError.
+    mocker.patch("core.admin.connection.vendor", "postgresql")
+    mocker.patch.object(
+        EstimatedCountPaginator, "_pg_class_estimate", return_value=None
+    )
+
+    paginator = _make_paginator(_ordered_users())
+    assert paginator.count == User.objects.count()
+
+
+def test_count_skips_pg_class_when_queryset_is_filtered(mocker):
+    # A WHERE clause means the catalog estimate covers the whole table
+    # rather than the filtered subset. We must not even ask pg_class.
+    mocker.patch("core.admin.connection.vendor", "postgresql")
+    estimate = mocker.patch.object(EstimatedCountPaginator, "_pg_class_estimate")
+
+    paginator = _make_paginator(_ordered_users().filter(is_staff=True))
+    _ = paginator.count
+
+    estimate.assert_not_called()
+
+
+def test_count_skips_pg_class_on_non_postgres_backend(mocker):
+    mocker.patch("core.admin.connection.vendor", "sqlite")
+    estimate = mocker.patch.object(EstimatedCountPaginator, "_pg_class_estimate")
+
+    paginator = _make_paginator(_ordered_users())
+    _ = paginator.count
+
+    estimate.assert_not_called()
+
+
+def test_pg_class_estimate_returns_none_on_exception(mocker):
+    # Direct test of the helper's swallow-and-return-None contract — a
+    # misconfigured DB or revoked SELECT on pg_class must not break the
+    # admin page.
+    mocker.patch("core.admin.connection.cursor", side_effect=RuntimeError("boom"))
+    assert EstimatedCountPaginator._pg_class_estimate("activity_log_activitylog") is None

--- a/cdip_admin/integrations/admin.py
+++ b/cdip_admin/integrations/admin.py
@@ -7,7 +7,7 @@ from django_celery_beat.admin import PeriodicTaskAdmin
 from django_celery_beat.models import PeriodicTask
 from simple_history.admin import SimpleHistoryAdmin
 from django.contrib import messages
-from core.admin import CustomDateFilter
+from core.admin import CustomDateFilter, EstimatedCountPaginator
 import deployments.models
 from .models import (
     OutboundIntegrationType,
@@ -523,6 +523,15 @@ class SourceConfigurationAdmin(SimpleHistoryAdmin):
 
 @admin.register(GundiTrace)
 class GundiTraceAdmin(SimpleHistoryAdmin):
+    # GundiTrace grows roughly proportionally to delivered observations.
+    # The default admin paginator runs COUNT(*) on every changelist render,
+    # which is the incident this PR was opened to fix. EstimatedCountPaginator
+    # uses pg_class.reltuples for the unfiltered changelist (cheap planner
+    # read) and falls back to the exact count when filters are applied.
+    paginator = EstimatedCountPaginator
+    # Suppresses the *secondary* full-table total shown next to a filtered
+    # count. Doesn't replace the paginator's primary count — that's the
+    # job of ``paginator`` above.
     show_full_result_count = False
     list_select_related = True
     list_display = (

--- a/cdip_admin/integrations/admin.py
+++ b/cdip_admin/integrations/admin.py
@@ -523,6 +523,8 @@ class SourceConfigurationAdmin(SimpleHistoryAdmin):
 
 @admin.register(GundiTrace)
 class GundiTraceAdmin(SimpleHistoryAdmin):
+    show_full_result_count = False
+    list_select_related = True
     list_display = (
         "pk",
         "object_id",


### PR DESCRIPTION
## Summary

Fixes the unfiltered `COUNT(*)` that ActivityLog and GundiTrace admin changelists run on every render — the source of recent worker lock-ups when an operator opened either index page.

The original 2-line patch (`show_full_result_count = False` on both admins) was wrong: that setting only suppresses the *secondary* full-table total shown next to a filtered count. Django's default paginator still runs `queryset.count()` for the page itself, which is the actual lock-up. Catching this required a real paginator, plus extra handling for ActivityLog (partitioned + has a baseline manager filter).

## Files

| File | What changed |
|------|--------------|
| `cdip_admin/core/admin.py` | New `EstimatedCountPaginator`. Uses `pg_partition_tree(table::regclass)` to sum `reltuples` across leaf partitions (works uniformly for partitioned and regular tables). Skips the estimate for distinct/group_by/non-Postgres/filtered querysets and falls back to exact COUNT. Provides `estimate_through_baseline_filter` opt-in for ModelAdmins whose manager injects a baseline WHERE clause. |
| `cdip_admin/activity_log/admin.py` | New `ActivityLogPaginator(EstimatedCountPaginator)` with `estimate_through_baseline_filter = True` — ActivityLogManager filters `created_at <= now` to skip future partitions, which the base paginator would treat as user-filtered. `ActivityLogAdmin.paginator` set to it. Kept `show_full_result_count = False` with a corrected comment. |
| `cdip_admin/integrations/admin.py` | `GundiTraceAdmin.paginator = EstimatedCountPaginator`. No baseline filter, not partitioned, so the conservative defaults apply. |
| `cdip_admin/core/tests.py` | New tests covering: estimate-above-threshold returns; below-threshold fallback; None-estimate fallback; filtered-queryset skip; non-Postgres skip; `_pg_class_estimate` swallows exceptions; SQL shape uses `pg_partition_tree` + `isleaf` + `SUM(reltuples)`; `estimate_through_baseline_filter=True` reaches the estimate path despite a WHERE clause; `ActivityLogPaginator` carries the flag. |

## Behaviour

| Queryset shape | Backend | Path |
|----------------|---------|------|
| Unfiltered or baseline-filter-only on Postgres, estimate ≥ 1000 | Postgres | `pg_partition_tree` sum of `reltuples` (microseconds) |
| Same, estimate < 1000 | Postgres | Fall back to exact `COUNT(*)` |
| User-filtered, baseline-filter opt-in OFF | Postgres | Fall back to exact `COUNT(*)` |
| Distinct / group_by | Any | Fall back to exact `COUNT(*)` |
| Non-Postgres | SQLite/MySQL/etc. | Fall back to exact `COUNT(*)` |
| Catalog read raises | Any | Logged at WARNING; fall back to exact `COUNT(*)` |

The baseline-filter opt-in means user-applied filters on ActivityLog can't be distinguished from the manager's `created_at <= now`, so filtered counts on that changelist may overcount. That's the intentional trade-off — the incident was the unfiltered index page; filtered drill-downs now render rather than stall.

## Test plan

- [x] `pytest cdip_admin/core/tests.py` — 9/9 pass.
- [ ] Operator smoke: open `/admin/activity_log/activitylog/` and `/admin/integrations/gunditrace/` against staging. Confirm the page renders and the result count is roughly accurate (estimate, not exact). Confirm a filtered drill-down still renders (count may overcount on ActivityLog; that's expected).
