### PR TITLE
fix(DASOPS-2057): use serca-artifact-registry and ArgoCD deploys on release branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,38 +19,43 @@ jobs:
       - id: vars
         run: |
           echo "tag=${{ github.head_ref || github.ref_name }}-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-          echo "repository=us-central1-docker.pkg.dev/cdip-78ca/gundi/admin-portal" >> $GITHUB_OUTPUT
+          echo "repository=europe-west3-docker.pkg.dev/serca-artifact-registry/gundi/admin-portal" >> $GITHUB_OUTPUT
 
   build:
-    uses: PADAS/gundi-workflows/.github/workflows/build_docker.yml@v7
+    uses: PADAS/gundi-workflows/.github/workflows/build_docker.yml@v11
     needs: vars
     with:
-      environment: stage
+      workload_identity_provider: "projects/563316706574/locations/global/workloadIdentityPools/github-actions/providers/github-oidc"  # pragma: allowlist secret
       repository: ${{ needs.vars.outputs.repository }}
       tag: ${{ needs.vars.outputs.tag }}
+      build-args: BASE_REGISTRY=europe-west3-docker.pkg.dev/serca-artifact-registry/virtual-docker/
 
   deploy_dev:
-    uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v7
+    # gundi-dev is reconciled by ArgoCD. This job bumps the image tag in
+    # PADAS/serca-argocd-apps:gundi/admin-portal/values-gundi-dev.yaml and lets
+    # ArgoCD's automated selfHeal pick up the change.
+    uses: PADAS/gundi-workflows/.github/workflows/deploy_argocd.yml@v8
     if: startsWith(github.ref, 'refs/heads/main')
     needs: [vars, build]
     with:
-      environment: dev
-      chart_name: admin-portal
-      chart_version: '1.3.6'
-      repository: ${{ needs.vars.outputs.repository }}
-      tag: ${{ needs.vars.outputs.tag }}
+      app-name: admin-portal
+      environment: gundi-dev
+      image-repository: ${{ needs.vars.outputs.repository }}
+      image-tag: ${{ needs.vars.outputs.tag }}
     secrets: inherit
 
   deploy_stage:
-    uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v7
+    # gundi-stage is reconciled by ArgoCD. This job bumps the image tag in
+    # PADAS/serca-argocd-apps:gundi/admin-portal/values-gundi-stage.yaml and lets
+    # ArgoCD's automated selfHeal pick up the change.
+    uses: PADAS/gundi-workflows/.github/workflows/deploy_argocd.yml@v8
     if: startsWith(github.ref, 'refs/heads/release')
     needs: [vars, build]
     with:
-      environment: stage
-      chart_name: admin-portal
-      chart_version: '1.3.6'
-      repository: ${{ needs.vars.outputs.repository }}
-      tag: ${{ needs.vars.outputs.tag }}
+      app-name: admin-portal
+      environment: gundi-stage
+      image-repository: ${{ needs.vars.outputs.repository }}
+      image-tag: ${{ needs.vars.outputs.tag }}
     secrets: inherit
 
   deploy_dev_legacy:
@@ -60,7 +65,7 @@ jobs:
     needs: [vars, build]
     strategy:
       matrix:
-        deployment: 
+        deployment:
           - cdip-portal
           - celery-beat
           - celery-deployments-worker
@@ -76,15 +81,17 @@ jobs:
     secrets: inherit
 
   deploy_prod:
-    uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v7
+    # gundi-prod is reconciled by ArgoCD. This job bumps the image tag in
+    # PADAS/serca-argocd-apps:gundi/admin-portal/values-gundi-prod.yaml and lets
+    # ArgoCD's automated selfHeal pick up the change.
+    uses: PADAS/gundi-workflows/.github/workflows/deploy_argocd.yml@v8
     if: startsWith(github.ref, 'refs/heads/release')
     needs: [vars, build, deploy_stage]
     with:
-      environment: prod
-      chart_name: admin-portal
-      chart_version: '1.3.6'
-      repository: ${{ needs.vars.outputs.repository }}
-      tag: ${{ needs.vars.outputs.tag }}
+      app-name: admin-portal
+      environment: gundi-prod
+      image-repository: ${{ needs.vars.outputs.repository }}
+      image-tag: ${{ needs.vars.outputs.tag }}
     secrets: inherit
 
   deploy_prod_legacy:
@@ -93,7 +100,7 @@ jobs:
     needs: [vars, build, deploy_stage]
     strategy:
       matrix:
-        deployment: 
+        deployment:
           - cdip-portal
           - celery-beat
           - celery-deployments-worker


### PR DESCRIPTION
## Summary

Backport the CI/CD workflow changes from main to the \`release-20260508\` branch so a pending prod deploy doesn't fall back to the old Helm-based workflow that pushes to cdip-78ca (which ArgoCD would revert).

## Changes

### Changed
- \`repository\` → \`europe-west3-docker.pkg.dev/serca-artifact-registry/gundi/admin-portal\`
- \`build\` job → \`build_docker.yml@v11\` with Direct WIF (no service account)
- \`deploy_dev\` → \`deploy_argocd.yml@v8\` targeting \`gundi-dev\`
- \`deploy_stage\` → \`deploy_argocd.yml@v8\` targeting \`gundi-stage\`
- \`deploy_prod\` → \`deploy_argocd.yml@v8\` targeting \`gundi-prod\`
- \`deploy_prod_legacy\` — kept as-is (\`update_k8s_image.yml@v7\`)

## Technical Details

The release branch was still on \`deploy_k8s.yml@v7\` (Helm) which pushes images to \`cdip-78ca\` and deploys via Helm directly. Since gundi-stage and gundi-prod are now managed by ArgoCD pulling from \`serca-artifact-registry\`, re-running a release pipeline with the old workflow would push the wrong image URL, and ArgoCD would immediately revert. This PR aligns the release branch with main.

**Jira**: https://padas.atlassian.net/browse/DASOPS-2057