### PR TITLE
fix(DASOPS-2057): add approve_prod gate before prod deploy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,13 +80,21 @@ jobs:
       namespace: cdip-v1
     secrets: inherit
 
+  approve_prod:
+    runs-on: ubuntu-latest
+    environment: prod
+    if: startsWith(github.ref, 'refs/heads/release')
+    needs: [vars, build, deploy_stage]
+    steps:
+      - run: echo "Approved for prod"
+
   deploy_prod:
     # gundi-prod is reconciled by ArgoCD. This job bumps the image tag in
     # PADAS/serca-argocd-apps:gundi/admin-portal/values-gundi-prod.yaml and lets
     # ArgoCD's automated selfHeal pick up the change.
     uses: PADAS/gundi-workflows/.github/workflows/deploy_argocd.yml@v8
     if: startsWith(github.ref, 'refs/heads/release')
-    needs: [vars, build, deploy_stage]
+    needs: [vars, build, deploy_stage, approve_prod]
     with:
       app-name: admin-portal
       environment: gundi-prod
@@ -97,7 +105,7 @@ jobs:
   deploy_prod_legacy:
     uses: PADAS/gundi-workflows/.github/workflows/update_k8s_image.yml@v7
     if: startsWith(github.ref, 'refs/heads/release')
-    needs: [vars, build, deploy_stage]
+    needs: [vars, build, deploy_stage, approve_prod]
     strategy:
       matrix:
         deployment:


### PR DESCRIPTION
## Summary

Adds an \`approve_prod\` gate job (with \`environment: prod\`) before \`deploy_prod\` and \`deploy_prod_legacy\` on the release branch, restoring the manual approval requirement that was accidentally dropped when migrating from \`deploy_k8s.yml@v7\` to \`deploy_argocd.yml@v8\`.

## Changes

### Added
- \`approve_prod\` job with \`environment: prod\` — blocks on required reviewers before any prod deployment
- \`deploy_prod\` and \`deploy_prod_legacy\` now depend on \`approve_prod\`

## Technical Details

\`deploy_argocd.yml@v8\` does not declare a GitHub Actions \`environment:\` internally (it uses the \`environment\` input only as a values file slug). GitHub Actions does not allow setting \`environment:\` on jobs that call reusable workflows via \`uses:\`. The \`approve_prod\` pattern is the standard workaround: a lightweight job that holds the approval gate, which the actual deploy jobs list as a dependency.

**Jira**: https://padas.atlassian.net/browse/DASOPS-2057