### PR TITLE
ci(DASOPS-2057): fix deploy_prod_legacy — use direct GKE credentials

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,7 +103,7 @@ jobs:
     secrets: inherit
 
   deploy_prod_legacy:
-    uses: PADAS/gundi-workflows/.github/workflows/update_k8s_image.yml@v7
+    uses: PADAS/gundi-workflows/.github/workflows/update_k8s_image.yml@v12
     if: startsWith(github.ref, 'refs/heads/release')
     needs: [vars, build, deploy_stage, approve_prod]
     strategy:


### PR DESCRIPTION
## Summary

Fixes `deploy_prod_legacy` which has been failing because `cdip-prod01` (cluster `sintegrate-4bb07e9c`) is not registered in the serca-tools Fleet.

## Changes

- Bump `deploy_prod_legacy` from `update_k8s_image.yml@v7` → `@v12` — the new version uses `gcloud container clusters get-credentials` directly instead of Fleet Connect Gateway
- Updated `prod-legacy` GitHub Actions environment variables:
  - `GKE_CLUTER_NAME`: `cdip-prod01` → `sintegrate-4bb07e9c` (actual cluster name)
  - `LOCATION`: `us-central1-c` → `us-central1` (cluster is regional)
  - `PROJECT_ID`: `cdip-78ca` → `cdip-prod1-78ca` (cluster's project)

## Technical Details

`update_k8s_image.yml@v7` used `gcloud container fleet memberships get-credentials --project=serca-tools` which requires the cluster to be in the Fleet. The legacy cluster was never registered there. The `LOCATION` and `PROJECT_ID` vars already existed in the environment but weren't being used — v12 picks them up for direct GKE auth.

## Files Changed

**1 file changed, 1 insertion(+), 1 deletion(-)**

---
**Jira**: https://allenai.atlassian.net/browse/DASOPS-2057