### PR TITLE
ci(DASOPS-2057): fix deploy_prod_legacy — use direct GKE credentials [release-20260508]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,7 +103,7 @@ jobs:
     secrets: inherit
 
   deploy_prod_legacy:
-    uses: PADAS/gundi-workflows/.github/workflows/update_k8s_image.yml@v7
+    uses: PADAS/gundi-workflows/.github/workflows/update_k8s_image.yml@v12
     if: startsWith(github.ref, 'refs/heads/release')
     needs: [vars, build, deploy_stage, approve_prod]
     strategy:


### PR DESCRIPTION
## Summary

Fixes `deploy_prod_legacy` on the release branch — same fix as #421 targeting main.

## Changes

- Bump `deploy_prod_legacy` from `update_k8s_image.yml@v7` → `@v12`

## Technical Details

v12 replaces `gcloud container fleet memberships get-credentials --project=serca-tools` with `gcloud container clusters get-credentials --location --project`, reading from the `prod-legacy` environment vars (already updated: `GKE_CLUTER_NAME=sintegrate-4bb07e9c`, `LOCATION=us-central1`, `PROJECT_ID=cdip-prod1-78ca`).

## Files Changed

**1 file changed, 1 insertion(+), 1 deletion(-)**

---
**Jira**: https://allenai.atlassian.net/browse/DASOPS-2057