### PR TITLE
fix: stop Route admin change page from timing out

### DIFF
--- a/cdip_admin/integrations/admin.py
+++ b/cdip_admin/integrations/admin.py
@@ -436,10 +436,15 @@ class WebhookConfigurationAdmin(admin.ModelAdmin):
 
 class RouteProviderInline(admin.TabularInline):
     model = Route.data_providers.through
+    # Without this, every inline row renders a <select> of *every* Integration,
+    # and Integration.__str__ touches owner.name/type.name (not select_related),
+    # making the Route change page an N+1 storm that times out in production.
+    autocomplete_fields = ("integration",)
 
 
 class RouteDestinationInline(admin.TabularInline):
     model = Route.destinations.through
+    autocomplete_fields = ("integration",)
 
 
 @admin.register(Route)

--- a/cdip_admin/integrations/tests/test_admin.py
+++ b/cdip_admin/integrations/tests/test_admin.py
@@ -1,0 +1,53 @@
+import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+
+from integrations.models import Integration
+
+pytestmark = pytest.mark.django_db
+
+
+def _render_query_count(admin_client, url):
+    with CaptureQueriesContext(connection) as ctx:
+        response = admin_client.get(url)
+    assert response.status_code == 200, response.status_code
+    return len(ctx.captured_queries)
+
+
+def test_route_change_page_does_not_scale_with_integration_count(
+    admin_client, route_1, organization, integration_type_er
+):
+    """The Route change page renders RouteProvider/RouteDestination inlines.
+
+    Without autocomplete_fields, each inline renders a <select> of *every*
+    Integration, and Integration.__str__ touches owner.name and type.name
+    (neither select_related), so building the dropdowns is an N+1 storm whose
+    cost grows with the number of integrations -- the cause of the timeout.
+    The query count must stay flat as integrations are added.
+    """
+    url = reverse("admin:integrations_route_change", args=[route_1.pk])
+
+    baseline = _render_query_count(admin_client, url)
+
+    # bulk_create bypasses save hooks/dispatcher deployment -- we only need
+    # rows that would populate the inline FK dropdowns.
+    Integration.objects.bulk_create(
+        [
+            Integration(
+                type=integration_type_er,
+                owner=organization,
+                name=f"Bulk Integration {i}",
+                base_url=f"https://bulk-{i}.example.org",
+            )
+            for i in range(100)
+        ]
+    )
+
+    after = _render_query_count(admin_client, url)
+
+    assert after - baseline <= 10, (
+        "Route change page query count scales with integration count: "
+        f"{baseline} queries -> {after} queries after adding 100 integrations. "
+        "Inline FK fields should use autocomplete_fields."
+    )


### PR DESCRIPTION
## Problem

Requesting the Django admin **change page** for a `Route` (e.g. `/admin/integrations/route/<id>/change/`) times out in production.

## Root cause

The change page renders `RouteProviderInline` and `RouteDestinationInline`. Each inline renders a `<select>` of **every** `Integration` — for every existing row and every extra form. `Integration.__str__` is `f"{self.owner.name} - {self.name} - {self.type.name}"`, and neither `owner` nor `type` is `select_related`, so building each dropdown fires N+1 queries. The total cost scales with the number of integrations, which is large in production → timeout.

Quantified with the new regression test: rendering the page went from **460 → 4,259 queries** after adding just 100 integrations (~38 queries per integration).

This is distinct from the changelist `COUNT(*)` issue fixed in #418 — this is the single-object change view and its inlines.

## Fix

Add `autocomplete_fields = ("integration",)` to both inlines. The FK now renders as an AJAX autocomplete box (backed by `IntegrationAdmin`'s existing `search_fields`) instead of a full-table dropdown, so no `Integration` options are pre-rendered and there is no N+1.

## Testing

- New `integrations/tests/test_admin.py` renders the change page, adds 100 integrations, and asserts the query count stays flat (delta ≤ 10). Fails before the fix, passes after.
- `manage.py check` passes (confirms the `autocomplete_fields` config is valid and won't break admin startup).

## Note for reviewers

Staff users need *view* permission on `Integration` for the autocomplete results to populate (standard Django autocomplete behavior). Superusers and typical admin roles already have it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)