### PR TITLE
fix: Route admin change page timeout (N+1 in inline integration dropdowns)

### DIFF
--- a/cdip_admin/integrations/admin.py
+++ b/cdip_admin/integrations/admin.py
@@ -436,10 +436,16 @@ class WebhookConfigurationAdmin(admin.ModelAdmin):
 
 class RouteProviderInline(admin.TabularInline):
     model = Route.data_providers.through
+    # Without this, every inline row renders a <select> of every Integration,
+    # and Integration.__str__ dereferences owner+type (N+1). With thousands of
+    # integrations this made the Route change page time out. autocomplete_fields
+    # swaps the eager dropdown for an AJAX search (zero options rendered).
+    autocomplete_fields = ("integration",)
 
 
 class RouteDestinationInline(admin.TabularInline):
     model = Route.destinations.through
+    autocomplete_fields = ("integration",)
 
 
 @admin.register(Route)
@@ -451,6 +457,12 @@ class RouteAdmin(admin.ModelAdmin):
     list_filter = (
         "owner",
     )
+    # Render owner/configuration as AJAX search boxes instead of dropdowns that
+    # eagerly load every Organization/RouteConfiguration on the change page.
+    autocomplete_fields = (
+        "owner",
+        "configuration",
+    )
     inlines = (
         RouteProviderInline,
         RouteDestinationInline,
@@ -460,6 +472,11 @@ class RouteAdmin(admin.ModelAdmin):
 @admin.register(RouteConfiguration)
 class RouteConfigAdmin(admin.ModelAdmin):
     list_display = (
+        "id",
+        "name",
+    )
+    # Required so RouteAdmin can use ``configuration`` in autocomplete_fields.
+    search_fields = (
         "id",
         "name",
     )

--- a/cdip_admin/integrations/tests/test_admin.py
+++ b/cdip_admin/integrations/tests/test_admin.py
@@ -1,0 +1,63 @@
+import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+
+from integrations.models import Integration
+
+pytestmark = pytest.mark.django_db
+
+
+def _render_route_change(admin_client, route):
+    url = reverse("admin:integrations_route_change", args=[route.pk])
+    with CaptureQueriesContext(connection) as ctx:
+        response = admin_client.get(url)
+    assert response.status_code == 200
+    return response, len(ctx.captured_queries)
+
+
+def _queries_to_render_route_change(admin_client, route):
+    return _render_route_change(admin_client, route)[1]
+
+
+def test_route_change_page_uses_autocomplete_for_integration_inlines(
+    admin_client, route_2
+):
+    """The inline integration field must render as an AJAX autocomplete widget,
+    not an eager <select> of every Integration."""
+    response, _ = _render_route_change(admin_client, route_2)
+    html = response.content.decode()
+    # Django renders autocomplete_fields with the ``admin-autocomplete`` class.
+    assert "admin-autocomplete" in html
+
+
+def test_route_change_page_query_count_does_not_scale_with_integrations(
+    admin_client, route_2, integration_type_er, organization
+):
+    """Regression test for the Route admin change page timing out.
+
+    The inline integration FK must not render an eager <select> of every
+    Integration. Because ``Integration.__str__`` dereferences ``owner`` and
+    ``type``, an eager dropdown triggers an N+1 query per option, per inline
+    row, which made the page time out in production. The query count to render
+    the page must therefore be constant with respect to the size of the
+    Integration table.
+    """
+    baseline = _queries_to_render_route_change(admin_client, route_2)
+
+    # Grow the Integration table substantially.
+    for i in range(25):
+        Integration.objects.create(
+            type=integration_type_er,
+            name=f"Extra ER Site {i}",
+            owner=organization,
+            base_url=f"extra-{i}.pamdas.org",
+        )
+
+    after = _queries_to_render_route_change(admin_client, route_2)
+
+    assert after <= baseline, (
+        "Route admin change page query count scaled with the Integration "
+        f"table size ({baseline} -> {after} queries). The inline integration "
+        "field is rendering an eager dropdown (N+1 via Integration.__str__)."
+    )


### PR DESCRIPTION
## Problem

The Route admin **change page** (e.g. `/admin/integrations/route/<id>/change/`) fails to load and times out in production.

## Root cause

`RouteAdmin` mounts two inlines on the M2M through models (`RouteProviderInline`, `RouteDestinationInline`). Each inline row renders the through model's `integration` ForeignKey as a plain `<select>` listing **every** `Integration`. Because `Integration.__str__` dereferences related objects:

```python
def __str__(self):
    return f"{self.owner.name} - {self.name} - {self.type.name}"
```

…and the admin's `ModelChoiceField` queryset has no `select_related`, rendering each `<option>` fires 2 extra queries (`owner`, `type`). That's `1 + 2N` queries **per inline row**, and there are 8+ rows by default (existing providers + destinations + 3 `extra` each). With thousands of integrations in production this becomes hundreds of thousands of queries → timeout.

This is distinct from the recent `fix-admin-performance` work, which addressed `COUNT(*)` on **changelist** views; this is the **change form**.

### Measured evidence

Loading a test route's change page:
- ~12 integrations → **247 queries**
- after adding 25 more → **746 queries**

i.e. ~20 queries added per integration — linear scaling with the Integration table.

## Fix

Switch the heavy FKs to `autocomplete_fields`, which renders an AJAX search box instead of an eager dropdown (zero options rendered up front, no N+1):

- `integration` on both inlines (`IntegrationAdmin` already has `search_fields`)
- `owner` + `configuration` on `RouteAdmin` (`OrganizationAdmin` already has `search_fields`)
- Added `search_fields` to `RouteConfigAdmin` so `configuration` qualifies for autocomplete

## Tests

New `integrations/tests/test_admin.py`:
- **Scaling regression test** — query count to render the change page no longer grows with the Integration table size (fails before, passes after).
- **Widget test** — the inline integration field renders as an `admin-autocomplete` widget.

`manage.py check` passes (validates the `autocomplete_fields` / `search_fields` wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)