### PR TITLE
perf: autocomplete owner/configuration on Route admin change page

### DIFF
--- a/cdip_admin/integrations/admin.py
+++ b/cdip_admin/integrations/admin.py
@@ -456,6 +456,12 @@ class RouteAdmin(admin.ModelAdmin):
     list_filter = (
         "owner",
     )
+    # Render owner/configuration as AJAX search boxes instead of dropdowns that
+    # eagerly load every Organization/RouteConfiguration on the change page.
+    autocomplete_fields = (
+        "owner",
+        "configuration",
+    )
     inlines = (
         RouteProviderInline,
         RouteDestinationInline,
@@ -465,6 +471,11 @@ class RouteAdmin(admin.ModelAdmin):
 @admin.register(RouteConfiguration)
 class RouteConfigAdmin(admin.ModelAdmin):
     list_display = (
+        "id",
+        "name",
+    )
+    # Required so RouteAdmin can use ``configuration`` in autocomplete_fields.
+    search_fields = (
         "id",
         "name",
     )

--- a/cdip_admin/integrations/tests/test_admin.py
+++ b/cdip_admin/integrations/tests/test_admin.py
@@ -1,4 +1,5 @@
 import pytest
+from django.contrib.admin.widgets import AutocompleteSelect, RelatedFieldWidgetWrapper
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
@@ -51,3 +52,22 @@ def test_route_change_page_does_not_scale_with_integration_count(
         f"{baseline} queries -> {after} queries after adding 100 integrations. "
         "Inline FK fields should use autocomplete_fields."
     )
+
+
+def test_route_change_page_owner_and_configuration_use_autocomplete(
+    admin_client, route_2
+):
+    """owner/configuration must render as autocomplete widgets rather than
+    dropdowns that eagerly load every Organization/RouteConfiguration."""
+    url = reverse("admin:integrations_route_change", args=[route_2.pk])
+    response = admin_client.get(url)
+    assert response.status_code == 200
+
+    form = response.context["adminform"].form
+
+    def unwrap(widget):
+        # Admin wraps FK widgets in RelatedFieldWidgetWrapper (the +/edit icons).
+        return widget.widget if isinstance(widget, RelatedFieldWidgetWrapper) else widget
+
+    assert isinstance(unwrap(form.fields["owner"].widget), AutocompleteSelect)
+    assert isinstance(unwrap(form.fields["configuration"].widget), AutocompleteSelect)


### PR DESCRIPTION
## Summary

Follow-up to #424. That PR fixed the dominant cause of the Route admin change-page timeout by adding `autocomplete_fields` to the inline `integration` FKs (an N+1 storm that scaled with the Integration table).

The main change form still renders the `owner` and `configuration` ForeignKeys as plain `<select>` dropdowns that eagerly load **every** `Organization` / `RouteConfiguration` row. These are single selects rendered once each — not the N+1 inline storm — but they still grow with those tables and add unnecessary weight to the page. This switches them to autocomplete for consistency and to keep the change page light as those tables grow.

## Changes

- `RouteAdmin.autocomplete_fields = ("owner", "configuration")` (`OrganizationAdmin` already has `search_fields`).
- Added `search_fields = ("id", "name")` to `RouteConfigAdmin` so `configuration` qualifies for autocomplete.
- Test asserting both fields render Django's `AutocompleteSelect` widget (unwrapping `RelatedFieldWidgetWrapper`).

## Verification

- `integrations/tests/test_admin.py` — 2 passed (the existing #424 scaling test plus the new widget test).
- `manage.py check` passes (validates the `autocomplete_fields` / `search_fields` wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)