### PR TITLE
Accept priority and notes on event PATCH (GUNDI-5386 dependency)

### DIFF
--- a/cdip_admin/api/v2/serializers.py
+++ b/cdip_admin/api/v2/serializers.py
@@ -1061,6 +1061,12 @@ class EventCreateUpdateSerializer(GundiTraceSerializer):
     event_details = serializers.JSONField(write_only=True, required=False)
     annotations = serializers.JSONField(write_only=True, required=False)
     status = serializers.CharField(write_only=True, required=False)
+    # Pass-through fields: not persisted on the GundiTrace, but accepted on PATCH
+    # so they flow through to the EventUpdate.changes dict for downstream routing.
+    # Used by provider runners that need to forward field-level edits and per-note
+    # additions to destination integrations (e.g. ER → CMORE comments).
+    priority = serializers.IntegerField(write_only=True, required=False)
+    notes = serializers.JSONField(write_only=True, required=False)
 
     class Meta:
         list_serializer_class = EventBulkCreateUpdateSerializer

--- a/cdip_admin/api/v2/tests/test_events_api.py
+++ b/cdip_admin/api/v2/tests/test_events_api.py
@@ -275,6 +275,8 @@ def test_create_single_event_with_status(api_client, mocker, mock_publisher, moc
 @pytest.mark.parametrize("request_data", [
     ("species_update_request_data"),
     ("status_update_request_data"),
+    ("priority_update_request_data"),
+    ("notes_update_request_data"),
 ])
 def test_update_event(api_client, mocker, request, request_data, trap_tagger_event_trace, mock_publisher, mock_deduplication, keyauth_headers_trap_tagger):
     # Mock external dependencies

--- a/cdip_admin/conftest.py
+++ b/cdip_admin/conftest.py
@@ -2872,6 +2872,27 @@ def status_update_request_data():
         "status": "resolved"
     }
 
+
+@pytest.fixture
+def priority_update_request_data():
+    return {
+        "priority": 200
+    }
+
+
+@pytest.fixture
+def notes_update_request_data():
+    return {
+        "notes": [
+            {
+                "id": "note-uuid-1",
+                "text": "Ranger spotted fresh tracks.",
+                "author": "ranger1",
+                "created_at": "2026-06-09T10:00:00+00:00"
+            }
+        ]
+    }
+
 ########################################################################################################################
 # GUNDI 1.0
 ########################################################################################################################


### PR DESCRIPTION
## Summary

Extends `EventCreateUpdateSerializer` with two write-only, not-persisted fields — `priority` and `notes` — so PATCH `/v2/events/{id}` requests carrying them get forwarded into the downstream `EventUpdate.changes` dict instead of being silently dropped by DRF.

Today the serializer only declares: `title, recorded_at, location, geometry, event_type, event_details, annotations, status`. Anything else in the PATCH body is silently dropped. Provider runners that want to forward field-level edits and per-note additions to destination integrations need these two fields to survive serialization.

## Why now

This is the gating dependency for [GUNDI-5386](https://allenai.atlassian.net/browse/GUNDI-5386) — forwarding EarthRanger event updates as CMORE comments. The downstream work in `gundi-integration-earthranger` and `gundi-integration-cmore` cannot land until this serializer change is live across dev / stage / prod.

## Behavior

No persistence change. Both new fields are `write_only=True, required=False`. The serializer's existing `update()` method already passes `validated_data` to `send_event_update_to_routing(event_changes=...)`, which constructs the `EventUpdate` system event with `changes=event_changes`. Adding the fields is enough to make them flow through end-to-end.

## Test plan

- [x] Extended the existing parametrized `test_update_event` with two new fixtures (`priority_update_request_data`, `notes_update_request_data`) covering both new fields via the same publish-verification pattern.
- [ ] CI runs full Django test suite. (Local test execution requires DB env vars / running Postgres that I did not set up in the worktree.)
- [ ] Smoke against dev once merged: PATCH `/v2/events/{id}` with `{"priority": 200}` → verify the published EventUpdate's `changes` dict contains `priority`.

## What does NOT change

- `GundiTrace` model — unchanged.
- Serializer `update()` method — unchanged.
- Existing PATCH callers — unchanged (extra accepted fields are additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[GUNDI-5386]: https://allenai.atlassian.net/browse/GUNDI-5386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ