### PR TITLE
Accept provider_metadata on event POST/PATCH (gundi-core 1.12.0 dep)

### DIFF
--- a/cdip_admin/api/v2/serializers.py
+++ b/cdip_admin/api/v2/serializers.py
@@ -1067,6 +1067,12 @@ class EventCreateUpdateSerializer(GundiTraceSerializer):
     # additions to destination integrations (e.g. ER → CMORE comments).
     priority = serializers.IntegerField(write_only=True, required=False)
     notes = serializers.JSONField(write_only=True, required=False)
+    # Provider-injected origin metadata (gundi-core 1.12.0+). Lets a provider
+    # runner attach things like a deep-link URL back to the source system's UI
+    # so destination integrations can render a cross-reference click-through.
+    # Distinct from event_details (which holds the event's domain data); the
+    # field is pass-through only and not persisted on GundiTrace.
+    provider_metadata = serializers.JSONField(write_only=True, required=False)
 
     class Meta:
         list_serializer_class = EventBulkCreateUpdateSerializer

--- a/cdip_admin/api/v2/tests/test_events_api.py
+++ b/cdip_admin/api/v2/tests/test_events_api.py
@@ -277,6 +277,7 @@ def test_create_single_event_with_status(api_client, mocker, mock_publisher, moc
     ("status_update_request_data"),
     ("priority_update_request_data"),
     ("notes_update_request_data"),
+    ("provider_metadata_update_request_data"),
 ])
 def test_update_event(api_client, mocker, request, request_data, trap_tagger_event_trace, mock_publisher, mock_deduplication, keyauth_headers_trap_tagger):
     # Mock external dependencies

--- a/cdip_admin/conftest.py
+++ b/cdip_admin/conftest.py
@@ -2893,6 +2893,15 @@ def notes_update_request_data():
         ]
     }
 
+
+@pytest.fixture
+def provider_metadata_update_request_data():
+    return {
+        "provider_metadata": {
+            "source_event_url": "https://gundi-er.pamdas.org/events/907a54b9-808b-45a6-919c-b6dd204c32c6"
+        }
+    }
+
 ########################################################################################################################
 # GUNDI 1.0
 ########################################################################################################################


### PR DESCRIPTION
## Summary

Adds `provider_metadata` as a write-only pass-through field on `EventCreateUpdateSerializer`. Required so the new gundi-core 1.12.0 field on `Event` survives DRF validation and flows through to the downstream `EventReceived` / `EventUpdate` routing payloads.

## Why

Operators viewing an event in a destination integration (CMORE, ...) currently have no link back to the source event in the provider system (EarthRanger, ...). The cross-link feature works like this:

1. Provider runner stamps a deep-link URL onto the event as it's posted: `event.provider_metadata = {"source_event_url": "https://gundi-er.pamdas.org/events/<uuid>"}`
2. The sensors API needs to accept that field (this PR) so it flows downstream.
3. cdip-routing relays the field unchanged via the existing EventReceived path.
4. Destination integration reads `event.provider_metadata.source_event_url` and renders a click-through.

Without this serializer change, DRF silently drops the field at step 2 and the URL never reaches the destination.

Naming rationale: `provider_metadata` (not the more anodyne `additional` used on Observation/TextMessage) signals scope at the name level — it's for provider-injected origin annotations, not for source-payload pass-through.

## Coordinated PRs

| Repo | PR | Status |
|---|---|---|
| `gundi-core` | #37 (releases as 1.12.0) | ✅ merged + published |
| **`cdip`** | this PR | open |
| `gundi-integration-earthranger` | TBD — replaces closed PR #20 | next |
| `gundi-integration-cmore` | TBD — renders the URL in CMORE description | last |

## What changes

```python
# cdip_admin/api/v2/serializers.py — EventCreateUpdateSerializer
provider_metadata = serializers.JSONField(write_only=True, required=False)
```

Same shape as the existing `priority` and `notes` pass-through fields from PR #428. The serializer's existing `update()` and `create()` already forward `validated_data` to routing without per-field inspection.

## Test plan

- Extended the existing parametrized `test_update_event` with a `provider_metadata_update_request_data` fixture so the publish-verification flow now covers the new field.
- CI runs the full Django test suite. (Did not run locally — same Django env constraints as PR #428.)
- Syntax check (`python -m py_compile`) passes on the three changed files.

## Behavior

Backward-compatible additive change. Callers that don't send `provider_metadata` see no behavior difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)