### PR TITLE
Wire provider_metadata through event create routing path

### DIFF
--- a/cdip_admin/api/v2/tests/test_events_api.py
+++ b/cdip_admin/api/v2/tests/test_events_api.py
@@ -272,6 +272,39 @@ def test_create_single_event_with_status(api_client, mocker, mock_publisher, moc
     assert data_kwarg.get("payload", {}).get("status") == "active"
 
 
+def test_create_single_event_with_provider_metadata(api_client, mocker, mock_publisher, mock_deduplication, keyauth_headers_trap_tagger):
+    # Mock external dependencies
+    mocker.patch("api.v2.utils.publisher", mock_publisher)
+    mocker.patch("api.v2.utils.is_duplicate_data", mock_deduplication)
+    provider_metadata = {
+        "source_event_url": "https://gundi-er.pamdas.org/events/907a54b9-808b-45a6-919c-b6dd204c32c6"
+    }
+    _test_create_event(
+        api_client=api_client,
+        mock_publisher=mock_publisher,
+        keyauth_headers=keyauth_headers_trap_tagger,
+        data={
+            "source": "camera123",
+            "title": "Animal Detected",
+            "event_type": "animals",
+            "recorded_at": "2024-08-22 13:01:26-0300",
+            "location": {
+                "lon": -109.239682,
+                "lat": -27.104423
+            },
+            "event_details": {
+                "species": "lion"
+            },
+            "provider_metadata": provider_metadata
+        }
+    )
+    # provider_metadata must survive the create -> routing path so downstream
+    # integrations (e.g. ER -> CMORE deep-link) receive the source_event_url.
+    data_kwarg = mock_publisher.publish.call_args.kwargs["data"]
+    assert data_kwarg.get("payload")
+    assert data_kwarg.get("payload", {}).get("provider_metadata") == provider_metadata
+
+
 @pytest.mark.parametrize("request_data", [
     ("species_update_request_data"),
     ("status_update_request_data"),

--- a/cdip_admin/api/v2/utils.py
+++ b/cdip_admin/api/v2/utils.py
@@ -121,7 +121,8 @@ def send_events_to_routing(events, gundi_ids):
                 event_details=event.get("event_details", {}),
                 geometry=event.get("geometry", None),
                 observation_type=StreamPrefixEnum.event.value,
-                status=event.get("status")
+                status=event.get("status"),
+                provider_metadata=event.get("provider_metadata"),
             )
             # Log info for traffic anomaly detection.
             log_data_received(data=event_obj, integration_type=integration_type)

--- a/dependencies/requirements.in
+++ b/dependencies/requirements.in
@@ -64,7 +64,7 @@ jsonschema==4.17.3
 django-celery-beat==2.8.0
 django-storages==1.13.2
 walrus==0.9.5
-gundi-core==1.11.0
+gundi-core==1.12.0
 gundi-client==1.1.0
 gundi-client-v2==2.4.1
 google-cloud-functions==1.13.1

--- a/dependencies/requirements.txt
+++ b/dependencies/requirements.txt
@@ -254,7 +254,7 @@ gundi-client==1.1.0
     #   cdip-connector
 gundi-client-v2==2.4.1
     # via -r requirements.in
-gundi-core==1.11.0
+gundi-core==1.12.0
     # via
     #   -r requirements.in
     #   cdip-connector


### PR DESCRIPTION
## Problem

The source-event deep-link chain (ER stamps `provider_metadata.source_event_url` → Sensors API → routing → CMORE) was broken at the **Sensors API**, not routing.

`EventCreateUpdateSerializer` declares `provider_metadata` (added in #429), so it reaches `validated_data` and shows up in the OpenAPI spec for `POST /v2/events/`. But `send_events_to_routing()` builds the routing `Event(...)` with an **explicit kwarg allow-list** that omitted `provider_metadata`:

```python
event_obj = Event(
    gundi_id=..., ..., status=event.get("status")
    # provider_metadata was NOT here → silently dropped
)
```

So the field died before anything was published to `RAW_OBSERVATIONS_TOPIC`. ER stamped it correctly and cdip-routing (on gundi-core 1.12.0) would have preserved it — but nothing ever arrived, so CMORE always saw `provider_metadata=None`.

## Fix

1. **`cdip_admin/api/v2/utils.py`** — pass `provider_metadata=event.get("provider_metadata")` into the `Event(...)` constructor in `send_events_to_routing()`.
2. **`gundi-core` 1.11.0 → 1.12.0** — the version that introduced the `Event.provider_metadata` field. Verified that 1.12.0's dependency closure is identical to 1.11.0 (both only require `pydantic<2`), so the lockfile change is a surgical one-line bump. Without this bump, Pydantic v1 would silently drop the kwarg even after wiring it through.
3. **Test** — added `test_create_single_event_with_provider_metadata` asserting the field survives the create → routing publish path. The update path was already covered by `test_update_event`; the create path had no coverage, which is how this regression shipped.

## Notes

- The EventUpdate path (`send_event_update_to_routing`) passes the full `changes` dict through, so it had no allow-list gap — only the create path needed the fix.
- `priority` and `notes` are intentionally **not** wired into the create allow-list. Per the serializer comments they are PATCH-only and travel via `EventUpdate.changes`; only `provider_metadata` is needed at create time (it carries the deep link stamped when the event is first created).
- Verified locally that `gundi_core.schemas.v2.Event` accepts `provider_metadata` on 1.12.0 (and that 1.11.0 silently drops it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)