### PR TITLE
GUNDI-5400: stamp explicit triggered_by on action-trigger messages

### DIFF
--- a/cdip_admin/api/v2/serializers.py
+++ b/cdip_admin/api/v2/serializers.py
@@ -1458,6 +1458,13 @@ class ActivityLogDetailsSerializer(ActivityLogBaseSerializer):
 class ActionTriggerSerializer(serializers.Serializer):
     run_in_background = serializers.BooleanField(required=False, default=False)
     config_overrides = serializers.JSONField(required=False)
+    # How the run was initiated. This endpoint is an explicit, operator-driven
+    # invocation, so it defaults to "manual" — the action runner keeps strict
+    # error behavior (4xx) for manual runs and skips quietly for "auto"
+    # (scheduled) runs. See GUNDI-5400.
+    triggered_by = serializers.ChoiceField(
+        choices=["auto", "manual"], required=False, default="manual"
+    )
 
 
 class UserAgreementSerializer(serializers.ModelSerializer):

--- a/cdip_admin/api/v2/tests/test_actions_execution_api.py
+++ b/cdip_admin/api/v2/tests/test_actions_execution_api.py
@@ -11,7 +11,8 @@ pytestmark = pytest.mark.django_db
 def _test_execute_action(
         api_client, mocker, requests_mock,
         user, integration, action, action_response, expected_response,
-        run_in_background=False, config_overrides=None
+        run_in_background=False, config_overrides=None, triggered_by=None,
+        expected_triggered_by="manual",
 ):
     mocker.patch("integrations.models.v2.models.google.auth.transport.requests.Request", mocker.MagicMock())
     mocker.patch("integrations.models.v2.models.google.oauth2.id_token.fetch_id_token", mocker.MagicMock(return_value="fake_id_token"))
@@ -24,6 +25,8 @@ def _test_execute_action(
         request_data["config_overrides"] = config_overrides
     if run_in_background:
         request_data["run_in_background"] = True
+    if triggered_by:
+        request_data["triggered_by"] = triggered_by
     api_client.force_authenticate(user)
 
     response = api_client.post(
@@ -36,6 +39,9 @@ def _test_execute_action(
     assert response.json() == expected_response
     if config_overrides:
         assert gcp_request_mock.last_request.json().get("config_overrides") == config_overrides
+    # The portal forwards how the run was initiated; direct API calls default
+    # to "manual" so the action runner stays strict (GUNDI-5400).
+    assert gcp_request_mock.last_request.json().get("triggered_by") == expected_triggered_by
 
 
 def _test_cannot_execute_action(
@@ -130,4 +136,24 @@ def test_execute_action_with_config_overrides(
         action_response=cellstop_action_auth_response,
         expected_response=cellstop_action_auth_response,
         config_overrides={"username": "test_user", "password": "test_password"}  # pragma: allowlist secret
+    )
+
+
+def test_execute_action_forwards_explicit_triggered_by(
+        api_client, mocker, requests_mock, superuser, organization,
+        cellstop_integration, cellstop_action_auth, cellstop_action_auth_response
+):
+    # A caller may override the default and declare the run automated; the
+    # portal forwards it verbatim to the action runner.
+    _test_execute_action(
+        mocker=mocker,
+        api_client=api_client,
+        requests_mock=requests_mock,
+        user=superuser,
+        integration=cellstop_integration,
+        action=cellstop_action_auth,
+        action_response=cellstop_action_auth_response,
+        expected_response=cellstop_action_auth_response,
+        triggered_by="auto",
+        expected_triggered_by="auto",
     )

--- a/cdip_admin/api/v2/views.py
+++ b/cdip_admin/api/v2/views.py
@@ -564,6 +564,7 @@ class ActionTriggerView(
         response_data = integration_action.execute(
             integration=integration,
             run_in_background=serializer.data.get("run_in_background", False),
-            config_overrides=serializer.data.get("config_overrides")
+            config_overrides=serializer.data.get("config_overrides"),
+            triggered_by=serializer.data.get("triggered_by", "manual"),
         )
         return Response(response_data, status=status.HTTP_200_OK)

--- a/cdip_admin/integrations/models/v2/models.py
+++ b/cdip_admin/integrations/models/v2/models.py
@@ -110,7 +110,7 @@ class IntegrationAction(UUIDAbstractModel, TimestampedModel):
         # Helper method to validate a configuration against the Action's schema
         jsonschema.validate(instance=configuration, schema=self.schema)
 
-    def execute(self, integration, config_overrides=None, run_in_background=False):
+    def execute(self, integration, config_overrides=None, run_in_background=False, triggered_by="manual"):
         service_url = integration.type.service_url
         if not service_url:
             raise ValueError(f"Integration Type '{integration.type}' does not have a service endpoint configured")
@@ -130,6 +130,10 @@ class IntegrationAction(UUIDAbstractModel, TimestampedModel):
                 "integration_id": str(integration.id),
                 "action_id": self.value,
                 "run_in_background": run_in_background,
+                # Direct execute() calls are operator-initiated; default to
+                # "manual" so the action runner keeps strict error behavior.
+                # See GUNDI-5400.
+                "triggered_by": triggered_by,
                 "config_overrides": config_overrides,
             }
         )

--- a/cdip_admin/integrations/tasks.py
+++ b/cdip_admin/integrations/tasks.py
@@ -45,7 +45,11 @@ def run_integration(integration_id=None, action_id=None, pubsub_topic=None):
     pubsub_topic_clean = convert_legacy_topic_name(pubsub_topic)
     data = {
         "integration_id": integration_id,
-        "action_id": action_id
+        "action_id": action_id,
+        # This task is the scheduler path, so mark the run as automated. The
+        # action runner uses this to skip quietly (rather than error) when a
+        # scheduled pull has no usable config. See GUNDI-5400.
+        "triggered_by": "auto",
     }
     # Send pubsub message to GCP
     send_message_to_gcp_pubsub(json.dumps(data), pubsub_topic_clean)

--- a/cdip_admin/integrations/tests/test_tasks.py
+++ b/cdip_admin/integrations/tests/test_tasks.py
@@ -10,8 +10,32 @@ from ..models import (
     Device,
     Source
 )
-from ..tasks import recreate_and_send_movebank_permissions_csv_file, update_mb_permissions_for_group
+import json
+
+from ..tasks import recreate_and_send_movebank_permissions_csv_file, update_mb_permissions_for_group, run_integration
 from ..utils import build_mb_tag_id
+
+
+@pytest.mark.django_db
+def test_run_integration_marks_scheduled_runs_as_auto(
+        mocker, provider_lotek_panthera, lotek_action_pull_positions
+):
+    # The scheduler path must stamp triggered_by="auto" on the PubSub message
+    # so the action runner skips quietly (rather than erroring) when a
+    # scheduled pull has no usable config. See GUNDI-5400.
+    mock_publish = mocker.patch("integrations.tasks.send_message_to_gcp_pubsub")
+
+    run_integration(
+        integration_id=str(provider_lotek_panthera.id),
+        action_id=lotek_action_pull_positions.value,
+        pubsub_topic="some-actions-topic",
+    )
+
+    assert mock_publish.called
+    published_payload = json.loads(mock_publish.call_args.args[0])
+    assert published_payload["triggered_by"] == "auto"
+    assert published_payload["integration_id"] == str(provider_lotek_panthera.id)
+    assert published_payload["action_id"] == lotek_action_pull_positions.value
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Resolves the connector-side coordination in **GUNDI-5400**.

## Why
The action runner (template `gundi-integration-action-runner`, merged) distinguishes **automated** (scheduled) runs from **manual** (operator) runs via a `triggered_by` marker: an automated pull with no usable config skips quietly (no `IntegrationActionFailed`), while a manual run stays strict (404/422). Today that mapping works only because scheduled runs happen to use PubSub and manual runs happen to use the HTTP endpoint — it relies on transport, not intent. This makes the signal explicit so it can't silently flip.

Contract: `triggered_by` is `"auto"` | `"manual"`; absent ⇒ the runner treats it as automated (case-insensitive).

## Changes
- **Scheduled path** — `integrations/tasks.py::run_integration` stamps `triggered_by: "auto"` on the PubSub message.
- **Manual path** — `IntegrationAction.execute()` forwards `triggered_by` (default `"manual"`) in the body posted to `/v1/actions/execute`; threaded through `ActionTriggerView.execute` and `ActionTriggerSerializer` (a `ChoiceField` of `auto`/`manual`, default `manual`, so callers may override).

## Tests
- `test_tasks.py::test_run_integration_marks_scheduled_runs_as_auto` — scheduled publish includes `triggered_by="auto"`.
- `test_actions_execution_api.py` — the shared helper now asserts direct API calls default to `triggered_by="manual"`; added `test_execute_action_forwards_explicit_triggered_by` for an explicit `"auto"` override.

> Note: ran `py_compile` on all changed files locally (no local Postgres/Docker to run the DB-backed suite); CI will run the full pytest suite.

## Not included (separate, per the ticket)
The related observation about why the periodic pull task is enabled (`is_used_as_provider`) for a destination-only integration is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)