### PR TITLE
GUNDI-5400: disable pull tasks when an integration stops being a provider

### DIFF
--- a/cdip_admin/integrations/signals.py
+++ b/cdip_admin/integrations/signals.py
@@ -1,9 +1,9 @@
 import logging
 
-from django.db.models.signals import pre_delete
+from django.db.models.signals import post_delete, pre_delete
 from django.dispatch import receiver
 
-from .models.v2 import IntegrationConfiguration
+from .models.v2 import Integration, IntegrationConfiguration, RouteProvider
 
 logger = logging.getLogger(__name__)
 
@@ -20,3 +20,36 @@ def on_integration_config_delete(sender, **kwargs):
     config = kwargs.get("instance")
     if config and config.periodic_task:
         config.periodic_task.delete()
+
+
+@receiver(post_delete, sender=RouteProvider)
+def disable_pull_tasks_when_no_longer_a_provider(sender, **kwargs):
+    """Pause scheduled pull actions when an integration stops being a provider.
+
+    `RouteProvider._post_save` enables an integration's periodic pull tasks when
+    it's added as a provider to a route. This is the mirror image: when a
+    provider link is removed (route edited via `data_providers.set(...)`, or the
+    route deleted), disable those tasks if the integration is no longer a
+    provider in ANY route — otherwise they keep firing pull_events /
+    pull_observations on what is now a destination-only integration. See
+    GUNDI-5400.
+
+    A signal (rather than RouteProvider.delete()) is used because removals go
+    through `QuerySet.delete()` on the through model, which bypasses the
+    model's delete() but still dispatches post_delete.
+    """
+    instance = kwargs.get("instance")
+    if not instance:
+        return
+    try:
+        integration = Integration.objects.get(pk=instance.integration_id)
+    except Integration.DoesNotExist:
+        # The integration itself was deleted (cascade) — its tasks go with it.
+        return
+    if integration.is_used_as_provider:
+        # Still a provider via another route; leave the tasks enabled.
+        return
+    for config in integration.periodic_pull_action_configurations:
+        if config.periodic_task and config.periodic_task.enabled:
+            config.periodic_task.enabled = False
+            config.periodic_task.save()

--- a/cdip_admin/integrations/tests/test_actions_scheduling.py
+++ b/cdip_admin/integrations/tests/test_actions_scheduling.py
@@ -2,11 +2,47 @@ import pytest
 import json
 from django_celery_beat.models import  PeriodicTask
 
-from integrations.models import Integration
+from integrations.models import Integration, Route, RouteProvider
 from ..models import IntegrationConfiguration
 
 
 pytestmark = pytest.mark.django_db
+
+
+def test_pull_task_disabled_when_integration_no_longer_a_provider(
+        provider_lotek_panthera, lotek_action_auth, lotek_action_pull_positions
+):
+    # The fixture wires the integration as a provider in its default route, so
+    # its periodic pull task starts enabled.
+    periodic_task = PeriodicTask.objects.get(task="integrations.tasks.run_integration")
+    assert periodic_task.enabled
+
+    # Remove it as a provider from every route (e.g. route edited/deleted).
+    RouteProvider.objects.filter(integration=provider_lotek_panthera).delete()
+
+    assert not provider_lotek_panthera.is_used_as_provider
+    periodic_task.refresh_from_db()
+    assert not periodic_task.enabled  # GUNDI-5400: paused, no longer a provider
+
+
+def test_pull_task_stays_enabled_if_still_a_provider_in_another_route(
+        organization, provider_lotek_panthera, lotek_action_auth, lotek_action_pull_positions
+):
+    periodic_task = PeriodicTask.objects.get(task="integrations.tasks.run_integration")
+    assert periodic_task.enabled
+
+    # The integration is also a provider in a second route.
+    second_route = Route.objects.create(owner=organization, name="Second Route")
+    RouteProvider.objects.create(integration=provider_lotek_panthera, route=second_route)
+
+    # Removing only the default-route provider link must NOT disable the task.
+    RouteProvider.objects.filter(
+        integration=provider_lotek_panthera, route=provider_lotek_panthera.default_route
+    ).delete()
+
+    assert provider_lotek_panthera.is_used_as_provider
+    periodic_task.refresh_from_db()
+    assert periodic_task.enabled
 
 
 def test_periodic_task_is_created_for_periodic_actions(provider_lotek_panthera, lotek_action_auth, lotek_action_pull_positions):


### PR DESCRIPTION
The root-cause half of **GUNDI-5400** (complements #431, which adds the `triggered_by` marker).

## Root cause
A periodic pull task's `enabled` state is set to `is_used_as_provider` only at config-creation time, and `RouteProvider._post_save` **enables** the tasks when an integration is added as a provider — but **nothing disables them when it stops being one**. So an integration that was a provider at some point and is later used only as a destination keeps firing `pull_events`/`pull_observations` on every scheduled tick (the noise reported for `ef2f2575-…`).

## Fix
Add a `post_delete` receiver on `RouteProvider` (in `integrations/signals.py`, mirroring the existing `_post_save` enable path): when a provider link is removed and the integration is no longer a provider in **any** route, disable its periodic pull tasks.

A signal (not `RouteProvider.delete()`) is used deliberately: route edits remove providers via `data_providers.set(...)`, whose removals go through `QuerySet.delete()` on the through model — bypassing the model's `delete()` but still dispatching `post_delete`. This also covers route deletion (cascade) and admin edits. The integration-deleted cascade is a no-op (guarded by `Integration.DoesNotExist`).

## Tests
- `test_pull_task_disabled_when_integration_no_longer_a_provider` — removing the last provider link disables the task.
- `test_pull_task_stays_enabled_if_still_a_provider_in_another_route` — removing one of two provider links leaves it enabled.

> `py_compile`-clean locally (no local Postgres/Docker); CI runs the DB-backed suite.

## Scope note
This prevents the problem **going forward**. Integrations whose pull task is *already* stuck-enabled (became destination-only before this lands) aren't retroactively disabled by the signal — but the connector-side changes (skip-on-no-config + `run_on_schedule` defaulting off in the ER connector) already neutralize the symptom for those, so no data backfill is planned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)