### PR TITLE
GUNDI-5383: field_mappings validation + delete-configuration endpoint

### DIFF
--- a/cdip_admin/api/v2/permissions.py
+++ b/cdip_admin/api/v2/permissions.py
@@ -51,7 +51,7 @@ def get_user_org(request, view) -> str:
         integration_id = request.data.get("provider")
         org_id = str(Integration.objects.get(id=integration_id).owner.id) if integration_id else None
     elif view.basename == "routes":
-        if view.action in ["retrieve", "update", "partial_update", "destroy"]:
+        if view.action in ["retrieve", "update", "partial_update", "destroy", "delete_configuration"]:
             route_id = context.get("pk")
             org_id = str(Route.objects.get(id=route_id).owner.id) if route_id else None
         elif request.data.get("owner"):

--- a/cdip_admin/api/v2/permissions.py
+++ b/cdip_admin/api/v2/permissions.py
@@ -79,7 +79,7 @@ class IsOrgAdmin(permissions.BasePermission):
         "integrations": ["list", "create", "retrieve", "update", "partial_update", "destroy"],
         "actions": ["execute"],
         "sources": ["list", "create", "retrieve", "update", "partial_update", "destroy"],
-        "routes": ["list", "create", "retrieve", "update", "partial_update", "destroy"],
+        "routes": ["list", "create", "retrieve", "update", "partial_update", "destroy", "delete_configuration"],
         "logs": ["list", "retrieve", "revert"]
     }
 

--- a/cdip_admin/api/v2/serializers.py
+++ b/cdip_admin/api/v2/serializers.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import datetime
 
 import jsonschema
@@ -836,12 +837,129 @@ class SourceRetrieveSerializer(serializers.ModelSerializer):
         return RoutingRuleSummarySerializer(instance=obj.integration.routing_rules, many=True).data
 
 
+FIELD_MAPPING_ACTION_TYPES = {"ev", "evu", "obv"}
+
+
+def _validate_field_mapping_rule(rule, path, errors):
+    if not isinstance(rule, dict):
+        errors[path] = "must be an object"
+        return
+    destination_field = rule.get("destination_field")
+    if not isinstance(destination_field, str) or not destination_field:
+        errors[f"{path}.destination_field"] = "is required and must be a non-empty string"
+    provider_field = rule.get("provider_field")
+    if provider_field is not None and not isinstance(provider_field, str):
+        errors[f"{path}.provider_field"] = "must be a string"
+    default = rule.get("default")
+    if default is not None and not isinstance(default, str):
+        errors[f"{path}.default"] = "must be a string"
+    map_ = rule.get("map")
+    if map_ is not None:
+        if not isinstance(map_, dict):
+            errors[f"{path}.map"] = "must be an object"
+        else:
+            if any(not isinstance(k, str) or not isinstance(v, str) for k, v in map_.items()):
+                errors[f"{path}.map"] = "keys and values must be strings"
+            if provider_field is None:
+                errors[f"{path}.provider_field"] = "is required when 'map' is present"
+    if default is None and map_ is None:
+        errors[path] = "must define at least one of 'default' or 'map'"
+
+
+def _validate_field_mappings_schema(field_mappings):
+    """Validate the shape of ``RouteConfiguration.data['field_mappings']``.
+
+    Shape: ``{PROVIDER_UUID: {ACTION_TYPE: {DESTINATION_UUID: rule}}}`` where
+    ``ACTION_TYPE`` is one of ``ev``/``evu``/``obv``. See Confluence "Field Mappings".
+    Raises ``serializers.ValidationError`` if the structure or any rule is invalid,
+    or if any UUID does not reference an existing ``Integration``.
+    """
+    if not isinstance(field_mappings, dict):
+        raise serializers.ValidationError({"field_mappings": "must be an object"})
+
+    errors = {}
+    referenced_ids = set()
+
+    for provider_id, by_action in field_mappings.items():
+        try:
+            uuid.UUID(str(provider_id))
+        except (ValueError, TypeError):
+            errors[f"field_mappings.{provider_id}"] = "key must be a valid UUID"
+            continue
+        referenced_ids.add(str(provider_id))
+        if not isinstance(by_action, dict):
+            errors[f"field_mappings.{provider_id}"] = "must be an object keyed by action type"
+            continue
+        for action_type, by_destination in by_action.items():
+            if action_type not in FIELD_MAPPING_ACTION_TYPES:
+                errors[f"field_mappings.{provider_id}.{action_type}"] = (
+                    f"must be one of {sorted(FIELD_MAPPING_ACTION_TYPES)}"
+                )
+                continue
+            if not isinstance(by_destination, dict):
+                errors[f"field_mappings.{provider_id}.{action_type}"] = (
+                    "must be an object keyed by destination UUID"
+                )
+                continue
+            for dest_id, rule in by_destination.items():
+                try:
+                    uuid.UUID(str(dest_id))
+                except (ValueError, TypeError):
+                    errors[f"field_mappings.{provider_id}.{action_type}.{dest_id}"] = (
+                        "key must be a valid UUID"
+                    )
+                    continue
+                referenced_ids.add(str(dest_id))
+                _validate_field_mapping_rule(
+                    rule, f"field_mappings.{provider_id}.{action_type}.{dest_id}", errors
+                )
+
+    if not errors and referenced_ids:
+        existing = {
+            str(pk)
+            for pk in Integration.objects.filter(id__in=referenced_ids).values_list("id", flat=True)
+        }
+        missing = referenced_ids - existing
+        if missing:
+            errors["field_mappings"] = f"unknown Integration IDs: {sorted(missing)}"
+
+    if errors:
+        raise serializers.ValidationError(errors)
+
+
+def _validate_field_mappings_in_route_context(field_mappings, provider_ids, destination_ids):
+    """Ensure every provider/destination referenced in ``field_mappings`` belongs
+    to the route's ``data_providers`` / ``destinations``."""
+    errors = {}
+    for provider_id, by_action in field_mappings.items():
+        if str(provider_id) not in provider_ids:
+            errors[f"field_mappings.{provider_id}"] = (
+                "provider is not in this route's data_providers"
+            )
+            continue
+        for action_type, by_destination in (by_action or {}).items():
+            for dest_id in (by_destination or {}):
+                if str(dest_id) not in destination_ids:
+                    errors[f"field_mappings.{provider_id}.{action_type}.{dest_id}"] = (
+                        "destination is not in this route's destinations"
+                    )
+    if errors:
+        raise serializers.ValidationError({"configuration": {"data": errors}})
+
+
 class RouteConfigurationSerializer(serializers.ModelSerializer):
     id = serializers.UUIDField(read_only=True)
 
     class Meta:
         model = RouteConfiguration
         fields = ["id", "name", "data"]
+
+    def validate_data(self, value):
+        if isinstance(value, dict):
+            field_mappings = value.get("field_mappings")
+            if field_mappings:
+                _validate_field_mappings_schema(field_mappings)
+        return value
 
 
 class PKRelatedOrNestedField(serializers.PrimaryKeyRelatedField):
@@ -907,14 +1025,60 @@ class RouteCreateUpdateSerializer(serializers.ModelSerializer):
         return self._validate_integrations_selection(integration_ids=value)
 
     def validate_configuration(self, value):
-        # We support sending an id or a nested configuration object
+        # Accept either an existing RouteConfiguration (UUID) or a nested dict.
+        # For dicts we run the full nested validation (incl. field_mappings schema)
+        # and defer the save to create/update so the global validate() can do
+        # route-context checks before any DB write happens.
         if isinstance(value, dict):
-            # Create the configuration
-            configuration = RouteConfigurationSerializer(data=value)
-            configuration.is_valid()
-            configuration.save()
-            return configuration.instance
+            existing = self.instance.configuration if self.instance else None
+            nested = RouteConfigurationSerializer(
+                instance=existing, data=value, partial=existing is not None
+            )
+            nested.is_valid(raise_exception=True)
+            return nested
         return value
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        nested = attrs.get("configuration")
+        if isinstance(nested, RouteConfigurationSerializer):
+            data = nested.validated_data.get("data") or {}
+            field_mappings = data.get("field_mappings")
+            if field_mappings:
+                providers = attrs.get("data_providers")
+                if providers is None and self.instance is not None:
+                    providers = list(self.instance.data_providers.all())
+                destinations = attrs.get("destinations")
+                if destinations is None and self.instance is not None:
+                    destinations = list(self.instance.destinations.all())
+                _validate_field_mappings_in_route_context(
+                    field_mappings,
+                    provider_ids={str(p.id) for p in (providers or [])},
+                    destination_ids={str(d.id) for d in (destinations or [])},
+                )
+        return attrs
+
+    def _materialize_configuration(self, value):
+        # Save the nested RouteConfigurationSerializer (create or update in-place)
+        # and return the resulting model instance for the FK assignment.
+        if isinstance(value, RouteConfigurationSerializer):
+            value.save()
+            return value.instance
+        return value
+
+    def create(self, validated_data):
+        if "configuration" in validated_data:
+            validated_data["configuration"] = self._materialize_configuration(
+                validated_data["configuration"]
+            )
+        return super().create(validated_data)
+
+    def update(self, instance, validated_data):
+        if "configuration" in validated_data:
+            validated_data["configuration"] = self._materialize_configuration(
+                validated_data["configuration"]
+            )
+        return super().update(instance, validated_data)
 
 
 class RouteRetrieveFullSerializer(serializers.ModelSerializer):

--- a/cdip_admin/api/v2/serializers.py
+++ b/cdip_admin/api/v2/serializers.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import datetime
+from typing import Any, Iterable
 
 import jsonschema
 from rest_framework import serializers
@@ -837,89 +838,135 @@ class SourceRetrieveSerializer(serializers.ModelSerializer):
         return RoutingRuleSummarySerializer(instance=obj.integration.routing_rules, many=True).data
 
 
-FIELD_MAPPING_ACTION_TYPES = {"ev", "evu", "obv"}
+FIELD_MAPPING_ACTION_TYPES: frozenset[str] = frozenset({"ev", "evu", "obv"})
 
 
-def _validate_field_mapping_rule(rule, path, errors):
+# ---- Schema validation for RouteConfiguration.data["field_mappings"] ------
+#
+# Tree shape (3 nesting levels):
+#   { PROVIDER_UUID: { action_type: { DESTINATION_UUID: rule } } }
+# Each helper validates one level and returns a pure (collected_ids, errors)
+# tuple instead of mutating shared state, so the higher-level validator just
+# composes them.
+
+
+def _is_uuid_string(value: Any) -> bool:
+    try:
+        uuid.UUID(str(value))
+    except (ValueError, TypeError):
+        return False
+    return True
+
+
+def _check_rule_payload(rule: Any, path: str) -> dict[str, str]:
+    """Validate the leaf of the tree — a single field-mapping rule."""
     if not isinstance(rule, dict):
-        errors[path] = "must be an object"
-        return
+        return {path: "must be an object"}
+
     destination_field = rule.get("destination_field")
-    if not isinstance(destination_field, str) or not destination_field:
-        errors[f"{path}.destination_field"] = "is required and must be a non-empty string"
     provider_field = rule.get("provider_field")
+    default = rule.get("default")
+    map_ = rule.get("map")
+
+    errors: dict[str, str] = {}
+
+    if not (isinstance(destination_field, str) and destination_field):
+        errors[f"{path}.destination_field"] = "is required and must be a non-empty string"
     if provider_field is not None and not isinstance(provider_field, str):
         errors[f"{path}.provider_field"] = "must be a string"
-    default = rule.get("default")
     if default is not None and not isinstance(default, str):
         errors[f"{path}.default"] = "must be a string"
-    map_ = rule.get("map")
-    if map_ is not None:
-        if not isinstance(map_, dict):
-            errors[f"{path}.map"] = "must be an object"
-        else:
-            if any(not isinstance(k, str) or not isinstance(v, str) for k, v in map_.items()):
-                errors[f"{path}.map"] = "keys and values must be strings"
-            if provider_field is None:
-                errors[f"{path}.provider_field"] = "is required when 'map' is present"
+
+    if isinstance(map_, dict):
+        all_strings = all(isinstance(k, str) and isinstance(v, str) for k, v in map_.items())
+        if not all_strings:
+            errors[f"{path}.map"] = "keys and values must be strings"
+        if provider_field is None:
+            errors[f"{path}.provider_field"] = "is required when 'map' is present"
+    elif map_ is not None:
+        errors[f"{path}.map"] = "must be an object"
+
     if default is None and map_ is None:
         errors[path] = "must define at least one of 'default' or 'map'"
 
+    return errors
 
-def _validate_field_mappings_schema(field_mappings):
-    """Validate the shape of ``RouteConfiguration.data['field_mappings']``.
 
-    Shape: ``{PROVIDER_UUID: {ACTION_TYPE: {DESTINATION_UUID: rule}}}`` where
-    ``ACTION_TYPE`` is one of ``ev``/``evu``/``obv``. See Confluence "Field Mappings".
-    Raises ``serializers.ValidationError`` if the structure or any rule is invalid,
-    or if any UUID does not reference an existing ``Integration``.
+def _validate_destinations_block(
+    by_destination: Any, path: str
+) -> tuple[set[str], dict[str, str]]:
+    """Validate the destination-keyed dict under a single (provider, action_type)."""
+    if not isinstance(by_destination, dict):
+        return set(), {path: "must be an object keyed by destination UUID"}
+
+    destination_ids: set[str] = set()
+    errors: dict[str, str] = {}
+    for destination_id, rule in by_destination.items():
+        destination_path = f"{path}.{destination_id}"
+        if not _is_uuid_string(destination_id):
+            errors[destination_path] = "key must be a valid UUID"
+            continue
+        destination_ids.add(str(destination_id))
+        errors.update(_check_rule_payload(rule, destination_path))
+    return destination_ids, errors
+
+
+def _validate_actions_block(by_action: Any, path: str) -> tuple[set[str], dict[str, str]]:
+    """Validate the action-type-keyed dict under a single provider."""
+    if not isinstance(by_action, dict):
+        return set(), {path: "must be an object keyed by action type"}
+
+    destination_ids: set[str] = set()
+    errors: dict[str, str] = {}
+    for action_type, by_destination in by_action.items():
+        action_path = f"{path}.{action_type}"
+        if action_type not in FIELD_MAPPING_ACTION_TYPES:
+            errors[action_path] = f"must be one of {sorted(FIELD_MAPPING_ACTION_TYPES)}"
+            continue
+        block_ids, block_errors = _validate_destinations_block(by_destination, action_path)
+        destination_ids |= block_ids
+        errors.update(block_errors)
+    return destination_ids, errors
+
+
+def _find_unknown_integration_ids(referenced_ids: Iterable[str]) -> set[str]:
+    referenced = set(referenced_ids)
+    if not referenced:
+        return set()
+    existing = {
+        str(pk)
+        for pk in Integration.objects.filter(id__in=referenced).values_list("id", flat=True)
+    }
+    return referenced - existing
+
+
+def _validate_field_mappings_schema(field_mappings: Any) -> None:
+    """Raise ``serializers.ValidationError`` if ``field_mappings`` violates the schema.
+
+    See Confluence "Field Mappings" for the canonical shape. This function only
+    cares about *structural* validity and that referenced UUIDs map to existing
+    ``Integration`` rows; the route-context check (provider/destination belong
+    to this route) lives in :func:`_validate_field_mappings_in_route_context`.
     """
     if not isinstance(field_mappings, dict):
         raise serializers.ValidationError({"field_mappings": "must be an object"})
 
-    errors = {}
-    referenced_ids = set()
+    provider_ids: set[str] = set()
+    destination_ids: set[str] = set()
+    errors: dict[str, str] = {}
 
     for provider_id, by_action in field_mappings.items():
-        try:
-            uuid.UUID(str(provider_id))
-        except (ValueError, TypeError):
-            errors[f"field_mappings.{provider_id}"] = "key must be a valid UUID"
+        provider_path = f"field_mappings.{provider_id}"
+        if not _is_uuid_string(provider_id):
+            errors[provider_path] = "key must be a valid UUID"
             continue
-        referenced_ids.add(str(provider_id))
-        if not isinstance(by_action, dict):
-            errors[f"field_mappings.{provider_id}"] = "must be an object keyed by action type"
-            continue
-        for action_type, by_destination in by_action.items():
-            if action_type not in FIELD_MAPPING_ACTION_TYPES:
-                errors[f"field_mappings.{provider_id}.{action_type}"] = (
-                    f"must be one of {sorted(FIELD_MAPPING_ACTION_TYPES)}"
-                )
-                continue
-            if not isinstance(by_destination, dict):
-                errors[f"field_mappings.{provider_id}.{action_type}"] = (
-                    "must be an object keyed by destination UUID"
-                )
-                continue
-            for dest_id, rule in by_destination.items():
-                try:
-                    uuid.UUID(str(dest_id))
-                except (ValueError, TypeError):
-                    errors[f"field_mappings.{provider_id}.{action_type}.{dest_id}"] = (
-                        "key must be a valid UUID"
-                    )
-                    continue
-                referenced_ids.add(str(dest_id))
-                _validate_field_mapping_rule(
-                    rule, f"field_mappings.{provider_id}.{action_type}.{dest_id}", errors
-                )
+        provider_ids.add(str(provider_id))
+        block_ids, block_errors = _validate_actions_block(by_action, provider_path)
+        destination_ids |= block_ids
+        errors.update(block_errors)
 
-    if not errors and referenced_ids:
-        existing = {
-            str(pk)
-            for pk in Integration.objects.filter(id__in=referenced_ids).values_list("id", flat=True)
-        }
-        missing = referenced_ids - existing
+    if not errors:
+        missing = _find_unknown_integration_ids(provider_ids | destination_ids)
         if missing:
             errors["field_mappings"] = f"unknown Integration IDs: {sorted(missing)}"
 
@@ -927,22 +974,36 @@ def _validate_field_mappings_schema(field_mappings):
         raise serializers.ValidationError(errors)
 
 
-def _validate_field_mappings_in_route_context(field_mappings, provider_ids, destination_ids):
-    """Ensure every provider/destination referenced in ``field_mappings`` belongs
-    to the route's ``data_providers`` / ``destinations``."""
-    errors = {}
+# ---- Route-context cross-check --------------------------------------------
+
+
+def _find_unknown_destinations(
+    provider_id: str, by_action: Any, valid_destination_ids: set[str]
+) -> dict[str, str]:
+    """Return one error per destination under ``provider_id`` not in ``valid_destination_ids``."""
+    return {
+        f"field_mappings.{provider_id}.{action_type}.{destination_id}":
+            "destination is not in this route's destinations"
+        for action_type, by_destination in (by_action or {}).items()
+        for destination_id in (by_destination or {})
+        if str(destination_id) not in valid_destination_ids
+    }
+
+
+def _validate_field_mappings_in_route_context(
+    field_mappings: dict[str, Any],
+    provider_ids: set[str],
+    destination_ids: set[str],
+) -> None:
+    """Ensure every provider/destination in ``field_mappings`` belongs to the route."""
+    errors: dict[str, str] = {}
     for provider_id, by_action in field_mappings.items():
+        provider_path = f"field_mappings.{provider_id}"
         if str(provider_id) not in provider_ids:
-            errors[f"field_mappings.{provider_id}"] = (
-                "provider is not in this route's data_providers"
-            )
+            errors[provider_path] = "provider is not in this route's data_providers"
             continue
-        for action_type, by_destination in (by_action or {}).items():
-            for dest_id in (by_destination or {}):
-                if str(dest_id) not in destination_ids:
-                    errors[f"field_mappings.{provider_id}.{action_type}.{dest_id}"] = (
-                        "destination is not in this route's destinations"
-                    )
+        errors.update(_find_unknown_destinations(provider_id, by_action, destination_ids))
+
     if errors:
         raise serializers.ValidationError({"configuration": {"data": errors}})
 
@@ -954,11 +1015,9 @@ class RouteConfigurationSerializer(serializers.ModelSerializer):
         model = RouteConfiguration
         fields = ["id", "name", "data"]
 
-    def validate_data(self, value):
-        if isinstance(value, dict):
-            field_mappings = value.get("field_mappings")
-            if field_mappings:
-                _validate_field_mappings_schema(field_mappings)
+    def validate_data(self, value: Any) -> Any:
+        if isinstance(value, dict) and value.get("field_mappings"):
+            _validate_field_mappings_schema(value["field_mappings"])
         return value
 
 
@@ -1024,61 +1083,78 @@ class RouteCreateUpdateSerializer(serializers.ModelSerializer):
         # Check if the user is allowed to manage the selected destinations
         return self._validate_integrations_selection(integration_ids=value)
 
-    def validate_configuration(self, value):
-        # Accept either an existing RouteConfiguration (UUID) or a nested dict.
-        # For dicts we run the full nested validation (incl. field_mappings schema)
-        # and defer the save to create/update so the global validate() can do
-        # route-context checks before any DB write happens.
-        if isinstance(value, dict):
-            existing = self.instance.configuration if self.instance else None
-            nested = RouteConfigurationSerializer(
-                instance=existing, data=value, partial=existing is not None
-            )
-            nested.is_valid(raise_exception=True)
-            return nested
-        return value
+    def validate_configuration(self, value: Any) -> Any:
+        """Run nested config validation eagerly; defer the save to create/update.
 
-    def validate(self, attrs):
+        If a dict comes in we either reuse the route's existing
+        ``RouteConfiguration`` (for PATCH on a route that already has one) or
+        instantiate a fresh one. The save is deferred so ``validate()`` can run
+        route-context checks before any DB write happens.
+        """
+        if not isinstance(value, dict):
+            return value
+        existing = self.instance.configuration if self.instance else None
+        nested = RouteConfigurationSerializer(
+            instance=existing, data=value, partial=existing is not None,
+        )
+        nested.is_valid(raise_exception=True)
+        return nested
+
+    def validate(self, attrs: dict) -> dict:
         attrs = super().validate(attrs)
-        nested = attrs.get("configuration")
-        if isinstance(nested, RouteConfigurationSerializer):
-            data = nested.validated_data.get("data") or {}
-            field_mappings = data.get("field_mappings")
-            if field_mappings:
-                providers = attrs.get("data_providers")
-                if providers is None and self.instance is not None:
-                    providers = list(self.instance.data_providers.all())
-                destinations = attrs.get("destinations")
-                if destinations is None and self.instance is not None:
-                    destinations = list(self.instance.destinations.all())
-                _validate_field_mappings_in_route_context(
-                    field_mappings,
-                    provider_ids={str(p.id) for p in (providers or [])},
-                    destination_ids={str(d.id) for d in (destinations or [])},
-                )
+        field_mappings = self._extract_field_mappings(attrs)
+        if not field_mappings:
+            return attrs
+        _validate_field_mappings_in_route_context(
+            field_mappings,
+            provider_ids=self._resolve_relation_ids(attrs, "data_providers"),
+            destination_ids=self._resolve_relation_ids(attrs, "destinations"),
+        )
         return attrs
 
-    def _materialize_configuration(self, value):
-        # Save the nested RouteConfigurationSerializer (create or update in-place)
-        # and return the resulting model instance for the FK assignment.
+    @staticmethod
+    def _extract_field_mappings(attrs: dict) -> dict[str, Any] | None:
+        nested = attrs.get("configuration")
+        if not isinstance(nested, RouteConfigurationSerializer):
+            return None
+        data = nested.validated_data.get("data") or {}
+        return data.get("field_mappings")
+
+    def _resolve_relation_ids(self, attrs: dict, field_name: str) -> set[str]:
+        """Return the set of related Integration ids for a Route M2M field.
+
+        Falls back to the stored values on the instance when the field isn't in
+        ``attrs`` (the usual case for a partial update).
+        """
+        provided = attrs.get(field_name)
+        if provided is not None:
+            return {str(item.id) for item in provided}
+        if self.instance is None:
+            return set()
+        return {str(item.id) for item in getattr(self.instance, field_name).all()}
+
+    @staticmethod
+    def _materialize_configuration(value: Any) -> Any:
+        """Save a deferred ``RouteConfigurationSerializer`` and unwrap to a model
+        instance suitable for FK assignment. Anything else is returned as-is."""
         if isinstance(value, RouteConfigurationSerializer):
             value.save()
             return value.instance
         return value
 
-    def create(self, validated_data):
-        if "configuration" in validated_data:
-            validated_data["configuration"] = self._materialize_configuration(
-                validated_data["configuration"]
-            )
-        return super().create(validated_data)
+    def _materialize_validated_data(self, validated_data: dict) -> dict:
+        if "configuration" not in validated_data:
+            return validated_data
+        return {
+            **validated_data,
+            "configuration": self._materialize_configuration(validated_data["configuration"]),
+        }
 
-    def update(self, instance, validated_data):
-        if "configuration" in validated_data:
-            validated_data["configuration"] = self._materialize_configuration(
-                validated_data["configuration"]
-            )
-        return super().update(instance, validated_data)
+    def create(self, validated_data: dict) -> Route:
+        return super().create(self._materialize_validated_data(validated_data))
+
+    def update(self, instance: Route, validated_data: dict) -> Route:
+        return super().update(instance, self._materialize_validated_data(validated_data))
 
 
 class RouteRetrieveFullSerializer(serializers.ModelSerializer):

--- a/cdip_admin/api/v2/serializers.py
+++ b/cdip_admin/api/v2/serializers.py
@@ -1016,7 +1016,10 @@ class RouteConfigurationSerializer(serializers.ModelSerializer):
         fields = ["id", "name", "data"]
 
     def validate_data(self, value: Any) -> Any:
-        if isinstance(value, dict) and value.get("field_mappings"):
+        # The presence of the key — not its truthiness — determines whether the
+        # schema check runs. This way ``{"field_mappings": null}`` or
+        # ``{"field_mappings": []}`` get rejected instead of silently passing.
+        if isinstance(value, dict) and "field_mappings" in value:
             _validate_field_mappings_schema(value["field_mappings"])
         return value
 
@@ -1114,10 +1117,18 @@ class RouteCreateUpdateSerializer(serializers.ModelSerializer):
 
     @staticmethod
     def _extract_field_mappings(attrs: dict) -> dict[str, Any] | None:
+        # Configuration can arrive either as a nested (unsaved) serializer or
+        # as an already-resolved ``RouteConfiguration`` instance (when the
+        # client passes a UUID). Both paths must trigger the route-context
+        # cross-check; otherwise an existing config with mismatched UUIDs
+        # could be attached and bypass validation.
         nested = attrs.get("configuration")
-        if not isinstance(nested, RouteConfigurationSerializer):
+        if isinstance(nested, RouteConfigurationSerializer):
+            data = nested.validated_data.get("data") or {}
+        elif isinstance(nested, RouteConfiguration):
+            data = nested.data or {}
+        else:
             return None
-        data = nested.validated_data.get("data") or {}
         return data.get("field_mappings")
 
     def _resolve_relation_ids(self, attrs: dict, field_name: str) -> set[str]:

--- a/cdip_admin/api/v2/tests/test_routes_api.py
+++ b/cdip_admin/api/v2/tests/test_routes_api.py
@@ -921,8 +921,8 @@ def test_create_route_rejects_provider_not_in_data_providers(
 def test_patch_route_updates_existing_configuration_in_place(
     api_client, superuser, route_2, provider_movebank_ewt
 ):
-    # route_2 ya tiene er_route_configuration_elephants attached — esperamos
-    # que el PATCH actualice esa misma fila en lugar de crear una nueva.
+    # route_2 already has er_route_configuration_elephants attached — we expect
+    # the PATCH to update that same row in place instead of creating a new one.
     original_config_id = route_2.configuration.id
     destination = route_2.destinations.first()
     new_configuration = {
@@ -954,7 +954,7 @@ def test_patch_route_updates_existing_configuration_in_place(
 def test_patch_route_configuration_without_field_mappings_passes(
     api_client, superuser, route_2
 ):
-    # data sin field_mappings: el validador de schema no debe activarse
+    # data without field_mappings: the schema validator must not run
     api_client.force_authenticate(superuser)
     response = api_client.patch(
         reverse("routes-detail", kwargs={"pk": route_2.id}),
@@ -1014,7 +1014,7 @@ def test_delete_route_configuration_as_org_admin_removes_the_row(
 def test_delete_route_configuration_keeps_row_when_shared_with_another_route(
     api_client, superuser, route_1, route_2
 ):
-    # Comparte la misma RouteConfiguration entre route_1 y route_2
+    # Share the same RouteConfiguration between route_1 and route_2
     shared_config = route_2.configuration
     route_1.configuration = shared_config
     route_1.save()
@@ -1028,7 +1028,7 @@ def test_delete_route_configuration_keeps_row_when_shared_with_another_route(
     route_2.refresh_from_db()
     route_1.refresh_from_db()
     assert route_2.configuration is None
-    # La fila sigue existiendo porque route_1 todavía la referencia
+    # The row still exists because route_1 keeps referencing it
     assert RouteConfiguration.objects.filter(id=shared_config.id).exists()
     assert route_1.configuration_id == shared_config.id
 
@@ -1055,7 +1055,7 @@ def test_cannot_delete_route_configuration_as_org_viewer(
     )
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
-    # La configuration sigue ligada al route
+    # The configuration is still attached to the route
     route_2.refresh_from_db()
     assert route_2.configuration is not None
 
@@ -1063,7 +1063,7 @@ def test_cannot_delete_route_configuration_as_org_viewer(
 def test_cannot_delete_unrelated_route_configuration_as_org_admin(
     api_client, org_admin_user, route_2
 ):
-    # org_admin_user pertenece a `organization`, no a `other_organization` (dueña de route_2)
+    # org_admin_user belongs to `organization`, not to `other_organization` (which owns route_2)
     api_client.force_authenticate(org_admin_user)
     response = api_client.delete(
         reverse("routes-delete-configuration", kwargs={"pk": route_2.id})

--- a/cdip_admin/api/v2/tests/test_routes_api.py
+++ b/cdip_admin/api/v2/tests/test_routes_api.py
@@ -1,8 +1,10 @@
+import uuid
+
 import pytest
 from django.urls import reverse
 from rest_framework import status
 from integrations.models import (
-    Route, get_user_routes_qs
+    Route, RouteConfiguration, get_user_routes_qs
 )
 
 
@@ -737,3 +739,336 @@ def test_global_search_routes_by_destination_url_as_org_admin(
         },
         expected_routes=[route_1]
     )
+
+
+# ---------------------------------------------------------------------------
+# Field mappings — schema validation + update-in-place of RouteConfiguration
+# ---------------------------------------------------------------------------
+#
+# ``RouteConfiguration.data["field_mappings"]`` is a 3-level nested dict:
+#     { PROVIDER_UUID: { action_type: { DESTINATION_UUID: rule } } }
+# where action_type ∈ {ev, evu, obv} and rule has the shape of VALID_RULE
+# below. These tests cover the schema validation introduced in the serializer
+# and the update-in-place behavior on PATCH.
+
+
+VALID_RULE = {
+    "destination_field": "event_type",
+    "provider_field": "event_details__species",
+    "default": "animal_detected",
+    "map": {"lion": "lion_sighting"},
+}
+
+
+def _build_field_mappings(provider_id, destination_id, *, rule=None, action_type="ev"):
+    """Build a single-entry field_mappings dict for one (provider, action, destination)."""
+    return {
+        str(provider_id): {
+            action_type: {str(destination_id): rule or dict(VALID_RULE)}
+        }
+    }
+
+
+def _post_route_with_field_mappings(
+    api_client, user, organization, provider, destination, field_mappings
+):
+    api_client.force_authenticate(user)
+    return api_client.post(
+        reverse("routes-list"),
+        data={
+            "name": "Field mappings test route",
+            "owner": str(organization.id),
+            "data_providers": [str(provider.id)],
+            "destinations": [str(destination.id)],
+            "configuration": {
+                "name": "config",
+                "data": {"field_mappings": field_mappings},
+            },
+            "additional": {},
+        },
+        format="json",
+    )
+
+
+# -- Happy path ------------------------------------------------------------
+
+
+def test_create_route_with_valid_field_mappings(
+    api_client, superuser, organization, integrations_list_er, provider_lotek_panthera
+):
+    destination = integrations_list_er[0]
+    field_mappings = _build_field_mappings(provider_lotek_panthera.id, destination.id)
+
+    response = _post_route_with_field_mappings(
+        api_client, superuser, organization,
+        provider_lotek_panthera, destination, field_mappings,
+    )
+
+    assert response.status_code == status.HTTP_201_CREATED
+    route = Route.objects.get(id=response.json()["id"])
+    stored_rule = (
+        route.configuration.data["field_mappings"]
+        [str(provider_lotek_panthera.id)]["ev"][str(destination.id)]
+    )
+    assert stored_rule["destination_field"] == "event_type"
+
+
+# -- Schema validation -----------------------------------------------------
+
+
+def _fm_with_invalid_action_type(provider_id, destination_id):
+    return {str(provider_id): {"xx": {str(destination_id): VALID_RULE}}}
+
+
+def _fm_missing_destination_field(provider_id, destination_id):
+    return {str(provider_id): {"ev": {str(destination_id): {
+        "provider_field": "x",
+        "map": {"a": "b"},
+    }}}}
+
+
+def _fm_map_without_provider_field(provider_id, destination_id):
+    return {str(provider_id): {"ev": {str(destination_id): {
+        "destination_field": "event_type",
+        "map": {"a": "b"},
+    }}}}
+
+
+def _fm_missing_default_and_map(provider_id, destination_id):
+    return {str(provider_id): {"ev": {str(destination_id): {
+        "destination_field": "event_type",
+    }}}}
+
+
+def _fm_with_non_uuid_provider_key(provider_id, destination_id):
+    return {"not-a-uuid": {"ev": {str(destination_id): VALID_RULE}}}
+
+
+INVALID_FIELD_MAPPING_CASES = [
+    pytest.param(_fm_with_invalid_action_type, "xx", id="invalid-action-type"),
+    pytest.param(_fm_missing_destination_field, "destination_field", id="missing-destination-field"),
+    pytest.param(_fm_map_without_provider_field, "provider_field", id="map-without-provider-field"),
+    pytest.param(_fm_missing_default_and_map, "default", id="missing-default-and-map"),
+    pytest.param(_fm_with_non_uuid_provider_key, "not-a-uuid", id="provider-key-not-uuid"),
+]
+
+
+@pytest.mark.parametrize("build_field_mappings, error_fragment", INVALID_FIELD_MAPPING_CASES)
+def test_create_route_rejects_invalid_field_mappings(
+    api_client,
+    superuser,
+    organization,
+    integrations_list_er,
+    provider_lotek_panthera,
+    build_field_mappings,
+    error_fragment,
+):
+    destination = integrations_list_er[0]
+    field_mappings = build_field_mappings(provider_lotek_panthera.id, destination.id)
+
+    response = _post_route_with_field_mappings(
+        api_client, superuser, organization,
+        provider_lotek_panthera, destination, field_mappings,
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert error_fragment in response.content.decode()
+
+
+def test_create_route_rejects_unknown_integration_uuid(
+    api_client, superuser, organization, integrations_list_er, provider_lotek_panthera
+):
+    destination = integrations_list_er[0]
+    unknown_destination_id = uuid.uuid4()
+    field_mappings = _build_field_mappings(provider_lotek_panthera.id, unknown_destination_id)
+
+    response = _post_route_with_field_mappings(
+        api_client, superuser, organization,
+        provider_lotek_panthera, destination, field_mappings,
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "unknown Integration" in response.content.decode()
+
+
+# -- Route-context cross-check --------------------------------------------
+
+
+def test_create_route_rejects_provider_not_in_data_providers(
+    api_client,
+    superuser,
+    organization,
+    integrations_list_er,
+    provider_lotek_panthera,
+    provider_movebank_ewt,
+):
+    # provider_movebank_ewt is a valid Integration but isn't attached to this route
+    destination = integrations_list_er[0]
+    field_mappings = _build_field_mappings(provider_movebank_ewt.id, destination.id)
+
+    response = _post_route_with_field_mappings(
+        api_client, superuser, organization,
+        provider_lotek_panthera, destination, field_mappings,
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "data_providers" in response.content.decode()
+
+
+# -- Update-in-place of the RouteConfiguration row -------------------------
+
+
+def test_patch_route_updates_existing_configuration_in_place(
+    api_client, superuser, route_2, provider_movebank_ewt
+):
+    # route_2 ya tiene er_route_configuration_elephants attached — esperamos
+    # que el PATCH actualice esa misma fila en lugar de crear una nueva.
+    original_config_id = route_2.configuration.id
+    destination = route_2.destinations.first()
+    new_configuration = {
+        "name": route_2.configuration.name,
+        "data": {
+            "subject_type": "elephant",
+            "field_mappings": _build_field_mappings(
+                provider_movebank_ewt.id, destination.id
+            ),
+        },
+    }
+
+    api_client.force_authenticate(superuser)
+    response = api_client.patch(
+        reverse("routes-detail", kwargs={"pk": route_2.id}),
+        data={"configuration": new_configuration},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK, response.content
+    route_2.refresh_from_db()
+    assert route_2.configuration.id == original_config_id, (
+        "expected the existing RouteConfiguration row to be updated in place"
+    )
+    assert "field_mappings" in route_2.configuration.data
+    assert RouteConfiguration.objects.filter(id=original_config_id).count() == 1
+
+
+def test_patch_route_configuration_without_field_mappings_passes(
+    api_client, superuser, route_2
+):
+    # data sin field_mappings: el validador de schema no debe activarse
+    api_client.force_authenticate(superuser)
+    response = api_client.patch(
+        reverse("routes-detail", kwargs={"pk": route_2.id}),
+        data={
+            "configuration": {
+                "name": "still elephants",
+                "data": {"subject_type": "elephant"},
+            }
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK, response.content
+
+
+# ---------------------------------------------------------------------------
+# DELETE /v2/routes/{id}/configuration/ — unlink + hard-delete the config row
+# ---------------------------------------------------------------------------
+#
+# Mirrors the Django admin's "delete row" behavior for a RouteConfiguration but
+# is safe when the same configuration is shared between routes: in that case
+# the row is only detached from the current route, never destroyed.
+
+
+def test_delete_route_configuration_as_superuser_removes_the_row(
+    api_client, superuser, route_2
+):
+    config_id = route_2.configuration.id
+
+    api_client.force_authenticate(superuser)
+    response = api_client.delete(
+        reverse("routes-delete-configuration", kwargs={"pk": route_2.id})
+    )
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    route_2.refresh_from_db()
+    assert route_2.configuration is None
+    assert not RouteConfiguration.objects.filter(id=config_id).exists()
+
+
+def test_delete_route_configuration_as_org_admin_removes_the_row(
+    api_client, org_admin_user_2, route_2
+):
+    config_id = route_2.configuration.id
+
+    api_client.force_authenticate(org_admin_user_2)
+    response = api_client.delete(
+        reverse("routes-delete-configuration", kwargs={"pk": route_2.id})
+    )
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    route_2.refresh_from_db()
+    assert route_2.configuration is None
+    assert not RouteConfiguration.objects.filter(id=config_id).exists()
+
+
+def test_delete_route_configuration_keeps_row_when_shared_with_another_route(
+    api_client, superuser, route_1, route_2
+):
+    # Comparte la misma RouteConfiguration entre route_1 y route_2
+    shared_config = route_2.configuration
+    route_1.configuration = shared_config
+    route_1.save()
+
+    api_client.force_authenticate(superuser)
+    response = api_client.delete(
+        reverse("routes-delete-configuration", kwargs={"pk": route_2.id})
+    )
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    route_2.refresh_from_db()
+    route_1.refresh_from_db()
+    assert route_2.configuration is None
+    # La fila sigue existiendo porque route_1 todavía la referencia
+    assert RouteConfiguration.objects.filter(id=shared_config.id).exists()
+    assert route_1.configuration_id == shared_config.id
+
+
+def test_delete_route_configuration_is_idempotent_when_already_empty(
+    api_client, superuser, route_1
+):
+    assert route_1.configuration is None  # sanity
+
+    api_client.force_authenticate(superuser)
+    response = api_client.delete(
+        reverse("routes-delete-configuration", kwargs={"pk": route_1.id})
+    )
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+
+def test_cannot_delete_route_configuration_as_org_viewer(
+    api_client, org_viewer_user_2, route_2
+):
+    api_client.force_authenticate(org_viewer_user_2)
+    response = api_client.delete(
+        reverse("routes-delete-configuration", kwargs={"pk": route_2.id})
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    # La configuration sigue ligada al route
+    route_2.refresh_from_db()
+    assert route_2.configuration is not None
+
+
+def test_cannot_delete_unrelated_route_configuration_as_org_admin(
+    api_client, org_admin_user, route_2
+):
+    # org_admin_user pertenece a `organization`, no a `other_organization` (dueña de route_2)
+    api_client.force_authenticate(org_admin_user)
+    response = api_client.delete(
+        reverse("routes-delete-configuration", kwargs={"pk": route_2.id})
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    route_2.refresh_from_db()
+    assert route_2.configuration is not None

--- a/cdip_admin/api/v2/views.py
+++ b/cdip_admin/api/v2/views.py
@@ -1,4 +1,5 @@
 import django_filters
+from django.db import transaction
 from django.db.models import Subquery
 from rest_framework.permissions import IsAuthenticated
 
@@ -375,14 +376,23 @@ class RoutesView(viewsets.ModelViewSet):
 
     @staticmethod
     def _detach_route_configuration(route: Route) -> None:
-        config = route.configuration
-        if config is None:
-            return
-        route.configuration = None
-        route.save(update_fields=["configuration"])
-        is_still_referenced = Route.objects.filter(configuration=config).exists()
-        if not is_still_referenced:
-            config.delete()
+        # ``Route.configuration`` uses ``on_delete=SET_NULL``, so a concurrent
+        # request attaching the same config between the existence check and
+        # ``config.delete()`` could silently null that other route's FK. The
+        # atomic block + row-level lock on the config narrows the window: any
+        # concurrent transaction touching the same config must wait until ours
+        # commits, so the "still referenced?" decision and the subsequent
+        # delete observe a consistent snapshot.
+        with transaction.atomic():
+            config = route.configuration
+            if config is None:
+                return
+            locked_config = type(config).objects.select_for_update().get(pk=config.pk)
+            route.configuration = None
+            route.save(update_fields=["configuration"])
+            is_still_referenced = Route.objects.filter(configuration=locked_config).exists()
+            if not is_still_referenced:
+                locked_config.delete()
 
 
 class SingleOrBulkCreateModelMixin(mixins.CreateModelMixin):

--- a/cdip_admin/api/v2/views.py
+++ b/cdip_admin/api/v2/views.py
@@ -364,6 +364,22 @@ class RoutesView(viewsets.ModelViewSet):
         # Returns a list with the routes that the user is allowed to see
         return get_user_routes_qs(user=self.request.user)
 
+    @action(detail=True, methods=["delete"], url_path="configuration")
+    def delete_configuration(self, request, pk=None):
+        # Detach the RouteConfiguration from this route and hard-delete the row
+        # when no other route still references it. Matches Django admin's
+        # delete-when-empty intent without orphaning configurations that are
+        # shared across routes.
+        route = self.get_object()
+        config = route.configuration
+        if config is None:
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        route.configuration = None
+        route.save(update_fields=["configuration"])
+        if not Route.objects.filter(configuration=config).exists():
+            config.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
 
 class SingleOrBulkCreateModelMixin(mixins.CreateModelMixin):
 

--- a/cdip_admin/api/v2/views.py
+++ b/cdip_admin/api/v2/views.py
@@ -365,20 +365,24 @@ class RoutesView(viewsets.ModelViewSet):
         return get_user_routes_qs(user=self.request.user)
 
     @action(detail=True, methods=["delete"], url_path="configuration")
-    def delete_configuration(self, request, pk=None):
-        # Detach the RouteConfiguration from this route and hard-delete the row
-        # when no other route still references it. Matches Django admin's
-        # delete-when-empty intent without orphaning configurations that are
-        # shared across routes.
-        route = self.get_object()
+    def delete_configuration(self, request, pk: str | None = None) -> Response:
+        """Detach this route's RouteConfiguration and hard-delete the row when
+        no other route still references it. Matches the Django admin's delete
+        intent without orphaning configurations shared across routes.
+        """
+        self._detach_route_configuration(self.get_object())
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @staticmethod
+    def _detach_route_configuration(route: Route) -> None:
         config = route.configuration
         if config is None:
-            return Response(status=status.HTTP_204_NO_CONTENT)
+            return
         route.configuration = None
         route.save(update_fields=["configuration"])
-        if not Route.objects.filter(configuration=config).exists():
+        is_still_referenced = Route.objects.filter(configuration=config).exists()
+        if not is_still_referenced:
             config.delete()
-        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class SingleOrBulkCreateModelMixin(mixins.CreateModelMixin):


### PR DESCRIPTION
## Summary

Enables the Transformation Rules feature (GUNDI-4170 / GUNDI-5383) by reusing the existing `/v2/routes/` endpoint instead of creating new resources, and prepares the backend so the frontend can perform CRUD over `field_mappings`:

- **Schema validation** for `RouteConfiguration.data["field_mappings"]` in `RouteConfigurationSerializer`: hierarchical structure, `action_type ∈ {ev, evu, obv}`, `destination_field` required, `provider_field` required when `map` is present, at least one of `default`/`map` required, and provider/destination UUIDs must exist as `Integration` rows and belong to the route (cross-check in `RouteCreateUpdateSerializer.validate`). 400 errors carry clear paths like `field_mappings.<provider>.ev.<dest>.destination_field`.
- **In-place update** of `RouteConfiguration`: `RouteCreateUpdateSerializer.validate_configuration` now updates the route's existing row instead of creating a new one on every PATCH (the save is deferred to `create`/`update` so the global cross-check runs before the first DB write).
- **`DELETE /v2/routes/{id}/configuration/`** (new action on `RoutesView`): detaches the configuration from the route and hard-deletes it when no other route still references it (mirrors the Django admin's intent without orphaning shared configurations). Idempotent when the route already has no configuration.

Reference: [Field Mappings](https://allenai.atlassian.net/wiki/spaces/CDIP/pages/29742694411/Field+Mappings) and the [plan draft on Confluence](https://allenai.atlassian.net/wiki/spaces/CDIP/pages/31471665155).

## Test plan

- [ ] `docker compose run --rm pytest cdip_admin/api/v2/tests/test_routes_api.py -q` — covers the existing tests plus 13 new ones (valid schema, 5 invalid-schema variants, unknown UUID, provider not in the route, in-place update, delete of a non-shared config, delete when shared, idempotency, viewer/admin/other-org permission matrix).
- [ ] Manual smoke: `POST /v2/routes/` with a valid `configuration.data.field_mappings` → 201; with `action_type: "xx"` → 400 carrying the path in the body.
- [ ] `PATCH /v2/routes/{id}/` on a route that already has a configuration → same `configuration.id` before and after.
- [ ] `DELETE /v2/routes/{id}/configuration/` → 204; the row disappears in Django admin; calling it again returns 204 (idempotent).
- [ ] Backwards compatibility: existing routes with `data` like `{"subject_type": "elephant"}` keep passing PATCH untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)