### PR TITLE
feat: use vars.WORKLOAD_IDENTITY_PROVIDER for WIF Direct Auth

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     uses: PADAS/gundi-workflows/.github/workflows/build_docker.yml@v11
     needs: vars
     with:
-      workload_identity_provider: "projects/563316706574/locations/global/workloadIdentityPools/github-actions/providers/github-oidc"  # pragma: allowlist secret
+      workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
       repository: ${{ needs.vars.outputs.repository }}
       tag: ${{ needs.vars.outputs.tag }}
       build-args: BASE_REGISTRY=europe-west3-docker.pkg.dev/serca-artifact-registry/virtual-docker/


### PR DESCRIPTION
## Summary

Replace hardcoded WIF pool path with `vars.WORKLOAD_IDENTITY_PROVIDER` in the Docker build workflow, consistent with the centralized WIF Direct Resource Access pattern used across all Gundi and EarthRanger repos.

## Changes

### Changed
- `build` job: replaced hardcoded `projects/563316706574/...` pool path with `${{ vars.WORKLOAD_IDENTITY_PROVIDER }}`
- Removed `# pragma: allowlist secret` comment (no longer needed without the raw value)

## Technical Details

`WORKLOAD_IDENTITY_PROVIDER` repo var has been set to the centralized `github-actions` pool in `serca-tools`. The principalSet binding for repo 271091521 (`roles/artifactregistry.writer` on the `gundi` AR repo) was already applied via serca-iac.

---
**Jira**: https://allenai.atlassian.net/browse/DASOPS-1949