### PR TITLE
Device group edit panel: devices section (list, remove, add)

### DIFF
--- a/cdip_admin/cdip_admin/views.py
+++ b/cdip_admin/cdip_admin/views.py
@@ -2,4 +2,4 @@ from django.shortcuts import render
 
 
 def custom_error_403(request, exception):
-    return render(request, "403.html", {})
+    return render(request, "403.html", {}, status=403)

--- a/cdip_admin/integrations/templates/integrations/device_group_devices_partial.html
+++ b/cdip_admin/integrations/templates/integrations/device_group_devices_partial.html
@@ -24,6 +24,7 @@
                         <span class="remove-device-btn-{{ dev.id }}">
                             <button class="btn btn-outline-danger btn-sm"
                                     title="Remove from group"
+                                    aria-label="Remove from group"
                                     _="on click hide .remove-device-btn-{{ dev.id }} then show .confirm-remove-device-{{ dev.id }} with display:flex">
                                 <i class="fas fa-trash"></i>
                             </button>

--- a/cdip_admin/integrations/templates/integrations/device_group_devices_partial.html
+++ b/cdip_admin/integrations/templates/integrations/device_group_devices_partial.html
@@ -48,4 +48,16 @@
     {% else %}
     <p class="text-muted">No devices in this group.</p>
     {% endif %}
+    <form hx-post="{% url 'device_group_devices_add' device_group_id=device_group_id %}"
+          hx-target="#device-group-devices-section"
+          hx-swap="outerHTML"
+          class="form-inline mb-1">
+        {% csrf_token %}
+        <select name="device_id"
+                class="form-control form-control-sm mr-2 device-select"
+                data-autocomplete-url="{% url 'device_group_devices_autocomplete' device_group_id=device_group_id %}?q="
+                required>
+        </select>
+        <button type="submit" class="btn btn-outline-primary btn-sm">Add device</button>
+    </form>
 </div>

--- a/cdip_admin/integrations/templates/integrations/device_group_devices_partial.html
+++ b/cdip_admin/integrations/templates/integrations/device_group_devices_partial.html
@@ -1,0 +1,30 @@
+<div id="device-group-devices-section" class="mt-4">
+    <h5>Devices in group</h5>
+    {% if devices %}
+    <div style="max-height: 240px; overflow-y: auto;">
+        <table class="table table-sm table-bordered">
+            <thead class="thead-light">
+                <tr>
+                    <th>External ID</th>
+                    <th>Created</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for dev in devices %}
+                <tr>
+                    <td>
+                        <a href="#"
+                           hx-get="{% url 'device_update' module_id=dev.id %}"
+                           hx-target="#slide-panel-body"
+                           hx-swap="innerHTML">{{ dev.external_id|default:dev }}</a>
+                    </td>
+                    <td class="text-muted">{{ dev.created_at|date:"M j, Y" }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% else %}
+    <p class="text-muted">No devices in this group.</p>
+    {% endif %}
+</div>

--- a/cdip_admin/integrations/templates/integrations/device_group_devices_partial.html
+++ b/cdip_admin/integrations/templates/integrations/device_group_devices_partial.html
@@ -22,7 +22,7 @@
                     <td class="text-muted">{{ dev.created_at|date:"M j, Y" }}</td>
                     <td class="text-right">
                         <span class="remove-device-btn-{{ dev.id }}">
-                            <button class="btn btn-outline-danger btn-sm"
+                            <button class="btn btn-outline-secondary btn-sm"
                                     title="Remove from group"
                                     aria-label="Remove from group"
                                     _="on click hide .remove-device-btn-{{ dev.id }} then show .confirm-remove-device-{{ dev.id }} with display:flex">

--- a/cdip_admin/integrations/templates/integrations/device_group_devices_partial.html
+++ b/cdip_admin/integrations/templates/integrations/device_group_devices_partial.html
@@ -7,6 +7,7 @@
                 <tr>
                     <th>External ID</th>
                     <th>Created</th>
+                    <th></th>
                 </tr>
             </thead>
             <tbody>
@@ -19,6 +20,25 @@
                            hx-swap="innerHTML">{{ dev.external_id|default:dev }}</a>
                     </td>
                     <td class="text-muted">{{ dev.created_at|date:"M j, Y" }}</td>
+                    <td class="text-right">
+                        <span class="remove-device-btn-{{ dev.id }}">
+                            <button class="btn btn-outline-danger btn-sm"
+                                    title="Remove from group"
+                                    _="on click hide .remove-device-btn-{{ dev.id }} then show .confirm-remove-device-{{ dev.id }} with display:flex">
+                                <i class="fas fa-trash"></i>
+                            </button>
+                        </span>
+                        <span class="confirm-remove-device-{{ dev.id }} align-items-center justify-content-end"
+                              style="display: none; gap: .4rem;">
+                            <small class="text-muted">Remove {{ dev.external_id|default:dev }}?</small>
+                            <button class="btn btn-danger btn-sm"
+                                    hx-post="{% url 'device_group_devices_remove' device_group_id=device_group_id device_id=dev.id %}"
+                                    hx-target="#device-group-devices-section"
+                                    hx-swap="outerHTML">Confirm</button>
+                            <button class="btn btn-secondary btn-sm"
+                                    _="on click hide .confirm-remove-device-{{ dev.id }} then show .remove-device-btn-{{ dev.id }}">Cancel</button>
+                        </span>
+                    </td>
                 </tr>
                 {% endfor %}
             </tbody>

--- a/cdip_admin/integrations/templates/integrations/device_group_devices_partial.html
+++ b/cdip_admin/integrations/templates/integrations/device_group_devices_partial.html
@@ -26,7 +26,7 @@
                                     title="Remove from group"
                                     aria-label="Remove from group"
                                     _="on click hide .remove-device-btn-{{ dev.id }} then show .confirm-remove-device-{{ dev.id }} with display:flex">
-                                <i class="fas fa-trash"></i>
+                                <i class="fas fa-minus-circle"></i>
                             </button>
                         </span>
                         <span class="confirm-remove-device-{{ dev.id }} align-items-center justify-content-end"

--- a/cdip_admin/integrations/templates/integrations/device_group_update_partial.html
+++ b/cdip_admin/integrations/templates/integrations/device_group_update_partial.html
@@ -48,6 +48,12 @@
 <div class="slide-panel-content">
     {% include "integrations/_form_errors.html" %}
     {% crispy form %}
+    <div id="device-group-devices-section"
+         hx-get="{% url 'device_group_devices_list' device_group_id=form.instance.id %}"
+         hx-trigger="load"
+         hx-swap="outerHTML">
+        <p class="text-muted">Loading devices...</p>
+    </div>
     <div id="device-group-destinations-section"
          hx-get="{% url 'device_group_destinations_list' device_group_id=form.instance.id %}"
          hx-trigger="load"

--- a/cdip_admin/integrations/tests/test_integration_views.py
+++ b/cdip_admin/integrations/tests/test_integration_views.py
@@ -867,3 +867,25 @@ def test_device_group_list_organization_member_viewer(
     assert list(response.context["filter"].qs) == list(
         DeviceGroup.objects.filter(owner=org1)
     )
+
+
+def test_device_group_devices_list_renders_group_devices(
+        client, global_admin_user, setup_data
+):
+    dg1 = setup_data["dg1"]
+    d1 = setup_data["d1"]
+
+    client.force_login(global_admin_user.user)
+
+    response = client.get(
+        reverse("device_group_devices_list", kwargs={"device_group_id": dg1.id}),
+        HTTP_X_USERINFO=global_admin_user.user_info,
+    )
+
+    assert response.status_code == 200
+    # The group's devices are listed.
+    assert list(response.context["devices"]) == list(dg1.devices.all())
+    content = response.content.decode()
+    assert d1.external_id in content
+    # Each device links to its own config, swapped into the same slide panel.
+    assert reverse("device_update", kwargs={"module_id": d1.id}) in content

--- a/cdip_admin/integrations/tests/test_integration_views.py
+++ b/cdip_admin/integrations/tests/test_integration_views.py
@@ -1059,3 +1059,21 @@ def test_device_group_devices_autocomplete_returns_eligible(
     assert str(d1.id) not in ids        # already in group
     assert str(d2.id) not in ids        # other org
     assert all("id" in r and "name" in r for r in results)
+
+
+def test_device_group_devices_list_shows_add_form(
+        client, global_admin_user, setup_data
+):
+    dg1 = setup_data["dg1"]
+
+    client.force_login(global_admin_user.user)
+    response = client.get(
+        reverse("device_group_devices_list", kwargs={"device_group_id": dg1.id}),
+        HTTP_X_USERINFO=global_admin_user.user_info,
+    )
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert 'name="device_id"' in content
+    assert reverse("device_group_devices_add", kwargs={"device_group_id": dg1.id}) in content
+    assert reverse("device_group_devices_autocomplete", kwargs={"device_group_id": dg1.id}) in content

--- a/cdip_admin/integrations/tests/test_integration_views.py
+++ b/cdip_admin/integrations/tests/test_integration_views.py
@@ -948,3 +948,27 @@ def test_device_group_devices_remove_requires_change_permission(
 
     assert response.status_code == 403
     assert d1 in dg1.devices.all()  # unchanged
+
+
+def test_device_group_devices_list_shows_remove_control(
+        client, global_admin_user, setup_data
+):
+    dg1 = setup_data["dg1"]
+    d1 = setup_data["d1"]
+
+    client.force_login(global_admin_user.user)
+
+    response = client.get(
+        reverse("device_group_devices_list", kwargs={"device_group_id": dg1.id}),
+        HTTP_X_USERINFO=global_admin_user.user_info,
+    )
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    # Trash icon present...
+    assert "fa-trash" in content
+    # ...wired to the remove endpoint for this device.
+    assert reverse(
+        "device_group_devices_remove",
+        kwargs={"device_group_id": dg1.id, "device_id": d1.id},
+    ) in content

--- a/cdip_admin/integrations/tests/test_integration_views.py
+++ b/cdip_admin/integrations/tests/test_integration_views.py
@@ -889,3 +889,62 @@ def test_device_group_devices_list_renders_group_devices(
     assert d1.external_id in content
     # Each device links to its own config, swapped into the same slide panel.
     assert reverse("device_update", kwargs={"module_id": d1.id}) in content
+
+
+def test_device_group_devices_remove_unlinks_device(
+        client, global_admin_user, setup_data
+):
+    dg1 = setup_data["dg1"]
+    d1 = setup_data["d1"]
+    assert d1 in dg1.devices.all()
+
+    client.force_login(global_admin_user.user)
+
+    response = client.post(
+        reverse(
+            "device_group_devices_remove",
+            kwargs={"device_group_id": dg1.id, "device_id": d1.id},
+        ),
+        HTTP_X_USERINFO=global_admin_user.user_info,
+    )
+
+    assert response.status_code == 200
+    dg1.refresh_from_db()
+    # Unlinked from the group...
+    assert d1 not in dg1.devices.all()
+    # ...but the Device row still exists.
+    assert Device.objects.filter(pk=d1.id).exists()
+    # dg1 had only d1, so the refreshed partial shows the empty state.
+    assert "No devices in this group." in response.content.decode()
+
+
+def test_device_group_devices_remove_requires_change_permission(
+        client, django_user_model, setup_data
+):
+    import base64
+    import json
+
+    dg1 = setup_data["dg1"]
+    d1 = setup_data["d1"]
+
+    # Plain user (no perms) -- create_user, NOT create_superuser.
+    user = django_user_model.objects.create_user(
+        username="viewer@example.com", email="viewer@example.com"
+    )
+    user_info = base64.b64encode(
+        json.dumps(
+            {"sub": str(user.id), "username": user.username, "email": user.email}
+        ).encode("utf-8")
+    )
+    client.force_login(user)
+
+    response = client.post(
+        reverse(
+            "device_group_devices_remove",
+            kwargs={"device_group_id": dg1.id, "device_id": d1.id},
+        ),
+        HTTP_X_USERINFO=user_info,
+    )
+
+    assert response.status_code == 403
+    assert d1 in dg1.devices.all()  # unchanged

--- a/cdip_admin/integrations/tests/test_integration_views.py
+++ b/cdip_admin/integrations/tests/test_integration_views.py
@@ -1,3 +1,4 @@
+import base64
 import json
 from typing import List
 from django.http import QueryDict
@@ -921,9 +922,6 @@ def test_device_group_devices_remove_unlinks_device(
 def test_device_group_devices_remove_requires_change_permission(
         client, django_user_model, setup_data
 ):
-    import base64
-    import json
-
     dg1 = setup_data["dg1"]
     d1 = setup_data["d1"]
 

--- a/cdip_admin/integrations/tests/test_integration_views.py
+++ b/cdip_admin/integrations/tests/test_integration_views.py
@@ -970,3 +970,92 @@ def test_device_group_devices_list_shows_remove_control(
         "device_group_devices_remove",
         kwargs={"device_group_id": dg1.id, "device_id": d1.id},
     ) in content
+
+
+def test_device_group_devices_add_adds_eligible_device(
+        client, global_admin_user, setup_data
+):
+    dg1 = setup_data["dg1"]
+    ii1 = setup_data["ii1"]  # owned by org1, same as dg1
+    new_device = Device.objects.create(external_id="new-org1-device", inbound_configuration=ii1)
+    assert new_device not in dg1.devices.all()
+
+    client.force_login(global_admin_user.user)
+    response = client.post(
+        reverse("device_group_devices_add", kwargs={"device_group_id": dg1.id}),
+        data={"device_id": str(new_device.id)},
+        HTTP_X_USERINFO=global_admin_user.user_info,
+    )
+
+    assert response.status_code == 200
+    dg1.refresh_from_db()
+    assert new_device in dg1.devices.all()
+    assert new_device.external_id in response.content.decode()
+
+
+def test_device_group_devices_add_rejects_other_org_device(
+        client, global_admin_user, setup_data
+):
+    dg1 = setup_data["dg1"]   # owned by org1
+    d2 = setup_data["d2"]     # device whose inbound integration is owned by org2
+
+    client.force_login(global_admin_user.user)
+    response = client.post(
+        reverse("device_group_devices_add", kwargs={"device_group_id": dg1.id}),
+        data={"device_id": str(d2.id)},
+        HTTP_X_USERINFO=global_admin_user.user_info,
+    )
+
+    assert response.status_code == 200      # no-op re-render, not an error
+    dg1.refresh_from_db()
+    assert d2 not in dg1.devices.all()
+
+
+def test_device_group_devices_add_requires_change_permission(
+        client, django_user_model, setup_data
+):
+    dg1 = setup_data["dg1"]
+    ii1 = setup_data["ii1"]
+    new_device = Device.objects.create(external_id="perm-test-device", inbound_configuration=ii1)
+
+    user = django_user_model.objects.create_user(
+        username="addviewer@example.com", email="addviewer@example.com"
+    )
+    user_info = base64.b64encode(
+        json.dumps({"sub": str(user.id), "username": user.username, "email": user.email}).encode("utf-8")
+    )
+    client.force_login(user)
+    response = client.post(
+        reverse("device_group_devices_add", kwargs={"device_group_id": dg1.id}),
+        data={"device_id": str(new_device.id)},
+        HTTP_X_USERINFO=user_info,
+    )
+
+    assert response.status_code == 403
+    dg1.refresh_from_db()
+    assert new_device not in dg1.devices.all()
+
+
+def test_device_group_devices_autocomplete_returns_eligible(
+        client, global_admin_user, setup_data
+):
+    dg1 = setup_data["dg1"]
+    d1 = setup_data["d1"]   # already in dg1
+    d2 = setup_data["d2"]   # other org
+    ii1 = setup_data["ii1"]
+    eligible = Device.objects.create(external_id="autocomplete-eligible", inbound_configuration=ii1)
+
+    client.force_login(global_admin_user.user)
+    response = client.get(
+        reverse("device_group_devices_autocomplete", kwargs={"device_group_id": dg1.id}),
+        data={"q": ""},
+        HTTP_X_USERINFO=global_admin_user.user_info,
+    )
+
+    assert response.status_code == 200
+    results = response.json()
+    ids = {r["id"] for r in results}
+    assert str(eligible.id) in ids      # same org, not in group
+    assert str(d1.id) not in ids        # already in group
+    assert str(d2.id) not in ids        # other org
+    assert all("id" in r and "name" in r for r in results)

--- a/cdip_admin/integrations/tests/test_integration_views.py
+++ b/cdip_admin/integrations/tests/test_integration_views.py
@@ -1077,3 +1077,21 @@ def test_device_group_devices_list_shows_add_form(
     assert 'name="device_id"' in content
     assert reverse("device_group_devices_add", kwargs={"device_group_id": dg1.id}) in content
     assert reverse("device_group_devices_autocomplete", kwargs={"device_group_id": dg1.id}) in content
+
+
+def test_device_group_devices_add_form_renders_in_empty_group(
+        client, global_admin_user, setup_data
+):
+    org1 = setup_data["org1"]
+    empty_group = DeviceGroup.objects.create(name="empty add-form group", owner=org1)
+
+    client.force_login(global_admin_user.user)
+    response = client.get(
+        reverse("device_group_devices_list", kwargs={"device_group_id": empty_group.id}),
+        HTTP_X_USERINFO=global_admin_user.user_info,
+    )
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "No devices in this group." in content   # empty-state branch
+    assert 'name="device_id"' in content            # add form still shown

--- a/cdip_admin/integrations/tests/test_integration_views.py
+++ b/cdip_admin/integrations/tests/test_integration_views.py
@@ -963,8 +963,8 @@ def test_device_group_devices_list_shows_remove_control(
 
     assert response.status_code == 200
     content = response.content.decode()
-    # Trash icon present...
-    assert "fa-trash" in content
+    # Remove (minus-circle) icon present...
+    assert "fa-minus-circle" in content
     # ...wired to the remove endpoint for this device.
     assert reverse(
         "device_group_devices_remove",

--- a/cdip_admin/integrations/urls.py
+++ b/cdip_admin/integrations/urls.py
@@ -258,6 +258,12 @@ urlpatterns = [
         views.inbound_connections_remove,
         name="inbound_connections_remove",
     ),
+    # Device Group Devices
+    path(
+        "devicegroups/<uuid:device_group_id>/devices",
+        views.device_group_devices_list,
+        name="device_group_devices_list",
+    ),
     # Device Group Destinations
     path(
         "devicegroups/<uuid:device_group_id>/destinations",

--- a/cdip_admin/integrations/urls.py
+++ b/cdip_admin/integrations/urls.py
@@ -269,6 +269,16 @@ urlpatterns = [
         views.device_group_devices_remove,
         name="device_group_devices_remove",
     ),
+    path(
+        "devicegroups/<uuid:device_group_id>/devices/add",
+        views.device_group_devices_add,
+        name="device_group_devices_add",
+    ),
+    path(
+        "devicegroups/<uuid:device_group_id>/devices/autocomplete",
+        views.device_group_devices_autocomplete,
+        name="device_group_devices_autocomplete",
+    ),
     # Device Group Destinations
     path(
         "devicegroups/<uuid:device_group_id>/destinations",

--- a/cdip_admin/integrations/urls.py
+++ b/cdip_admin/integrations/urls.py
@@ -264,6 +264,11 @@ urlpatterns = [
         views.device_group_devices_list,
         name="device_group_devices_list",
     ),
+    path(
+        "devicegroups/<uuid:device_group_id>/devices/<uuid:device_id>/remove",
+        views.device_group_devices_remove,
+        name="device_group_devices_remove",
+    ),
     # Device Group Destinations
     path(
         "devicegroups/<uuid:device_group_id>/destinations",

--- a/cdip_admin/integrations/views.py
+++ b/cdip_admin/integrations/views.py
@@ -2144,6 +2144,20 @@ def device_group_destinations_remove(request, device_group_id, outbound_id):
     return render(request, "integrations/device_group_destinations_partial.html", context)
 
 
+@require_POST
+@permission_required("integrations.change_devicegroup", raise_exception=True)
+def device_group_devices_remove(request, device_group_id, device_id):
+    device_group = get_object_or_404(DeviceGroup, pk=device_group_id)
+    permission_can_view(request, device_group)
+    device = get_object_or_404(Device, pk=device_id)
+    device_group.devices.remove(device)
+    context = {
+        "devices": device_group.devices.all(),
+        "device_group_id": device_group_id,
+    }
+    return render(request, "integrations/device_group_devices_partial.html", context)
+
+
 def _outbound_connections_context(config):
     """Build context dict for the outbound connections partial."""
     # Inbound configs whose default_devicegroup routes to this outbound

--- a/cdip_admin/integrations/views.py
+++ b/cdip_admin/integrations/views.py
@@ -2191,8 +2191,10 @@ def device_group_devices_add(request, device_group_id):
     device_group = get_object_or_404(DeviceGroup, pk=device_group_id)
     permission_can_view(request, device_group)
     device_id = request.POST.get("device_id")
-    if device_id and _eligible_devices_for_group(device_group).filter(pk=device_id).exists():
-        device_group.devices.add(Device.objects.get(pk=device_id))
+    if device_id:
+        device = _eligible_devices_for_group(device_group).filter(pk=device_id).first()
+        if device:
+            device_group.devices.add(device)
     context = {
         "devices": device_group.devices.select_related("inbound_configuration__type"),
         "device_group_id": device_group_id,

--- a/cdip_admin/integrations/views.py
+++ b/cdip_admin/integrations/views.py
@@ -2103,6 +2103,16 @@ def _device_group_destinations_context(device_group, request):
 
 @require_GET
 @permission_required("integrations.view_devicegroup", raise_exception=True)
+def device_group_devices_list(request, device_group_id):
+    device_group = get_object_or_404(DeviceGroup, pk=device_group_id)
+    permission_can_view(request, device_group)
+    context = {
+        "devices": device_group.devices.all(),
+        "device_group_id": device_group_id,
+    }
+    return render(request, "integrations/device_group_devices_partial.html", context)
+
+
 def device_group_destinations_list(request, device_group_id):
     device_group = get_object_or_404(DeviceGroup, pk=device_group_id)
     permission_can_view(request, device_group)

--- a/cdip_admin/integrations/views.py
+++ b/cdip_admin/integrations/views.py
@@ -2107,7 +2107,7 @@ def device_group_devices_list(request, device_group_id):
     device_group = get_object_or_404(DeviceGroup, pk=device_group_id)
     permission_can_view(request, device_group)
     context = {
-        "devices": device_group.devices.all(),
+        "devices": device_group.devices.select_related("inbound_configuration__type"),
         "device_group_id": device_group_id,
     }
     return render(request, "integrations/device_group_devices_partial.html", context)
@@ -2152,7 +2152,7 @@ def device_group_devices_remove(request, device_group_id, device_id):
     device = get_object_or_404(Device, pk=device_id)
     device_group.devices.remove(device)
     context = {
-        "devices": device_group.devices.all(),
+        "devices": device_group.devices.select_related("inbound_configuration__type"),
         "device_group_id": device_group_id,
     }
     return render(request, "integrations/device_group_devices_partial.html", context)

--- a/cdip_admin/integrations/views.py
+++ b/cdip_admin/integrations/views.py
@@ -2158,6 +2158,48 @@ def device_group_devices_remove(request, device_group_id, device_id):
     return render(request, "integrations/device_group_devices_partial.html", context)
 
 
+def _eligible_devices_for_group(device_group, q=""):
+    """Devices addable to this group: same owning org, matching external_id,
+    not already in the group."""
+    return (
+        Device.objects
+        .filter(inbound_configuration__owner=device_group.owner)
+        .filter(external_id__icontains=q)
+        .exclude(id__in=device_group.devices.values_list("id", flat=True))
+        .select_related("inbound_configuration__type")
+        .order_by("external_id")
+    )
+
+
+@require_GET
+@permission_required("integrations.view_devicegroup", raise_exception=True)
+def device_group_devices_autocomplete(request, device_group_id):
+    device_group = get_object_or_404(DeviceGroup, pk=device_group_id)
+    permission_can_view(request, device_group)
+    q = request.GET.get("q", "")
+    devices = _eligible_devices_for_group(device_group, q)[:50]
+    results = [
+        {"id": str(d.id), "name": f"{d.external_id} — {d.inbound_configuration.type.name}"}
+        for d in devices
+    ]
+    return JsonResponse(results, safe=False)
+
+
+@require_POST
+@permission_required("integrations.change_devicegroup", raise_exception=True)
+def device_group_devices_add(request, device_group_id):
+    device_group = get_object_or_404(DeviceGroup, pk=device_group_id)
+    permission_can_view(request, device_group)
+    device_id = request.POST.get("device_id")
+    if device_id and _eligible_devices_for_group(device_group).filter(pk=device_id).exists():
+        device_group.devices.add(Device.objects.get(pk=device_id))
+    context = {
+        "devices": device_group.devices.select_related("inbound_configuration__type"),
+        "device_group_id": device_group_id,
+    }
+    return render(request, "integrations/device_group_devices_partial.html", context)
+
+
 def _outbound_connections_context(config):
     """Build context dict for the outbound connections partial."""
     # Inbound configs whose default_devicegroup routes to this outbound

--- a/cdip_admin/website/templates/base.html
+++ b/cdip_admin/website/templates/base.html
@@ -52,6 +52,7 @@
     <style>
         .ts-wrapper.destination-select { flex: 1 1 auto; min-width: 0; }
         .ts-wrapper.lazy-select.single .ts-control:after { display: none; }
+        #device-group-devices-section .ts-wrapper { flex: 1 1 auto; min-width: 0; }
     </style>
     <script>
         function makeLazySelect(el, url) {

--- a/cdip_admin/website/templates/base.html
+++ b/cdip_admin/website/templates/base.html
@@ -83,6 +83,12 @@
                     makeLazySelect(el, '/integrations/autocomplete/device-groups/?q=');
                 }
             });
+
+            root.querySelectorAll('select[name="device_id"]').forEach(function(el) {
+                if (!el.tomselect) {
+                    makeLazySelect(el, el.dataset.autocompleteUrl);
+                }
+            });
         }
 
         document.addEventListener('DOMContentLoaded', function() {

--- a/cdip_admin/website/templates/base.html
+++ b/cdip_admin/website/templates/base.html
@@ -85,7 +85,7 @@
             });
 
             root.querySelectorAll('select[name="device_id"]').forEach(function(el) {
-                if (!el.tomselect) {
+                if (!el.tomselect && el.dataset.autocompleteUrl) {
                     makeLazySelect(el, el.dataset.autocompleteUrl);
                 }
             });

--- a/docs/device-group-devices-section-mock.html
+++ b/docs/device-group-devices-section-mock.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Device group edit panel — devices section mock</title>
+<style>
+  :root {
+    --surface-0: #f5f4ef; --surface-1: #f1efe8; --surface-2: #ffffff;
+    --text-primary: #2c2c2a; --text-secondary: #5f5e5a; --text-muted: #888780;
+    --border: #d3d1c7; --accent: #185fa5; --bg-accent: #e6f1fb; --danger: #a32d2d;
+  }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: var(--surface-0); color: var(--text-primary); margin: 0; padding: 2rem; }
+  .panel-wrap { background: var(--surface-1); border-radius: 12px; padding: 1rem; max-width: 620px; margin: 0 auto; }
+  .panel { background: var(--surface-2); border: 0.5px solid var(--border); border-radius: 8px; overflow: hidden; }
+  .toolbar { display: flex; align-items: center; justify-content: space-between; gap: 12px;
+    padding: 10px 14px; border-bottom: 0.5px solid var(--border); }
+  .toolbar .name { flex: 1; text-align: center; color: var(--text-secondary); font-size: 13px; }
+  button { font-size: 13px; padding: 4px 10px; border-radius: 6px; border: 0.5px solid var(--border);
+    background: transparent; cursor: pointer; }
+  .btn-danger { color: var(--danger); border-color: var(--danger); }
+  .btn-save { background: var(--accent); color: #fff; border: none; }
+  .body { padding: 16px; }
+  label { font-size: 13px; color: var(--text-secondary); display: block; margin-bottom: 4px; }
+  .field { height: 34px; border: 0.5px solid var(--border); border-radius: 6px; display: flex;
+    align-items: center; padding: 0 10px; font-size: 14px; margin-bottom: 14px; }
+  h3 { font-size: 15px; font-weight: 500; margin: 0 0 8px; }
+  table { width: 100%; border-collapse: collapse; font-size: 13px; background: var(--surface-2); }
+  th { text-align: left; padding: 6px 8px; border: 0.5px solid var(--border); font-weight: 500; background: var(--surface-1); }
+  td { padding: 6px 8px; border: 0.5px solid var(--border); }
+  a { color: var(--accent); }
+  .muted { color: var(--text-secondary); }
+  .new-box { border: 2px solid var(--accent); border-radius: 8px; padding: 12px; background: var(--bg-accent); margin-bottom: 22px; }
+  .badge { font-size: 11px; background: var(--surface-2); color: var(--accent); border: 0.5px solid var(--accent);
+    padding: 1px 8px; border-radius: 10px; margin-left: 8px; }
+  .hint { font-size: 12px; color: var(--text-secondary); margin-top: 8px; }
+  .section { margin-bottom: 22px; }
+</style>
+</head>
+<body>
+<div class="panel-wrap">
+  <div class="panel">
+    <div class="toolbar">
+      <button class="btn-danger">Delete</button>
+      <span class="name">addonp - Default Group &#128279;</span>
+      <span><button>Cancel</button> <button class="btn-save">Save</button></span>
+    </div>
+    <div class="body">
+      <label>Name</label>
+      <div class="field">addonp - Default Group</div>
+      <label>Owner</label>
+      <div class="field" style="margin-bottom:20px;">Addo National Park</div>
+
+      <div class="new-box">
+        <h3 style="color: var(--accent); display:inline-block;">Devices in group</h3>
+        <span class="badge">NEW &middot; read-only</span>
+        <table style="margin-top:8px;">
+          <thead><tr><th>External ID</th><th>Created</th></tr></thead>
+          <tbody>
+            <tr><td><a href="#">012345-67-8901</a></td><td class="muted">May 26, 2023</td></tr>
+            <tr><td><a href="#">012345-67-8902</a></td><td class="muted">May 26, 2023</td></tr>
+            <tr><td><a href="#">012345-67-8903</a></td><td class="muted">May 27, 2023</td></tr>
+          </tbody>
+        </table>
+        <div class="hint">&rarr; Click External ID &mdash; device config swaps into this same panel</div>
+      </div>
+
+      <div class="section">
+        <h3>Destinations</h3>
+        <table>
+          <thead><tr><th>Outbound Destination</th><th>Type</th><th style="width:70px;"></th></tr></thead>
+          <tbody>
+            <tr>
+              <td><a href="#">Addo ER</a><div class="muted" style="font-size:11px;">addo.pamdas.org/api/v1.0</div></td>
+              <td>EarthRanger</td>
+              <td style="text-align:right; color: var(--danger); font-size:12px;">Remove</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/device-group-devices-section-plan.md
+++ b/docs/device-group-devices-section-plan.md
@@ -1,0 +1,166 @@
+# Plan — devices section in the device group edit panel
+
+> **This PR is for discussion and planning only.** It contains no production
+> code changes — just this plan document and an HTML mock. Someone else will
+> implement and test it. The author cannot run the portal locally, so the plan
+> was derived by reading the code, not by running the UI.
+
+## Problem
+
+On the **Device Groups** list (`/integrations/devicegroups`), the only action on a
+group is **Edit**, which opens a slide panel showing the group's form fields and
+its **Destinations** section. There is no way to see the **list of devices** that
+belong to the group, and no deep link from a device to its configuration.
+
+The `DeviceGroupDetail` view (`devicegroups/<uuid:module_id>`) does render a device
+table, but it is not reachable from the current list UI (rows open the Edit panel,
+not the detail page).
+
+## Goal
+
+Add a **read-only** "Devices in group" section to the device group **Edit** slide
+panel, listing each device by `external_id`, where each device links to its own
+configuration. The device config opens in the **same** slide panel (content
+swapped), exactly like clicking an outbound destination does today.
+
+- Devices section appears **above** the Destinations section.
+- Read-only — adding/removing devices stays in the existing **Manage Devices** view.
+
+## How it works today (verified in code)
+
+- The edit panel partial `integrations/device_group_update_partial.html` lazy-loads
+  the destinations section via HTMX:
+  ```django
+  <div id="device-group-destinations-section"
+       hx-get="{% url 'device_group_destinations_list' device_group_id=form.instance.id %}"
+       hx-trigger="load" hx-swap="outerHTML">
+  ```
+- `device_group_destinations_list` (in `integrations/views.py`) renders
+  `device_group_destinations_partial.html`.
+- In that partial, clicking a destination swaps the outbound config form into the
+  **same** panel:
+  ```django
+  <a href="#"
+     hx-get="{% url 'outbound_integration_configuration_update' configuration_id=dest.id %}"
+     hx-target="#slide-panel-body" hx-swap="innerHTML">{{ dest.name }}</a>
+  ```
+  This is not an illusion — `OutboundIntegrationConfigurationUpdateView.get` detects
+  the `HX-Request` header and returns `..._update_partial.html` (panel body only),
+  which HTMX swaps into `#slide-panel-body`.
+- `DeviceUpdateView.get` already does the same: on `HX-Request` it renders
+  `device_update_partial.html`. So a device link with
+  `hx-target="#slide-panel-body" hx-swap="innerHTML"` will behave identically.
+- `DeviceGroup.devices` is a `ManyToManyField(Device)`, so the device list is just
+  `device_group.devices.all()`.
+
+## Suggested implementation
+
+### 1. New view function — `integrations/views.py`
+
+Place next to `device_group_destinations_list`.
+
+```python
+def device_group_devices_list(request, device_group_id):
+    device_group = get_object_or_404(DeviceGroup, pk=device_group_id)
+    permission_can_view(request, device_group)
+    context = {
+        "devices": device_group.devices.all(),
+        "device_group_id": device_group_id,
+    }
+    return render(request, "integrations/device_group_devices_partial.html", context)
+```
+
+### 2. New URL — `integrations/urls.py`
+
+Place next to the device group destinations routes.
+
+```python
+path(
+    "devicegroups/<uuid:device_group_id>/devices",
+    views.device_group_devices_list,
+    name="device_group_devices_list",
+),
+```
+
+### 3. New partial — `integrations/templates/integrations/device_group_devices_partial.html`
+
+Read-only table. Each `external_id` is a link that swaps the device config into the
+same slide panel.
+
+```django
+<div id="device-group-devices-section" class="mt-4">
+    <h5>Devices in group</h5>
+    {% if devices %}
+    <table class="table table-sm table-bordered">
+        <thead class="thead-light">
+            <tr>
+                <th>External ID</th>
+                <th>Created</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for dev in devices %}
+            <tr>
+                <td>
+                    <a href="#"
+                       hx-get="{% url 'device_update' module_id=dev.id %}"
+                       hx-target="#slide-panel-body"
+                       hx-swap="innerHTML">{{ dev.external_id|default:dev }}</a>
+                </td>
+                <td class="text-muted">{{ dev.created_at }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+    <p class="text-muted">No devices in this group.</p>
+    {% endif %}
+</div>
+```
+
+### 4. Wire it into the edit panel — `device_group_update_partial.html`
+
+Add the lazy-load div **before** the existing destinations div:
+
+```django
+<div class="slide-panel-content">
+    {% include "integrations/_form_errors.html" %}
+    {% crispy form %}
+
+    {# NEW — devices section, loads before destinations #}
+    <div id="device-group-devices-section"
+         hx-get="{% url 'device_group_devices_list' device_group_id=form.instance.id %}"
+         hx-trigger="load"
+         hx-swap="outerHTML">
+        <p class="text-muted">Loading devices...</p>
+    </div>
+
+    <div id="device-group-destinations-section"
+         hx-get="{% url 'device_group_destinations_list' device_group_id=form.instance.id %}"
+         hx-trigger="load"
+         hx-swap="outerHTML">
+        <p class="text-muted">Loading destinations...</p>
+    </div>
+</div>
+```
+
+## Notes / open questions for the implementer
+
+- **Device label**: plan uses `external_id`. Confirm this is the right field to show
+  (it's the manufacturer/source id). `default:dev` falls back to the model's
+  `__str__` if `external_id` is empty.
+- **Created column**: `Device.created_at` field name should be confirmed against the
+  model (uses `TimestampedModel`); drop the column if not wanted.
+- **Permissions**: reuses `permission_can_view` like the destinations list — same
+  visibility rules. Confirm that's the intended access level for the device list.
+- **Pagination**: not included. Groups can be large (e.g. addonp has 31 devices,
+  some have more). Consider a scroll container or pagination if a group has many
+  devices.
+- **Not testable by author**: the portal can't be run locally here, so this must be
+  verified in a feature env / locally by whoever implements it.
+
+## Mock
+
+See [`device-group-devices-section-mock.html`](./device-group-devices-section-mock.html)
+(open in a browser) for a visual of the resulting edit panel. The boxed/highlighted
+section is the new part; everything else already exists.

--- a/docs/superpowers/plans/2026-06-29-add-device-to-device-group.md
+++ b/docs/superpowers/plans/2026-06-29-add-device-to-device-group.md
@@ -1,0 +1,340 @@
+# Add a Device to a Device Group — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user add an existing device to a device group from the edit panel, via a searchable autocomplete + Add button scoped to the group's org.
+
+**Architecture:** A shared eligibility queryset backs two new views — a `@require_GET` autocomplete returning JSON `[{id,name}]` and a `@require_POST` add view that links the device to the group's `devices` M2M and re-renders the partial. The template gains an Add form whose `<select name="device_id">` lazy-loads matches via the existing `makeLazySelect` helper.
+
+**Tech Stack:** Django 4.2, htmx 1.6, TomSelect 2.3 (via `makeLazySelect` in base.html), pytest + pytest-django.
+
+## Global Constraints
+
+- **Eligibility:** a device is addable iff `device.inbound_configuration.owner == device_group.owner` AND it is not already in the group. One shared helper enforces this for both views.
+- **Permissions:** add view = `@require_POST` + `@permission_required("integrations.change_devicegroup", raise_exception=True)`; autocomplete = `@require_GET` + `@permission_required("integrations.view_devicegroup", raise_exception=True)`; both also call `permission_can_view(request, device_group)`.
+- **Autocomplete response:** `JsonResponse([{ "id": str, "name": "<external_id> — <inbound type>" }], safe=False)`, capped at 50, ordered by `external_id`.
+- **Reuse** `makeLazySelect` (base.html); the device select is `select[name="device_id"]` with a `data-autocomplete-url` attribute.
+- `Device`, `DeviceGroup`, `JsonResponse`, `require_GET`, `require_POST`, `permission_required`, `get_object_or_404`, `render`, `permission_can_view` are already imported in `integrations/views.py`. `Device`, `reverse`, `base64`, `json` are already imported at the top of the test file.
+- Run tests from the review worktree root: `docker compose run --rm pytest --ds=cdip_admin.settings <path> -p no:cacheprovider`. Test paths are container-relative (no `cdip_admin/` prefix).
+- Commit ONLY each task's files with explicit `git add <paths>`. NEVER `git add -A`/`.`/`commit -a` — the worktree has unrelated uncommitted files (`cdip_admin/cdip_admin/auth/middleware.py`, `docker-compose.yml`) that must stay out.
+
+## File Structure
+
+- Modify `cdip_admin/integrations/views.py` — eligibility helper + 2 views.
+- Modify `cdip_admin/integrations/urls.py` — 2 routes.
+- Modify `cdip_admin/integrations/templates/integrations/device_group_devices_partial.html` — Add form.
+- Modify `cdip_admin/website/templates/base.html` — one `initTomSelects` block.
+- Modify `cdip_admin/integrations/tests/test_integration_views.py` — backend + template tests.
+
+---
+
+### Task 1: Backend — eligibility helper, autocomplete view, add view, URLs
+
+**Files:**
+- Modify: `cdip_admin/integrations/views.py`
+- Modify: `cdip_admin/integrations/urls.py`
+- Test: `cdip_admin/integrations/tests/test_integration_views.py`
+
+**Interfaces:**
+- Consumes: `setup_data` fixture (`dg1` owner `org1` with device `d1`; `d2` owner `org2`; `ii1` owner `org1`); `global_admin_user` (superuser + `.user_info`).
+- Produces:
+  - `_eligible_devices_for_group(device_group, q="")` → `QuerySet[Device]` (same-org, `external_id__icontains=q`, excluding current members).
+  - URL `device_group_devices_add` (kwarg `device_group_id`); POSTs `device_id`; returns rendered `device_group_devices_partial.html` (200).
+  - URL `device_group_devices_autocomplete` (kwarg `device_group_id`); GET `q`; returns `JsonResponse([{id,name}])`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `cdip_admin/integrations/tests/test_integration_views.py`:
+
+```python
+def test_device_group_devices_add_adds_eligible_device(
+        client, global_admin_user, setup_data
+):
+    dg1 = setup_data["dg1"]
+    ii1 = setup_data["ii1"]  # owned by org1, same as dg1
+    new_device = Device.objects.create(external_id="new-org1-device", inbound_configuration=ii1)
+    assert new_device not in dg1.devices.all()
+
+    client.force_login(global_admin_user.user)
+    response = client.post(
+        reverse("device_group_devices_add", kwargs={"device_group_id": dg1.id}),
+        data={"device_id": str(new_device.id)},
+        HTTP_X_USERINFO=global_admin_user.user_info,
+    )
+
+    assert response.status_code == 200
+    dg1.refresh_from_db()
+    assert new_device in dg1.devices.all()
+    assert new_device.external_id in response.content.decode()
+
+
+def test_device_group_devices_add_rejects_other_org_device(
+        client, global_admin_user, setup_data
+):
+    dg1 = setup_data["dg1"]   # owned by org1
+    d2 = setup_data["d2"]     # device whose inbound integration is owned by org2
+
+    client.force_login(global_admin_user.user)
+    response = client.post(
+        reverse("device_group_devices_add", kwargs={"device_group_id": dg1.id}),
+        data={"device_id": str(d2.id)},
+        HTTP_X_USERINFO=global_admin_user.user_info,
+    )
+
+    assert response.status_code == 200      # no-op re-render, not an error
+    dg1.refresh_from_db()
+    assert d2 not in dg1.devices.all()
+
+
+def test_device_group_devices_add_requires_change_permission(
+        client, django_user_model, setup_data
+):
+    dg1 = setup_data["dg1"]
+    ii1 = setup_data["ii1"]
+    new_device = Device.objects.create(external_id="perm-test-device", inbound_configuration=ii1)
+
+    user = django_user_model.objects.create_user(
+        username="addviewer@example.com", email="addviewer@example.com"
+    )
+    user_info = base64.b64encode(
+        json.dumps({"sub": str(user.id), "username": user.username, "email": user.email}).encode("utf-8")
+    )
+    client.force_login(user)
+    response = client.post(
+        reverse("device_group_devices_add", kwargs={"device_group_id": dg1.id}),
+        data={"device_id": str(new_device.id)},
+        HTTP_X_USERINFO=user_info,
+    )
+
+    assert response.status_code == 403
+    dg1.refresh_from_db()
+    assert new_device not in dg1.devices.all()
+
+
+def test_device_group_devices_autocomplete_returns_eligible(
+        client, global_admin_user, setup_data
+):
+    dg1 = setup_data["dg1"]
+    d1 = setup_data["d1"]   # already in dg1
+    d2 = setup_data["d2"]   # other org
+    ii1 = setup_data["ii1"]
+    eligible = Device.objects.create(external_id="autocomplete-eligible", inbound_configuration=ii1)
+
+    client.force_login(global_admin_user.user)
+    response = client.get(
+        reverse("device_group_devices_autocomplete", kwargs={"device_group_id": dg1.id}),
+        data={"q": ""},
+        HTTP_X_USERINFO=global_admin_user.user_info,
+    )
+
+    assert response.status_code == 200
+    results = response.json()
+    ids = {r["id"] for r in results}
+    assert str(eligible.id) in ids      # same org, not in group
+    assert str(d1.id) not in ids        # already in group
+    assert str(d2.id) not in ids        # other org
+    assert all("id" in r and "name" in r for r in results)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `docker compose run --rm pytest --ds=cdip_admin.settings "integrations/tests/test_integration_views.py" -k "device_group_devices_add or device_group_devices_autocomplete" -p no:cacheprovider -q`
+Expected: FAIL — `NoReverseMatch: Reverse for 'device_group_devices_add' not found` (and the autocomplete name).
+
+- [ ] **Step 3: Add the helper and views**
+
+In `cdip_admin/integrations/views.py`, immediately after the `device_group_devices_remove` function, add:
+
+```python
+def _eligible_devices_for_group(device_group, q=""):
+    """Devices addable to this group: same owning org, matching external_id,
+    not already in the group."""
+    return (
+        Device.objects
+        .filter(inbound_configuration__owner=device_group.owner)
+        .filter(external_id__icontains=q)
+        .exclude(id__in=device_group.devices.values_list("id", flat=True))
+        .select_related("inbound_configuration__type")
+        .order_by("external_id")
+    )
+
+
+@require_GET
+@permission_required("integrations.view_devicegroup", raise_exception=True)
+def device_group_devices_autocomplete(request, device_group_id):
+    device_group = get_object_or_404(DeviceGroup, pk=device_group_id)
+    permission_can_view(request, device_group)
+    q = request.GET.get("q", "")
+    devices = _eligible_devices_for_group(device_group, q)[:50]
+    results = [
+        {"id": str(d.id), "name": f"{d.external_id} — {d.inbound_configuration.type.name}"}
+        for d in devices
+    ]
+    return JsonResponse(results, safe=False)
+
+
+@require_POST
+@permission_required("integrations.change_devicegroup", raise_exception=True)
+def device_group_devices_add(request, device_group_id):
+    device_group = get_object_or_404(DeviceGroup, pk=device_group_id)
+    permission_can_view(request, device_group)
+    device_id = request.POST.get("device_id")
+    if device_id and _eligible_devices_for_group(device_group).filter(pk=device_id).exists():
+        device_group.devices.add(Device.objects.get(pk=device_id))
+    context = {
+        "devices": device_group.devices.select_related("inbound_configuration__type"),
+        "device_group_id": device_group_id,
+    }
+    return render(request, "integrations/device_group_devices_partial.html", context)
+```
+
+- [ ] **Step 4: Add the URLs**
+
+In `cdip_admin/integrations/urls.py`, in the "Device Group Devices" block (next to `device_group_devices_remove`), add:
+
+```python
+    path(
+        "devicegroups/<uuid:device_group_id>/devices/add",
+        views.device_group_devices_add,
+        name="device_group_devices_add",
+    ),
+    path(
+        "devicegroups/<uuid:device_group_id>/devices/autocomplete",
+        views.device_group_devices_autocomplete,
+        name="device_group_devices_autocomplete",
+    ),
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `docker compose run --rm pytest --ds=cdip_admin.settings "integrations/tests/test_integration_views.py" -k "device_group_devices_add or device_group_devices_autocomplete" -p no:cacheprovider -q`
+Expected: PASS (4 passed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cdip_admin/integrations/views.py cdip_admin/integrations/urls.py cdip_admin/integrations/tests/test_integration_views.py
+git commit -m "feat: add device_group_devices_add and autocomplete views"
+```
+
+---
+
+### Task 2: Frontend — Add form + lazy-select wiring
+
+**Files:**
+- Modify: `cdip_admin/integrations/templates/integrations/device_group_devices_partial.html`
+- Modify: `cdip_admin/website/templates/base.html`
+- Test: `cdip_admin/integrations/tests/test_integration_views.py`
+
+**Interfaces:**
+- Consumes: URL names `device_group_devices_add`, `device_group_devices_autocomplete` (Task 1); `makeLazySelect(el, url)` + `initTomSelects(root)` in base.html; context key `device_group_id`.
+- Produces: an Add form with `select[name="device_id"]` carrying `data-autocomplete-url`, posting to the add view; `initTomSelects` initializes that select.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `cdip_admin/integrations/tests/test_integration_views.py`:
+
+```python
+def test_device_group_devices_list_shows_add_form(
+        client, global_admin_user, setup_data
+):
+    dg1 = setup_data["dg1"]
+
+    client.force_login(global_admin_user.user)
+    response = client.get(
+        reverse("device_group_devices_list", kwargs={"device_group_id": dg1.id}),
+        HTTP_X_USERINFO=global_admin_user.user_info,
+    )
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert 'name="device_id"' in content
+    assert reverse("device_group_devices_add", kwargs={"device_group_id": dg1.id}) in content
+    assert reverse("device_group_devices_autocomplete", kwargs={"device_group_id": dg1.id}) in content
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `docker compose run --rm pytest --ds=cdip_admin.settings "integrations/tests/test_integration_views.py::test_device_group_devices_list_shows_add_form" -p no:cacheprovider -q`
+Expected: FAIL — `assert 'name="device_id"' in content` (no Add form yet).
+
+- [ ] **Step 3: Add the Add form to the partial**
+
+In `cdip_admin/integrations/templates/integrations/device_group_devices_partial.html`, add the following immediately **before** the final closing `</div>` of `#device-group-devices-section` (after the `{% endif %}` that closes the table / empty-state block, so it shows in both states):
+
+```django
+    <form hx-post="{% url 'device_group_devices_add' device_group_id=device_group_id %}"
+          hx-target="#device-group-devices-section"
+          hx-swap="outerHTML"
+          class="form-inline mb-1">
+        {% csrf_token %}
+        <select name="device_id"
+                class="form-control form-control-sm mr-2 device-select"
+                data-autocomplete-url="{% url 'device_group_devices_autocomplete' device_group_id=device_group_id %}?q="
+                required>
+        </select>
+        <button type="submit" class="btn btn-outline-primary btn-sm">Add device</button>
+    </form>
+```
+
+- [ ] **Step 4: Wire the lazy-select in base.html**
+
+In `cdip_admin/website/templates/base.html`, inside `function initTomSelects(root) { ... }`, after the `select[name="default_devicegroup"]` block (the one ending around line 85), add:
+
+```javascript
+            root.querySelectorAll('select[name="device_id"]').forEach(function(el) {
+                if (!el.tomselect) {
+                    makeLazySelect(el, el.dataset.autocompleteUrl);
+                }
+            });
+```
+
+- [ ] **Step 5: Run the template test + device_group regression**
+
+Run: `docker compose run --rm pytest --ds=cdip_admin.settings "integrations/tests/test_integration_views.py::test_device_group_devices_list_shows_add_form" -p no:cacheprovider -q`
+Expected: PASS.
+
+Run: `docker compose run --rm pytest --ds=cdip_admin.settings "integrations/tests/test_integration_views.py" -k device_group -p no:cacheprovider -q`
+Expected: all device_group tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cdip_admin/integrations/templates/integrations/device_group_devices_partial.html cdip_admin/website/templates/base.html cdip_admin/integrations/tests/test_integration_views.py
+git commit -m "feat: add-device form with searchable autocomplete in device group panel"
+```
+
+---
+
+### Task 3: Live verification
+
+**Files:** none (verification in the running stack).
+
+- [ ] **Step 1: Autocomplete endpoint returns JSON (read-only check)**
+
+In the running stack, render-check the partial includes the Add form:
+```bash
+docker compose exec -T web python3.11 manage.py shell -c "
+from django.template.loader import render_to_string
+import uuid
+html = render_to_string('integrations/device_group_devices_partial.html', {'devices':[], 'device_group_id': uuid.UUID('22222222-2222-2222-2222-222222222222')})
+print('add form:', 'name=\"device_id\"' in html)
+print('autocomplete url:', '/devices/autocomplete' in html)
+print('add url:', '/devices/add' in html)
+"
+```
+Expected: all three print `True`.
+
+- [ ] **Step 2: Browser check (against an env with eligible devices)**
+
+Open a device group in the edit panel. Confirm: the "Add device" search box appears below the list; typing filters devices (by `external_id`) from the same org, excluding ones already in the group; selecting one and clicking **Add device** adds it and the section re-renders with the new row. (The local dev DB may have no eligible devices; verify in a feature env.)
+
+---
+
+## Self-Review
+
+**Spec coverage:** eligibility helper (Task 1), autocomplete view (Task 1), add view + guard (Task 1), URLs (Task 1), template Add form (Task 2), base.html lazy-select wiring (Task 2), permissions (Task 1 decorators + 403 test), tests for add/reject/permission/autocomplete (Task 1) and form render (Task 2), live verification (Task 3). All spec sections covered.
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code and exact commands.
+
+**Type consistency:** `_eligible_devices_for_group(device_group, q="")`, `device_group_devices_add`/`device_group_devices_autocomplete` view+URL names, the `device_id` POST/select name, the `data-autocomplete-url` attribute, and the `#device-group-devices-section` target are consistent across views, URLs, template, base.html, and tests. Autocomplete returns `{id, name}`, matching what `makeLazySelect` consumes (`valueField:'id'`, `labelField:'name'`).

--- a/docs/superpowers/plans/2026-06-29-remove-device-from-device-group.md
+++ b/docs/superpowers/plans/2026-06-29-remove-device-from-device-group.md
@@ -1,0 +1,308 @@
+# Remove a Device from a Device Group — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user remove a device from a device group via a trash icon with inline confirmation in the device group edit slide panel.
+
+**Architecture:** Mirror the existing destination-removal flow in the same panel. A new `@require_POST` view unlinks the device from the group's `devices` M2M and re-renders the devices partial; htmx swaps the section in place. The trash icon reveals an inline "Remove …? Confirm/Cancel" via hyperscript, exactly like destinations.
+
+**Tech Stack:** Django 4.2, htmx 1.6, hyperscript, FontAwesome (all already loaded in `base.html`), pytest + pytest-django.
+
+## Global Constraints
+
+- Removal is an **M2M unlink** (`device_group.devices.remove(device)`) — never deletes the `Device` row.
+- Mirror `device_group_destinations_remove` for the view, URL, and template patterns.
+- CSRF for `hx-post` rides on the global `htmx:configRequest` handler in `base.html` — no per-row `{% csrf_token %}`.
+- Run tests from the review worktree root with:
+  `docker compose run --rm pytest --ds=cdip_admin.settings <path> -p no:cacheprovider`
+  Test paths are container-relative (no `cdip_admin/` prefix), e.g. `integrations/tests/test_integration_views.py`.
+- `Device`, `require_POST`, and `permission_required` are already imported in `integrations/views.py`.
+
+## File Structure
+
+- Modify `cdip_admin/integrations/views.py` — add `device_group_devices_remove` view.
+- Modify `cdip_admin/integrations/urls.py` — add `device_group_devices_remove` route.
+- Modify `cdip_admin/integrations/templates/integrations/device_group_devices_partial.html` — add action column with trash icon + inline confirm.
+- Modify `cdip_admin/integrations/tests/test_integration_views.py` — add backend + template tests.
+
+---
+
+### Task 1: Backend — remove view + URL
+
+**Files:**
+- Modify: `cdip_admin/integrations/views.py` (add view next to `device_group_destinations_remove`)
+- Modify: `cdip_admin/integrations/urls.py` (add route next to `device_group_devices_list`)
+- Test: `cdip_admin/integrations/tests/test_integration_views.py`
+
+**Interfaces:**
+- Consumes: `DeviceGroup.devices` (M2M), `permission_can_view(request, target)`, `setup_data` fixture (`dg1` owned by `org1`, with device `d1`), `global_admin_user` fixture (superuser + `.user_info` header).
+- Produces: URL name `device_group_devices_remove` with kwargs `device_group_id`, `device_id`; view `device_group_devices_remove(request, device_group_id, device_id)` returning the rendered `device_group_devices_partial.html` (HTTP 200) after unlinking.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `cdip_admin/integrations/tests/test_integration_views.py`:
+
+```python
+def test_device_group_devices_remove_unlinks_device(
+        client, global_admin_user, setup_data
+):
+    dg1 = setup_data["dg1"]
+    d1 = setup_data["d1"]
+    assert d1 in dg1.devices.all()
+
+    client.force_login(global_admin_user.user)
+
+    response = client.post(
+        reverse(
+            "device_group_devices_remove",
+            kwargs={"device_group_id": dg1.id, "device_id": d1.id},
+        ),
+        HTTP_X_USERINFO=global_admin_user.user_info,
+    )
+
+    assert response.status_code == 200
+    dg1.refresh_from_db()
+    # Unlinked from the group...
+    assert d1 not in dg1.devices.all()
+    # ...but the Device row still exists.
+    assert Device.objects.filter(pk=d1.id).exists()
+    # dg1 had only d1, so the refreshed partial shows the empty state.
+    assert "No devices in this group." in response.content.decode()
+
+
+def test_device_group_devices_remove_requires_change_permission(
+        client, django_user_model, setup_data
+):
+    import base64
+    import json
+
+    dg1 = setup_data["dg1"]
+    d1 = setup_data["d1"]
+
+    # Plain user (no perms) -- create_user, NOT create_superuser.
+    user = django_user_model.objects.create_user(
+        username="viewer@example.com", email="viewer@example.com"
+    )
+    user_info = base64.b64encode(
+        json.dumps(
+            {"sub": str(user.id), "username": user.username, "email": user.email}
+        ).encode("utf-8")
+    )
+    client.force_login(user)
+
+    response = client.post(
+        reverse(
+            "device_group_devices_remove",
+            kwargs={"device_group_id": dg1.id, "device_id": d1.id},
+        ),
+        HTTP_X_USERINFO=user_info,
+    )
+
+    assert response.status_code == 403
+    assert d1 in dg1.devices.all()  # unchanged
+```
+
+Note: `Device` and `reverse` are already imported at the top of this test file (used by existing tests).
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `docker compose run --rm pytest --ds=cdip_admin.settings "integrations/tests/test_integration_views.py::test_device_group_devices_remove_unlinks_device" "integrations/tests/test_integration_views.py::test_device_group_devices_remove_requires_change_permission" -p no:cacheprovider -q`
+Expected: FAIL — `NoReverseMatch: Reverse for 'device_group_devices_remove' not found`.
+
+- [ ] **Step 3: Add the view**
+
+In `cdip_admin/integrations/views.py`, immediately after the `device_group_destinations_remove` function, add:
+
+```python
+@require_POST
+@permission_required("integrations.change_devicegroup", raise_exception=True)
+def device_group_devices_remove(request, device_group_id, device_id):
+    device_group = get_object_or_404(DeviceGroup, pk=device_group_id)
+    permission_can_view(request, device_group)
+    device = get_object_or_404(Device, pk=device_id)
+    device_group.devices.remove(device)
+    context = {
+        "devices": device_group.devices.all(),
+        "device_group_id": device_group_id,
+    }
+    return render(request, "integrations/device_group_devices_partial.html", context)
+```
+
+- [ ] **Step 4: Add the URL**
+
+In `cdip_admin/integrations/urls.py`, in the "Device Group Devices" block (next to the `device_group_devices_list` route), add:
+
+```python
+    path(
+        "devicegroups/<uuid:device_group_id>/devices/<uuid:device_id>/remove",
+        views.device_group_devices_remove,
+        name="device_group_devices_remove",
+    ),
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `docker compose run --rm pytest --ds=cdip_admin.settings "integrations/tests/test_integration_views.py::test_device_group_devices_remove_unlinks_device" "integrations/tests/test_integration_views.py::test_device_group_devices_remove_requires_change_permission" -p no:cacheprovider -q`
+Expected: PASS (2 passed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cdip_admin/integrations/views.py cdip_admin/integrations/urls.py cdip_admin/integrations/tests/test_integration_views.py
+git commit -m "feat: add device_group_devices_remove view and URL"
+```
+
+---
+
+### Task 2: Template — trash icon + inline confirm
+
+**Files:**
+- Modify: `cdip_admin/integrations/templates/integrations/device_group_devices_partial.html`
+- Test: `cdip_admin/integrations/tests/test_integration_views.py`
+
+**Interfaces:**
+- Consumes: URL name `device_group_devices_remove` (from Task 1); `device_group_id` and `devices` in the partial context; section id `#device-group-devices-section`.
+- Produces: each device row renders a remove control posting to `device_group_devices_remove`, targeting `#device-group-devices-section` with `outerHTML` swap.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `cdip_admin/integrations/tests/test_integration_views.py`:
+
+```python
+def test_device_group_devices_list_shows_remove_control(
+        client, global_admin_user, setup_data
+):
+    dg1 = setup_data["dg1"]
+    d1 = setup_data["d1"]
+
+    client.force_login(global_admin_user.user)
+
+    response = client.get(
+        reverse("device_group_devices_list", kwargs={"device_group_id": dg1.id}),
+        HTTP_X_USERINFO=global_admin_user.user_info,
+    )
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    # Trash icon present...
+    assert "fa-trash" in content
+    # ...wired to the remove endpoint for this device.
+    assert reverse(
+        "device_group_devices_remove",
+        kwargs={"device_group_id": dg1.id, "device_id": d1.id},
+    ) in content
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `docker compose run --rm pytest --ds=cdip_admin.settings "integrations/tests/test_integration_views.py::test_device_group_devices_list_shows_remove_control" -p no:cacheprovider -q`
+Expected: FAIL — `assert 'fa-trash' in content` (the partial has no remove control yet).
+
+- [ ] **Step 3: Add the action column to the partial**
+
+Replace the entire contents of `cdip_admin/integrations/templates/integrations/device_group_devices_partial.html` with:
+
+```django
+<div id="device-group-devices-section" class="mt-4">
+    <h5>Devices in group</h5>
+    {% if devices %}
+    <div style="max-height: 240px; overflow-y: auto;">
+        <table class="table table-sm table-bordered">
+            <thead class="thead-light">
+                <tr>
+                    <th>External ID</th>
+                    <th>Created</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for dev in devices %}
+                <tr>
+                    <td>
+                        <a href="#"
+                           hx-get="{% url 'device_update' module_id=dev.id %}"
+                           hx-target="#slide-panel-body"
+                           hx-swap="innerHTML">{{ dev.external_id|default:dev }}</a>
+                    </td>
+                    <td class="text-muted">{{ dev.created_at|date:"M j, Y" }}</td>
+                    <td class="text-right">
+                        <span class="remove-device-btn-{{ dev.id }}">
+                            <button class="btn btn-outline-danger btn-sm"
+                                    title="Remove from group"
+                                    _="on click hide .remove-device-btn-{{ dev.id }} then show .confirm-remove-device-{{ dev.id }} with display:flex">
+                                <i class="fas fa-trash"></i>
+                            </button>
+                        </span>
+                        <span class="confirm-remove-device-{{ dev.id }} align-items-center justify-content-end"
+                              style="display: none; gap: .4rem;">
+                            <small class="text-muted">Remove {{ dev.external_id|default:dev }}?</small>
+                            <button class="btn btn-danger btn-sm"
+                                    hx-post="{% url 'device_group_devices_remove' device_group_id=device_group_id device_id=dev.id %}"
+                                    hx-target="#device-group-devices-section"
+                                    hx-swap="outerHTML">Confirm</button>
+                            <button class="btn btn-secondary btn-sm"
+                                    _="on click hide .confirm-remove-device-{{ dev.id }} then show .remove-device-btn-{{ dev.id }}">Cancel</button>
+                        </span>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% else %}
+    <p class="text-muted">No devices in this group.</p>
+    {% endif %}
+</div>
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `docker compose run --rm pytest --ds=cdip_admin.settings "integrations/tests/test_integration_views.py::test_device_group_devices_list_shows_remove_control" -p no:cacheprovider -q`
+Expected: PASS.
+
+- [ ] **Step 5: Re-run the device-group tests to confirm no regression**
+
+Run: `docker compose run --rm pytest --ds=cdip_admin.settings "integrations/tests/test_integration_views.py" -k device_group -p no:cacheprovider -q`
+Expected: all `device_group` tests pass (list, devices list, devices remove, remove permission, remove control).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cdip_admin/integrations/templates/integrations/device_group_devices_partial.html cdip_admin/integrations/tests/test_integration_views.py
+git commit -m "feat: trash icon + inline confirm to remove a device from a group"
+```
+
+---
+
+### Task 3: Live verification
+
+**Files:** none (manual verification in the running stack).
+
+- [ ] **Step 1: Confirm the partial renders the remove control (read-only, no DB writes)**
+
+Run:
+```bash
+docker compose exec -T web python3.11 manage.py shell -c "
+from django.template.loader import render_to_string
+from integrations.models.v1.models import Device
+import uuid, datetime
+d = Device(id=uuid.UUID('11111111-1111-1111-1111-111111111111'), external_id='012345-67-8901')
+d.created_at = datetime.datetime(2023,5,26)
+print(render_to_string('integrations/device_group_devices_partial.html', {'devices':[d], 'device_group_id': uuid.uuid4()}))
+"
+```
+Expected: HTML contains the `fa-trash` button, the `confirm-remove-device-…` span, and an `hx-post` to `/integrations/devicegroups/…/devices/11111111-…/remove`.
+
+- [ ] **Step 2: Browser check (against an env with a populated group)**
+
+Open a device group with devices in the edit panel. Confirm: trash icon on each row → click reveals inline "Remove <external_id>? Confirm / Cancel" → Confirm removes the row and the section re-renders (or shows "No devices in this group."); Cancel restores the icon. (The local dev DB has no populated group; verify in a feature env.)
+
+---
+
+## Self-Review
+
+**Spec coverage:** View (Task 1), URL (Task 1), template trash icon + inline confirm (Task 2), M2M-unlink semantics (Task 1 test asserts Device still exists), permission gate (Task 1 403 test), tests (Tasks 1–2), live verification (Task 3). All spec sections covered.
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code and exact commands.
+
+**Type consistency:** `device_group_devices_remove(request, device_group_id, device_id)` and URL kwargs `device_group_id`/`device_id` match across view, URL, template, and tests. Section id `#device-group-devices-section` matches the partial root and the `hx-target`. Hyperscript class names `remove-device-btn-<id>` / `confirm-remove-device-<id>` are paired consistently.

--- a/docs/superpowers/specs/2026-06-29-add-device-to-device-group-design.md
+++ b/docs/superpowers/specs/2026-06-29-add-device-to-device-group-design.md
@@ -1,0 +1,186 @@
+# Design — add a device to a device group
+
+## Problem
+
+The device group edit slide panel can now list and remove devices, but there is
+no way to **add** a device to a group from the panel. Adding currently lives
+only in the separate Manage Devices view. Users want a quick add directly in the
+panel, next to the devices list.
+
+## Goal
+
+Add an "Add device" control to the "Devices in group" section: a **searchable
+autocomplete** (type to search by `external_id`) plus an **Add** button. On add,
+the device is linked to the group (`devices` M2M) and the section re-renders in
+place — mirroring the existing destination-add and the device-remove flows.
+
+- **Searchable, not a preloaded dropdown.** Devices can be numerous, so the
+  select lazy-loads matches from a new device-search endpoint (reusing the
+  `makeLazySelect` pattern used for the owner / device-group fields), rather than
+  preloading every option like the "Add Destination" control does.
+- **Eligibility = same org as the group.** Only devices whose inbound
+  integration is owned by the group's organization
+  (`device.inbound_configuration.owner == device_group.owner`), excluding
+  devices already in the group.
+- **Add only.** Removal already exists; bulk management stays in Manage Devices.
+
+## Existing patterns this mirrors
+
+- `device_group_destinations_add` (`integrations/views.py`): `@require_POST` +
+  `@permission_required("integrations.change_devicegroup", raise_exception=True)`,
+  `permission_can_view`, mutate the relation, re-render the partial.
+- `device_group_autocomplete` (`integrations/views.py`): `@require_GET`, filter by
+  `q`, scope by permission, return `JsonResponse([{ "id": ..., "name": ... }])`.
+- `base.html` `makeLazySelect(el, url)` + `initTomSelects(root)`: `initTomSelects`
+  runs on `DOMContentLoaded` (line 89) and on `htmx:afterSettle` (line 93,
+  `initTomSelects(evt.detail.elt)`). `makeLazySelect` builds a TomSelect with
+  `valueField:'id'`, `labelField:'name'`, `searchField:'name'`, and `load:` that
+  does `fetch(url + encodeURIComponent(query))` expecting `[{id, name}]`.
+
+`Device.owner` is a property returning `inbound_configuration.owner`;
+`DeviceGroup.owner` is an FK to the owning organization.
+`JsonResponse`, `require_GET`, `require_POST`, `permission_required`,
+`permission_can_view`, `Device`, and `DeviceGroup` are already imported in
+`integrations/views.py`.
+
+## Components
+
+### 1. Shared eligibility helper — `integrations/views.py`
+
+One queryset, used by both the autocomplete and the add-view guard (DRY):
+
+```python
+def _eligible_devices_for_group(device_group, q=""):
+    """Devices addable to this group: same owning org, matching external_id,
+    not already in the group."""
+    return (
+        Device.objects
+        .filter(inbound_configuration__owner=device_group.owner)
+        .filter(external_id__icontains=q)
+        .exclude(id__in=device_group.devices.values_list("id", flat=True))
+        .select_related("inbound_configuration__type")
+        .order_by("external_id")
+    )
+```
+
+### 2. Autocomplete view — `integrations/views.py`
+
+```python
+@require_GET
+@permission_required("integrations.view_devicegroup", raise_exception=True)
+def device_group_devices_autocomplete(request, device_group_id):
+    device_group = get_object_or_404(DeviceGroup, pk=device_group_id)
+    permission_can_view(request, device_group)
+    q = request.GET.get("q", "")
+    devices = _eligible_devices_for_group(device_group, q)[:50]
+    results = [
+        {"id": str(d.id), "name": f"{d.external_id} — {d.inbound_configuration.type.name}"}
+        for d in devices
+    ]
+    return JsonResponse(results, safe=False)
+```
+
+Scoping to the group's org plus `permission_can_view` means the endpoint cannot
+leak devices the user shouldn't see.
+
+### 3. Add view — `integrations/views.py`
+
+```python
+@require_POST
+@permission_required("integrations.change_devicegroup", raise_exception=True)
+def device_group_devices_add(request, device_group_id):
+    device_group = get_object_or_404(DeviceGroup, pk=device_group_id)
+    permission_can_view(request, device_group)
+    device_id = request.POST.get("device_id")
+    # Eligibility guard (defense against a crafted POST): only add a device that
+    # is in the eligible set (same org, not already in the group).
+    if device_id and _eligible_devices_for_group(device_group).filter(pk=device_id).exists():
+        device_group.devices.add(Device.objects.get(pk=device_id))
+    context = {
+        "devices": device_group.devices.select_related("inbound_configuration__type"),
+        "device_group_id": device_group_id,
+    }
+    return render(request, "integrations/device_group_devices_partial.html", context)
+```
+
+An ineligible or missing `device_id` is a no-op that simply re-renders the
+current list (the UI never offers ineligible devices).
+
+### 4. URLs — `integrations/urls.py`
+
+In the "Device Group Devices" block:
+
+```python
+path(
+    "devicegroups/<uuid:device_group_id>/devices/add",
+    views.device_group_devices_add,
+    name="device_group_devices_add",
+),
+path(
+    "devicegroups/<uuid:device_group_id>/devices/autocomplete",
+    views.device_group_devices_autocomplete,
+    name="device_group_devices_autocomplete",
+),
+```
+
+### 5. Template — `device_group_devices_partial.html`
+
+After the table / empty-state block (so it shows in both states), add the form:
+
+```django
+<form hx-post="{% url 'device_group_devices_add' device_group_id=device_group_id %}"
+      hx-target="#device-group-devices-section"
+      hx-swap="outerHTML"
+      class="form-inline mb-3">
+    {% csrf_token %}
+    <select name="device_id"
+            class="form-control form-control-sm mr-2 device-select"
+            data-autocomplete-url="{% url 'device_group_devices_autocomplete' device_group_id=device_group_id %}?q="
+            required>
+    </select>
+    <button type="submit" class="btn btn-outline-primary btn-sm">Add device</button>
+</form>
+```
+
+The `<select>` starts empty; TomSelect lazy-loads options from
+`data-autocomplete-url` on focus/typing. `{% csrf_token %}` is included (the form
+is serialized by htmx on `hx-post`), consistent with the destinations add form.
+
+### 6. JS wiring — `website/templates/base.html`
+
+Add one block to `initTomSelects(root)` (alongside the `owner` and
+`default_devicegroup` blocks), so the device search initializes on initial
+lazy-load and on every re-render swap:
+
+```javascript
+root.querySelectorAll('select[name="device_id"]').forEach(function(el) {
+    if (!el.tomselect) {
+        makeLazySelect(el, el.dataset.autocompleteUrl);
+    }
+});
+```
+
+## Permissions / visibility
+
+The Add form renders for anyone who can view the section; the `add` POST is gated
+by `change_devicegroup` and the autocomplete by `view_devicegroup` (both plus
+`permission_can_view`). This matches the remove and destinations controls.
+
+## Tests — `integrations/tests/test_integration_views.py`
+
+- **add adds an eligible device**: POST a same-org device not yet in the group →
+  200, device now in `device_group.devices`, refreshed partial lists it.
+- **add rejects an other-org device**: POST a device whose inbound integration is
+  owned by a different org → group membership unchanged (no-op), 200.
+- **add requires change permission**: a user without `change_devicegroup` → 403,
+  membership unchanged.
+- **autocomplete returns eligible matches**: returns same-org devices matching
+  `q`, excludes devices already in the group and devices from other orgs; result
+  items have `id` and `name`.
+
+## Out of scope
+
+- Creating a brand-new Device (this only links existing devices).
+- Bulk add (stays in Manage Devices).
+- Cross-org device membership.
+- Hiding the Add form from non-editors (server-gated, consistent with peers).

--- a/docs/superpowers/specs/2026-06-29-remove-device-from-device-group-design.md
+++ b/docs/superpowers/specs/2026-06-29-remove-device-from-device-group-design.md
@@ -1,0 +1,148 @@
+# Design — remove a device from a device group
+
+## Problem
+
+The device group edit slide panel now shows a read-only "Devices in group"
+section (see `docs/device-group-devices-section-plan.md`). There is no way to
+remove a device from a group directly from this panel — removal currently
+requires the separate Manage Devices view.
+
+## Goal
+
+Let a user remove a device from a device group directly in the edit panel:
+a clickable trash icon on each device row, with an inline confirmation before
+the removal takes effect.
+
+- **Removal = M2M unlink.** `DeviceGroup.devices` is a `ManyToManyField`, so
+  removing means `device_group.devices.remove(device)`. The `Device` row itself
+  is **not** deleted.
+- **Removal only.** Adding new devices to a group stays in the existing Manage
+  Devices view; this change does not add device-creation here.
+- Mirrors the existing destination-removal pattern in the same panel for
+  consistency (`device_group_destinations_remove`).
+
+## How removal works today for destinations (pattern to mirror)
+
+`device_group_destinations_partial.html` renders, per destination row, a
+"Remove" button that reveals an inline confirm via hyperscript:
+
+```django
+<span class="remove-btn-{{ dest.id }}">
+    <button class="btn btn-outline-danger btn-sm"
+            _="on click hide .remove-btn-{{ dest.id }} then show .confirm-remove-{{ dest.id }} with display:flex">
+        Remove
+    </button>
+</span>
+<span class="confirm-remove-{{ dest.id }} ..." style="display: none; ...">
+    <small>Remove {{ dest.name|default:dest }}?</small>
+    <button class="btn btn-danger btn-sm"
+            hx-post="{% url 'device_group_destinations_remove' device_group_id=device_group_id outbound_id=dest.id %}"
+            hx-target="#device-group-destinations-section"
+            hx-swap="outerHTML">Confirm</button>
+    <button class="btn btn-secondary btn-sm"
+            _="on click hide .confirm-remove-{{ dest.id }} then show .remove-btn-{{ dest.id }}">Cancel</button>
+</span>
+```
+
+The backing view:
+
+```python
+@require_POST
+@permission_required("integrations.change_devicegroup", raise_exception=True)
+def device_group_destinations_remove(request, device_group_id, outbound_id):
+    device_group = get_object_or_404(DeviceGroup, pk=device_group_id)
+    permission_can_view(request, device_group)
+    ...
+    device_group.destinations.remove(outbound)
+    context = _device_group_destinations_context(device_group, request)
+    return render(request, "integrations/device_group_destinations_partial.html", context)
+```
+
+CSRF for the `hx-post` rides on the global `htmx:configRequest` handler in
+`base.html`, which sets the `X-CSRFToken` header — no per-row `{% csrf_token %}`
+needed. (This is the handler made reliable by the CSRF token-rotation fix.)
+
+## Components
+
+### 1. View — `integrations/views.py`
+
+Add next to `device_group_destinations_remove`:
+
+```python
+@require_POST
+@permission_required("integrations.change_devicegroup", raise_exception=True)
+def device_group_devices_remove(request, device_group_id, device_id):
+    device_group = get_object_or_404(DeviceGroup, pk=device_group_id)
+    permission_can_view(request, device_group)
+    device = get_object_or_404(Device, pk=device_id)
+    device_group.devices.remove(device)
+    context = {
+        "devices": device_group.devices.all(),
+        "device_group_id": device_group_id,
+    }
+    return render(request, "integrations/device_group_devices_partial.html", context)
+```
+
+### 2. URL — `integrations/urls.py`
+
+Add next to the devices-list route:
+
+```python
+path(
+    "devicegroups/<uuid:device_group_id>/devices/<uuid:device_id>/remove",
+    views.device_group_devices_remove,
+    name="device_group_devices_remove",
+),
+```
+
+### 3. Template — `device_group_devices_partial.html`
+
+Add a right-aligned action column. Each row gets a trash-icon button that
+reveals the inline confirm, mirroring destinations:
+
+```django
+<th></th>   {# action column header #}
+...
+<td class="text-right">
+    <span class="remove-device-btn-{{ dev.id }}">
+        <button class="btn btn-outline-danger btn-sm"
+                title="Remove from group"
+                _="on click hide .remove-device-btn-{{ dev.id }} then show .confirm-remove-device-{{ dev.id }} with display:flex">
+            <i class="fas fa-trash"></i>
+        </button>
+    </span>
+    <span class="confirm-remove-device-{{ dev.id }} align-items-center justify-content-end"
+          style="display: none; gap: .4rem;">
+        <small class="text-muted">Remove {{ dev.external_id|default:dev }}?</small>
+        <button class="btn btn-danger btn-sm"
+                hx-post="{% url 'device_group_devices_remove' device_group_id=device_group_id device_id=dev.id %}"
+                hx-target="#device-group-devices-section"
+                hx-swap="outerHTML">Confirm</button>
+        <button class="btn btn-secondary btn-sm"
+                _="on click hide .confirm-remove-device-{{ dev.id }} then show .remove-device-btn-{{ dev.id }}">Cancel</button>
+    </span>
+</td>
+```
+
+The empty-state and scroll container are unchanged.
+
+### 4. Tests — `integrations/tests/test_integration_views.py`
+
+- `test_device_group_devices_remove_unlinks_device`: POST as global admin
+  removes the device from the group (M2M); response 200; the removed device is
+  absent from the refreshed `devices` context; the `Device` row still exists.
+- `test_device_group_devices_remove_requires_change_permission`: a view-only
+  org member gets 403.
+
+## Permissions / visibility
+
+The trash icon renders for any user who can view the section; the POST is gated
+server-side by `change_devicegroup` (a view-only user who clicks Confirm gets
+403). This matches the existing destinations behavior in the same panel. Hiding
+the icon for non-editors is intentionally out of scope for consistency.
+
+## Out of scope
+
+- Adding devices to a group (stays in Manage Devices).
+- Deleting the `Device` record (removal is M2M unlink only).
+- Hiding the icon for non-editors.


### PR DESCRIPTION
## What this does

Adds full device management to the **device group edit slide panel**:

1. **Devices in group** — a list of the group's devices by `external_id`; each links to its own config, swapped into the same panel.
2. **Remove a device** — a minus-circle icon per row with an inline `Remove <external_id>? [Confirm] [Cancel]`. Confirm unlinks the device from the group's `devices` M2M (**does not delete the Device**) and re-renders the section.
3. **Add a device** — an "Add device" form below the list: a **searchable autocomplete** (type to search by `external_id`) scoped to the group's organization, excluding devices already in the group. Selecting one and clicking **Add device** links it and re-renders.

Removal and addition both operate on the M2M only; bulk management still lives in Manage Devices.


https://github.com/user-attachments/assets/d25b32bf-bc74-4cee-91da-186f5d48eb09


## Also included

- **Fix:** `custom_error_403` (global `handler403`) returned HTTP 200 instead of 403 — split into its own commit. DRF endpoints are unaffected.

## How it's built

- Views (`integrations/views.py`), all mirroring the `device_group_destinations_*` pattern with the `permission_can_view` gate:
  - `device_group_devices_list`, `device_group_devices_remove` (`@require_POST` + `change_devicegroup`), `device_group_devices_add` (`@require_POST` + `change_devicegroup`), `device_group_devices_autocomplete` (`@require_GET` + `view_devicegroup`).
  - A single `_eligible_devices_for_group(group, q)` helper enforces eligibility (same-org, not-already-in-group) for both the autocomplete and the add guard — one leak-proof source of truth.
- Partial `device_group_devices_partial.html` (list + remove control + add form), lazy-loaded into `device_group_update_partial.html` above Destinations.
- The add search reuses the existing `makeLazySelect` lazy-select via one block in `base.html` `initTomSelects`; the `<select name="device_id">` carries a group-scoped `data-autocomplete-url`.
- CSRF rides the form's `{% csrf_token %}` / the global htmx header handler — no per-row token.
- Device querysets use `select_related("inbound_configuration__type")`.

## Tests

`integrations/tests/test_integration_views.py` — list renders devices + remove control + add form (incl. empty-group state); remove unlinks (Device still exists) and is permission-gated (403); add links an eligible device, **rejects a cross-org device**, and is permission-gated (403); autocomplete returns same-org, not-already-in-group matches and excludes others.

All device-group tests pass (12). The branch's only suite failures are pre-existing/environmental (external-network `gaierror`, flaky `--reuse-db` ordering), unrelated to this change.

## Design docs

- Specs: `docs/superpowers/specs/2026-06-29-remove-device-from-device-group-design.md`, `docs/superpowers/specs/2026-06-29-add-device-to-device-group-design.md`
- Plans: `docs/device-group-devices-section-plan.md`, `docs/superpowers/plans/2026-06-29-remove-device-from-device-group.md`, `docs/superpowers/plans/2026-06-29-add-device-to-device-group.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)