### PR TITLE
fix: stop OIDC middleware rotating CSRF token on every request

### DIFF
--- a/cdip_admin/cdip_admin/auth/middleware.py
+++ b/cdip_admin/cdip_admin/auth/middleware.py
@@ -80,18 +80,29 @@ class OidcRemoteUserMiddleware(MiddlewareMixin):
         if request.user.is_authenticated:
             if request.user.get_username() == username:
                 return
-            else:
-                # An authenticated user is associated with the request, but
-                # it does not match the authorized user in the header.
-                self._remove_invalid_user(request)
-        # We are seeing this user for the first time in this session, attempt
-        # to authenticate the user.
+            # Otherwise fall through and re-resolve: the stored Django username
+            # may simply differ from the `username` claim. The backend matches
+            # users by email, not username, so a username comparison is not a
+            # reliable identity check -- compare the resolved user below.
+        # Remember who (if anyone) is already authenticated so we only re-login
+        # when the session user actually changes.
+        current_user_pk = request.user.pk if request.user.is_authenticated else None
+        # Attempt to authenticate the user from the header.
         user = auth.authenticate(request, user_info=user_info)
         if user:
-            # User is valid.  Set request.user and persist user in the session
-            # by logging the user in.
             request.user = user
-            auth.login(request, user)
+            if user.pk != current_user_pk:
+                # New or changed session user. auth.login() calls
+                # rotate_token(); calling it on every request -- as happens when
+                # the stored username differs from the `username` claim -- keeps
+                # regenerating the CSRF secret, so an already-rendered form
+                # fails on submit with "CSRF token from POST incorrect."
+                # Only rotate when the user genuinely changes.
+                auth.login(request, user)
+        elif current_user_pk is not None:
+            # Header user could not be authenticated but a stale user remains in
+            # the session -- drop it.
+            self._remove_invalid_user(request)
 
     def clean_username(self, username, request):
         """

--- a/cdip_admin/cdip_admin/auth/tests/test_middleware.py
+++ b/cdip_admin/cdip_admin/auth/tests/test_middleware.py
@@ -1,0 +1,128 @@
+import base64
+import json
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.middleware.csrf import get_token
+from django.test import RequestFactory
+
+from cdip_admin.auth.middleware import (
+    AuthenticationMiddleware,
+    OidcRemoteUserMiddleware,
+)
+
+
+def _userinfo_header(username, email):
+    return base64.b64encode(
+        json.dumps({"username": username, "email": email}).encode("utf-8")
+    )
+
+
+def _noop_response(request):
+    return None
+
+
+@pytest.mark.django_db
+def test_authenticated_user_with_mismatched_username_does_not_rotate_csrf_token():
+    """
+    OidcRemoteUserMiddleware must not re-login an already-authenticated user on
+    every request. auth.login() calls rotate_token(), which regenerates the
+    CSRF secret -- a form rendered earlier then fails on submit with
+    "CSRF token from POST incorrect."
+
+    The trigger is a user whose stored Django username differs from the
+    Keycloak `username` claim. The backend (SimpleUserInfoBackend) resolves
+    users by email, so the same user authenticates fine, but the middleware's
+    username-based guard never short-circuits and logs in on every request.
+    """
+    User = get_user_model()
+    email = "person@example.com"
+    # Stored Django username == email, but Keycloak sends a short username claim.
+    User.objects.create(username=email, email=email)
+    header = _userinfo_header(username="person", email=email)
+
+    factory = RequestFactory()
+
+    # Request 1: establishes the session and logs the user in. Rotation here is
+    # expected and correct -- this is where the form's CSRF token is minted.
+    req1 = factory.get("/", HTTP_X_USERINFO=header)
+    SessionMiddleware(_noop_response).process_request(req1)
+    AuthenticationMiddleware(_noop_response).process_request(req1)
+    OidcRemoteUserMiddleware(_noop_response).process_request(req1)
+    assert req1.user.is_authenticated
+    get_token(req1)  # mint the CSRF secret a rendered form would embed
+    req1.session.save()
+
+    # Request 2: same session, user already authenticated (e.g. the browser
+    # fetching an asset or autocomplete while the form is open). This must NOT
+    # rotate the CSRF token, or the still-open form's token goes stale.
+    req2 = factory.get("/", HTTP_X_USERINFO=header)
+    req2.session = req1.session
+    AuthenticationMiddleware(_noop_response).process_request(req2)
+    assert req2.user.is_authenticated  # loaded from the session
+    OidcRemoteUserMiddleware(_noop_response).process_request(req2)
+
+    assert req2.META.get("CSRF_COOKIE_NEEDS_UPDATE") is not True, (
+        "CSRF token was rotated on a follow-up request for an already-"
+        "authenticated user; this breaks form POSTs with 'CSRF token "
+        "incorrect.'"
+    )
+
+
+@pytest.mark.django_db
+def test_genuine_user_switch_still_logs_in_the_new_user():
+    """
+    The no-rotation guard must not defeat the security behavior: when the header
+    presents a *different* user than the one in the session, the middleware must
+    switch the session to the new user (and rotate the token, as login does).
+    """
+    User = get_user_model()
+    first = User.objects.create(username="first@example.com", email="first@example.com")
+    User.objects.create(username="second@example.com", email="second@example.com")
+
+    factory = RequestFactory()
+
+    # Session belongs to `first`.
+    req1 = factory.get("/", HTTP_X_USERINFO=_userinfo_header("first@example.com", "first@example.com"))
+    SessionMiddleware(_noop_response).process_request(req1)
+    AuthenticationMiddleware(_noop_response).process_request(req1)
+    OidcRemoteUserMiddleware(_noop_response).process_request(req1)
+    assert req1.user.email == "first@example.com"
+    req1.session.save()
+
+    # A request arrives in the same session but with `second` in the header.
+    req2 = factory.get("/", HTTP_X_USERINFO=_userinfo_header("second@example.com", "second@example.com"))
+    req2.session = req1.session
+    AuthenticationMiddleware(_noop_response).process_request(req2)
+    OidcRemoteUserMiddleware(_noop_response).process_request(req2)
+
+    assert req2.user.email == "second@example.com"
+    assert req2.META.get("CSRF_COOKIE_NEEDS_UPDATE") is True, (
+        "Switching the session to a different user must rotate the CSRF token."
+    )
+
+
+@pytest.mark.django_db
+def test_matching_username_short_circuits_without_rotation():
+    """
+    The common case -- stored Django username equals the `username` claim --
+    must short-circuit without re-login or token rotation.
+    """
+    User = get_user_model()
+    User.objects.create(username="match@example.com", email="match@example.com")
+    header = _userinfo_header("match@example.com", "match@example.com")
+
+    factory = RequestFactory()
+    req1 = factory.get("/", HTTP_X_USERINFO=header)
+    SessionMiddleware(_noop_response).process_request(req1)
+    AuthenticationMiddleware(_noop_response).process_request(req1)
+    OidcRemoteUserMiddleware(_noop_response).process_request(req1)
+    req1.session.save()
+
+    req2 = factory.get("/", HTTP_X_USERINFO=header)
+    req2.session = req1.session
+    AuthenticationMiddleware(_noop_response).process_request(req2)
+    OidcRemoteUserMiddleware(_noop_response).process_request(req2)
+
+    assert req2.META.get("CSRF_COOKIE_NEEDS_UPDATE") is not True


### PR DESCRIPTION
## Problem

Saving any Django form (e.g. *Add inbound integration*) fails with:

```
Forbidden (CSRF token from POST incorrect.): /integrations/inboundconfigurations/add
```

## Root cause

`OidcRemoteUserMiddleware.process_request` re-ran `auth.authenticate()` + `auth.login()` on **every request** whenever a user's stored Django username differed from the Keycloak `username` claim. The early-return guard compares usernames, but `SimpleUserInfoBackend` resolves users by **email**, so a mismatched user (e.g. a Django user whose `username` is their email while Keycloak sends a short username claim) never short-circuited.

`auth.login()` calls `rotate_token()`, so the CSRF secret was regenerated on every response. A form rendered earlier then failed on submit as soon as any concurrent request (static asset, autocomplete, htmx fragment) rotated the cookie.

## Fix

Only call `auth.login()` when the resolved user actually differs from the user already in the session. The token still rotates on genuine login / user switch (preserving the security property), but not on every request.

## Tests

`cdip_admin/cdip_admin/auth/tests/test_middleware.py`:
- no rotation on a follow-up request for an already-authenticated mismatched-username user (the bug — fails before, passes after)
- a genuine user switch still rotates the token
- the matching-username fast path short-circuits without rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)