### PR TITLE
Automate local environment setup (./dev.sh setup)

### DIFF
--- a/cdip_admin/accounts/management/commands/seed_dev_admin.py
+++ b/cdip_admin/accounts/management/commands/seed_dev_admin.py
@@ -1,0 +1,29 @@
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+
+DEV_EMAIL = "dev@local.dev"      # matches the cdip-dev Keycloak realm user
+DEV_USERNAME = "dev"             # matches the realm 'username' claim
+
+
+class Command(BaseCommand):
+    help = "Seed the local 'dev' Keycloak user as a Django superuser (local dev only)."
+
+    def handle(self, *args, **options):
+        if not settings.DEBUG:
+            raise CommandError(
+                "seed_dev_admin refuses to run when DEBUG is False (local dev only)."
+            )
+        User = get_user_model()
+        user, created = User.objects.get_or_create(
+            email=DEV_EMAIL, defaults={"username": DEV_USERNAME}
+        )
+        if not (user.is_superuser and user.is_staff):
+            user.is_superuser = True
+            user.is_staff = True
+            user.save(update_fields=["is_superuser", "is_staff"])
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"dev admin ready: {user.username} <{user.email}> (created={created})"
+            )
+        )

--- a/cdip_admin/accounts/tests/test_seed_dev_admin.py
+++ b/cdip_admin/accounts/tests/test_seed_dev_admin.py
@@ -1,0 +1,45 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+
+@pytest.mark.django_db
+def test_seed_dev_admin_creates_superuser(settings):
+    settings.DEBUG = True
+    call_command("seed_dev_admin")
+    user = get_user_model().objects.get(email="dev@local.dev")
+    assert user.username == "dev"
+    assert user.is_superuser
+    assert user.is_staff
+
+
+@pytest.mark.django_db
+def test_seed_dev_admin_is_idempotent(settings):
+    settings.DEBUG = True
+    call_command("seed_dev_admin")
+    call_command("seed_dev_admin")
+    User = get_user_model()
+    assert User.objects.filter(email="dev@local.dev").count() == 1
+    assert User.objects.get(email="dev@local.dev").is_superuser
+
+
+@pytest.mark.django_db
+def test_seed_dev_admin_elevates_existing_user(settings):
+    settings.DEBUG = True
+    User = get_user_model()
+    User.objects.create(
+        username="dev", email="dev@local.dev", is_superuser=False, is_staff=False
+    )
+    call_command("seed_dev_admin")
+    user = User.objects.get(email="dev@local.dev")
+    assert user.is_superuser
+    assert user.is_staff
+
+
+@pytest.mark.django_db
+def test_seed_dev_admin_refuses_when_not_debug(settings):
+    settings.DEBUG = False
+    with pytest.raises(CommandError):
+        call_command("seed_dev_admin")
+    assert not get_user_model().objects.filter(email="dev@local.dev").exists()

--- a/cdip_admin/accounts/tests/test_seed_dev_admin.py
+++ b/cdip_admin/accounts/tests/test_seed_dev_admin.py
@@ -40,6 +40,6 @@ def test_seed_dev_admin_elevates_existing_user(settings):
 @pytest.mark.django_db
 def test_seed_dev_admin_refuses_when_not_debug(settings):
     settings.DEBUG = False
-    with pytest.raises(CommandError):
+    with pytest.raises(CommandError, match="refuses to run"):
         call_command("seed_dev_admin")
     assert not get_user_model().objects.filter(email="dev@local.dev").exists()

--- a/cdip_admin/core/migrations/0007_create_access_groups.py
+++ b/cdip_admin/core/migrations/0007_create_access_groups.py
@@ -1,0 +1,21 @@
+from django.db import migrations
+
+GROUP_NAMES = ("GlobalAdmin", "OrganizationMember")  # mirror core.enums.DjangoGroups
+
+
+def create_access_groups(apps, schema_editor):
+    Group = apps.get_model("auth", "Group")
+    for name in GROUP_NAMES:
+        Group.objects.get_or_create(name=name)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0006_alter_task_id"),
+        ("auth", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_access_groups, migrations.RunPython.noop),
+    ]

--- a/cdip_admin/core/tests.py
+++ b/cdip_admin/core/tests.py
@@ -1,5 +1,5 @@
 import pytest
-from django.contrib.auth.models import User
+from django.contrib.auth.models import Group, User
 
 from core.admin import EstimatedCountPaginator
 
@@ -137,8 +137,6 @@ def test_activity_log_paginator_has_baseline_filter_flag():
 
     assert ActivityLogPaginator.estimate_through_baseline_filter is True
 
-
-from django.contrib.auth.models import Group
 
 
 @pytest.mark.django_db

--- a/cdip_admin/core/tests.py
+++ b/cdip_admin/core/tests.py
@@ -136,3 +136,16 @@ def test_activity_log_paginator_has_baseline_filter_flag():
     from activity_log.admin import ActivityLogPaginator
 
     assert ActivityLogPaginator.estimate_through_baseline_filter is True
+
+
+from django.contrib.auth.models import Group
+
+
+@pytest.mark.django_db
+def test_access_groups_created_by_migration():
+    names = set(
+        Group.objects.filter(
+            name__in=["GlobalAdmin", "OrganizationMember"]
+        ).values_list("name", flat=True)
+    )
+    assert names == {"GlobalAdmin", "OrganizationMember"}

--- a/dev.sh
+++ b/dev.sh
@@ -40,7 +40,7 @@ function print_help() {
     echo "  createsuperuser - Create Django superuser"
     echo "  clean           - Stop and remove all containers and volumes"
     echo "  status          - Show status of all services"
-    echo "  setup           - Initial setup (copy env, build, migrate, createsuperuser)"
+    echo "  setup           - One-command setup: secret, build, wait, migrate, kong routes, dev admin"
     echo ""
 }
 
@@ -134,48 +134,60 @@ function show_status() {
 function initial_setup() {
     echo -e "${GREEN}Starting initial setup...${NC}"
 
-    # Check if .env exists
-    local env_template="cdip_admin/cdip_admin/.env.example"
-    if [ ! -f "cdip_admin/.env" ]; then
-        if [ -f "${env_template}" ]; then
-            echo -e "${YELLOW}Copying ${env_template} to cdip_admin/.env${NC}"
-            cp "${env_template}" cdip_admin/.env
-        else
-            echo -e "${RED}Missing environment template: ${env_template}${NC}"
-            return 1
-        fi
-    else
-        echo -e "${YELLOW}.env file already exists, skipping copy${NC}"
+    # 1. Kong's image builds from a sibling repo; fail early with guidance if absent.
+    local kong_dir="${KONG_DIR:-../gundi-kp-dynamic-routing}"
+    if [ ! -d "${kong_dir}" ]; then
+        echo -e "${RED}Kong repo not found at ${kong_dir}.${NC}" >&2
+        echo -e "${YELLOW}Clone it (or set KONG_DIR), then re-run ./dev.sh setup:${NC}" >&2
+        echo "  git clone <gundi-kp-dynamic-routing repo> ../gundi-kp-dynamic-routing" >&2
+        return 1
     fi
 
-    # Build containers
+    # 2. Root .env (compose interpolation): ensure OIDC_SESSION_SECRET exists.
+    touch .env
+    if ! grep -q '^OIDC_SESSION_SECRET=' .env; then
+        echo -e "${YELLOW}Generating OIDC_SESSION_SECRET in .env${NC}"
+        echo "OIDC_SESSION_SECRET=$(openssl rand -base64 32)" >> .env
+    fi
+
+    # Secondary Django app env template (retained as-is; stack runs off compose env).
+    local env_template="cdip_admin/cdip_admin/.env.example"
+    if [ ! -f "cdip_admin/.env" ] && [ -f "${env_template}" ]; then
+        echo -e "${YELLOW}Copying ${env_template} to cdip_admin/.env${NC}"
+        cp "${env_template}" cdip_admin/.env
+    fi
+
+    # 3. Build (Kong builds from the verified sibling repo).
     echo -e "${GREEN}Building containers...${NC}"
     $DC build
 
-    # Start services
+    # 4. Start everything, then block until the core services are healthy.
     echo -e "${GREEN}Starting services...${NC}"
     $DC up -d
+    echo -e "${YELLOW}Waiting for services to be healthy...${NC}"
+    $DC up -d --wait postgres redis keycloak kong web caddy
 
-    # Wait for services to be ready
-    echo -e "${YELLOW}Waiting for services to be ready...${NC}"
-    sleep 10
-
-    # Run migrations
+    # 5. Migrations (also creates the GlobalAdmin / OrganizationMember groups).
     echo -e "${GREEN}Running migrations...${NC}"
-    $DC exec web python3.11 manage.py migrate
+    $DC exec -T web python3.11 manage.py migrate
 
-    # Create superuser
-    echo -e "${GREEN}Let's create a superuser...${NC}"
-    $DC exec web python3.11 manage.py createsuperuser
+    # 6. Register Kong's service/route/oidc plugin (idempotent; needs the secret above).
+    echo -e "${GREEN}Registering Kong routes...${NC}"
+    $DC run --rm kong-bootstrap
+
+    # 7. Seed the local dev admin (idempotent; matches the Keycloak dev/dev user).
+    echo -e "${GREEN}Seeding dev admin...${NC}"
+    $DC exec -T web python3.11 manage.py seed_dev_admin
 
     echo -e "${GREEN}Setup complete!${NC}"
     echo ""
-    echo "You can now access:"
-    echo "  - Django app: http://localhost:8888"
-    echo "  - Django admin: http://localhost:8888/admin"
-    echo "  - Keycloak: http://localhost:8080 (admin/admin)"
-    echo "  - Kong Admin: http://localhost:8001"
-    echo "  - Kong Manager: http://localhost:8002"
+    echo "Portal (through Caddy + Kong, with auth):"
+    echo "  https://web.127.0.0.1.nip.io   (accept the self-signed cert; log in dev / dev)"
+    echo ""
+    echo "Other endpoints:"
+    echo "  http://localhost:8888                    - Django direct (bypasses Kong/auth)"
+    echo "  https://keycloak.127.0.0.1.nip.io/auth   - Keycloak (admin / admin)"
+    echo "  http://localhost:8001                    - Kong Admin API"
 }
 
 # Main script logic

--- a/dev.sh
+++ b/dev.sh
@@ -147,7 +147,7 @@ function initial_setup() {
     touch .env
     if ! grep -q '^OIDC_SESSION_SECRET=' .env; then
         echo -e "${YELLOW}Generating OIDC_SESSION_SECRET in .env${NC}"
-        echo "OIDC_SESSION_SECRET=$(openssl rand -base64 32)" >> .env
+        echo "OIDC_SESSION_SECRET=$(openssl rand -base64 32 | tr -d '\n')" >> .env
     fi
 
     # Secondary Django app env template (retained as-is; stack runs off compose env).
@@ -155,6 +155,8 @@ function initial_setup() {
     if [ ! -f "cdip_admin/.env" ] && [ -f "${env_template}" ]; then
         echo -e "${YELLOW}Copying ${env_template} to cdip_admin/.env${NC}"
         cp "${env_template}" cdip_admin/.env
+    elif [ ! -f "cdip_admin/.env" ]; then
+        echo -e "${YELLOW}Note: ${env_template} not found; skipping cdip_admin/.env copy (stack uses compose env).${NC}"
     fi
 
     # 3. Build (Kong builds from the verified sibling repo).
@@ -163,6 +165,7 @@ function initial_setup() {
 
     # 4. Start everything, then block until the core services are healthy.
     echo -e "${GREEN}Starting services...${NC}"
+    # Start the full stack (incl. celery, kong-bootstrap); --wait below gates on the core services.
     $DC up -d
     echo -e "${YELLOW}Waiting for services to be healthy...${NC}"
     $DC up -d --wait postgres redis keycloak kong web caddy

--- a/dev.sh
+++ b/dev.sh
@@ -139,7 +139,7 @@ function initial_setup() {
     if [ ! -d "${kong_dir}" ]; then
         echo -e "${RED}Kong repo not found at ${kong_dir}.${NC}" >&2
         echo -e "${YELLOW}Clone it (or set KONG_DIR), then re-run ./dev.sh setup:${NC}" >&2
-        echo "  git clone <gundi-kp-dynamic-routing repo> ../gundi-kp-dynamic-routing" >&2
+        echo "  git clone git@github.com:PADAS/gundi-kp-dynamic-routing.git ../gundi-kp-dynamic-routing" >&2
         return 1
     fi
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -12,24 +12,27 @@ in the request path; Django trusts what Kong forwards.
 
 ## First run
 
-The kong-oidc plugin needs a base64-encoded 32-byte session secret. Generate
-one and drop it in `.env` at the worktree root (already gitignored, never
-committed):
+The Kong gateway image builds from a sibling repo. Clone it next to this one
+(or set `KONG_DIR`):
 
 ```bash
-echo "OIDC_SESSION_SECRET=$(openssl rand -base64 32)" >> .env
+git clone <gundi-kp-dynamic-routing repo> ../gundi-kp-dynamic-routing
 ```
 
-Then bring up the stack:
+Then run the one-command setup:
 
 ```bash
-./dev.sh setup     # builds, migrates, seeds the dev superuser
-./dev.sh start     # docker compose up -d
+./dev.sh setup
 ```
 
-If `OIDC_SESSION_SECRET` isn't set, the `kong-bootstrap` container exits
-immediately with a clear error (`OIDC_SESSION_SECRET is required (see
-dev/README.md)`) — that's the prompt to do the step above.
+This generates `OIDC_SESSION_SECRET` (in the root `.env`), builds, waits for the
+services to be healthy, runs migrations (which create the `GlobalAdmin` /
+`OrganizationMember` groups), registers the Kong service/route/oidc plugin, and
+seeds the local `dev` user as a Django superuser. It is idempotent — safe to
+re-run. For a clean slate, `./dev.sh clean` first.
+
+Then browse to <https://web.127.0.0.1.nip.io/> (accept Caddy's self-signed cert)
+and sign in as `dev` / `dev`.
 
 ## Opt-in services
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -16,7 +16,7 @@ The Kong gateway image builds from a sibling repo. Clone it next to this one
 (or set `KONG_DIR`):
 
 ```bash
-git clone <gundi-kp-dynamic-routing repo> ../gundi-kp-dynamic-routing
+git clone git@github.com:PADAS/gundi-kp-dynamic-routing.git ../gundi-kp-dynamic-routing
 ```
 
 Then run the one-command setup:


### PR DESCRIPTION
## What this does

Makes `./dev.sh setup` a **one-command, idempotent** local bootstrap so a fresh clone/workspace comes up with no manual steps. Pairs with `./dev.sh clean` for a fresh slate.

New `setup` flow: preflight the Kong sibling repo → generate `OIDC_SESSION_SECRET` in the root `.env` (only if missing) → build → `up -d` then `up -d --wait <core services>` (replaces `sleep 10`) → `migrate` → re-run `kong-bootstrap` → `seed_dev_admin` → print the real `https://web.127.0.0.1.nip.io` URL.

## Why

These were all manual, undocumented steps that blocked new developers (and fresh workspaces):
- `OIDC_SESSION_SECRET` had to be hand-generated, or `kong-bootstrap` exited and Kong registered no routes (app unreachable through Caddy/Kong).
- The `GlobalAdmin` / `OrganizationMember` access groups (checked by name in `core/permissions.py`) were created by hand — never in migrations, so **every** fresh DB lacked them.
- Logging in as `dev`/`dev` gave a non-privileged Django user, so the portal wasn't usable as admin.

## Changes

- **`core/migrations/0007_create_access_groups.py`** — idempotent data migration creating the `GlobalAdmin` / `OrganizationMember` groups (name-only markers, no permissions attached; historical model via `apps.get_model`; reverse is a no-op). Fixes this in **all** environments, not just local.
- **`accounts/.../seed_dev_admin.py`** — idempotent, **DEBUG-guarded** management command that makes the local `dev`/`dev@local.dev` user a Django superuser (matches the Keycloak realm user, so the normal OIDC login lands as admin). Refuses to run when `DEBUG=False`.
- **`dev.sh`** — rewritten `initial_setup()` (idempotent; health-wait instead of `sleep`); **`dev/README.md`** — simplified first-run instructions.

## Tests

- `core/tests.py`: both access groups exist after migrations.
- `accounts/tests/test_seed_dev_admin.py`: creates the superuser; idempotent; elevates an existing non-privileged dev user; **refuses when `DEBUG=False`** (asserts on the guard message, makes no DB changes).

Verified live against the dev DB: migration applied, `seed_dev_admin` ran, both groups present, `dev` is `is_superuser=is_staff=True`.

## Follow-up

`dev.sh` / `dev/README.md` use a placeholder `<gundi-kp-dynamic-routing repo>` for the Kong sibling-repo clone URL (auto-clone was intentionally out of scope). Replace with the real URL before this becomes the primary onboarding path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)