### PR TITLE
Local quickstart + dev.sh auto-generates the Kong creds placeholder

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -13,6 +13,8 @@ Keycloak (auth), Postgres, Redis, Celery, and Caddy (TLS) — with one command.
   ```
 
   Keep the two repos as siblings, or point `KONG_DIR` at wherever you cloned it.
+  (No credentials needed — `./dev.sh setup` auto-generates the placeholder
+  `application_default_credentials.json` the Kong image expects.)
 
 ## Bring it up
 
@@ -65,6 +67,9 @@ real path: browser → Caddy (TLS) → Kong (auth) → Django.
 - **`Cannot connect to the Docker daemon`** — start Docker Desktop, then re-run.
 - **`Kong repo not found at ...`** — clone `gundi-kp-dynamic-routing` as a sibling
   (see Prerequisites), or run with `KONG_DIR=/abs/path/to/gundi-kp-dynamic-routing ./dev.sh setup`.
+- **Kong build fails on `COPY application_default_credentials.json`** — a fresh
+  Kong clone lacks that gitignored file; `./dev.sh setup` generates a local
+  placeholder automatically, so just re-run setup.
 - **Browser certificate warning** at `web.127.0.0.1.nip.io` — expected; Caddy
   uses a local CA. Accept/proceed (or trust Caddy's root CA to silence it).
 - **Re-running `./dev.sh setup`** is always safe — every step is idempotent.

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,79 @@
+# Local Quickstart
+
+Bring up the full Gundi Portal stack locally — Django app, Kong gateway,
+Keycloak (auth), Postgres, Redis, Celery, and Caddy (TLS) — with one command.
+
+## Prerequisites
+
+- **Docker Desktop** running (Docker Compose v2).
+- **The Kong gateway repo cloned next to this one** (the Kong image builds from it):
+
+  ```bash
+  git clone git@github.com:PADAS/gundi-kp-dynamic-routing.git ../gundi-kp-dynamic-routing
+  ```
+
+  Keep the two repos as siblings, or point `KONG_DIR` at wherever you cloned it.
+
+## Bring it up
+
+```bash
+./dev.sh setup
+```
+
+One idempotent command. It:
+
+1. generates an `OIDC_SESSION_SECRET` (in `.env`) if missing,
+2. builds the images,
+3. starts the stack and waits for the core services to be healthy,
+4. runs migrations — which also create the `GlobalAdmin` / `OrganizationMember`
+   access groups,
+5. registers the Kong service/route + `oidc` plugin,
+6. seeds the local `dev` user as a Django superuser.
+
+Safe to re-run. For a clean slate, run `./dev.sh clean` first (drops containers
+and volumes), then `./dev.sh setup`.
+
+## Sign in
+
+Browse to **<https://web.127.0.0.1.nip.io/>** — accept Caddy's self-signed
+certificate (one-time, local CA) — and log in as **`dev` / `dev`**. That account
+is a superuser, so you land in the portal with full admin access. This is the
+real path: browser → Caddy (TLS) → Kong (auth) → Django.
+
+## Endpoints
+
+| URL | What |
+|---|---|
+| `https://web.127.0.0.1.nip.io` | Portal, through Caddy + Kong (auth) — **use this** |
+| `http://localhost:8888` | Django directly — bypasses Kong/auth, handy for debugging |
+| `https://keycloak.127.0.0.1.nip.io/auth` | Keycloak admin console (`admin` / `admin`) |
+| `http://localhost:8001` | Kong Admin API |
+
+## Everyday commands
+
+```bash
+./dev.sh start | stop | restart | status   # control the stack
+./dev.sh logs [service]                     # tail logs
+./dev.sh migrate | makemigrations           # database
+./dev.sh shell | dbshell                     # Django / psql shell
+./dev.sh test [path]                         # run tests
+./dev.sh clean                               # stop + remove containers and volumes
+```
+
+## Troubleshooting
+
+- **`Cannot connect to the Docker daemon`** — start Docker Desktop, then re-run.
+- **`Kong repo not found at ...`** — clone `gundi-kp-dynamic-routing` as a sibling
+  (see Prerequisites), or run with `KONG_DIR=/abs/path/to/gundi-kp-dynamic-routing ./dev.sh setup`.
+- **Browser certificate warning** at `web.127.0.0.1.nip.io` — expected; Caddy
+  uses a local CA. Accept/proceed (or trust Caddy's root CA to silence it).
+- **Re-running `./dev.sh setup`** is always safe — every step is idempotent.
+
+## Running tests
+
+```bash
+docker compose run --rm pytest --ds=cdip_admin.settings [path]
+```
+
+Pass `--ds=cdip_admin.settings` explicitly — `pytest.ini` points at a
+`local_settings` module that isn't present in a fresh checkout.

--- a/dev.sh
+++ b/dev.sh
@@ -143,6 +143,31 @@ function initial_setup() {
         return 1
     fi
 
+    # 1b. The Kong image COPYs a GCP service-account creds file that is gitignored
+    # in the Kong repo, so a fresh clone lacks it and the build fails. The local
+    # stack only needs a well-formed placeholder (the upstream-google-id-token
+    # plugin isn't exercised by the local OIDC route). Generate one if missing —
+    # the throwaway key is generated here at runtime, so nothing key-shaped is
+    # ever committed to this repo.
+    local kong_creds="${kong_dir}/application_default_credentials.json"
+    if [ ! -f "${kong_creds}" ]; then
+        echo -e "${YELLOW}Generating placeholder application_default_credentials.json for the Kong build${NC}"
+        local kong_key
+        kong_key=$(openssl genrsa 2048 2>/dev/null | awk '{printf "%s\\n", $0}')
+        cat > "${kong_creds}" <<EOF
+{
+  "type": "service_account",
+  "project_id": "local-dev",
+  "private_key_id": "local-dev-key-id",
+  "private_key": "${kong_key}",
+  "client_email": "local-dev@local-dev.iam.gserviceaccount.com",
+  "client_id": "000000000000000000000",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token"
+}
+EOF
+    fi
+
     # 2. Root .env (compose interpolation): ensure OIDC_SESSION_SECRET exists.
     touch .env
     if ! grep -q '^OIDC_SESSION_SECRET=' .env; then


### PR DESCRIPTION
Two related onboarding improvements so a teammate can bring up the local stack from a clean checkout with no manual fiddling.

## 1. `dev.sh` self-heals the Kong build prerequisite
The Kong image's `Dockerfile.local` does a hard `COPY application_default_credentials.json`, but that file is **gitignored** in `gundi-kp-dynamic-routing` — so a fresh clone fails the build with `"/application_default_credentials.json": not found`.

`./dev.sh setup` now generates a well-formed **placeholder** at `$KONG_DIR/application_default_credentials.json` when it's missing. Details:
- It's a synthetic service-account JSON with a throwaway RSA key generated at runtime (`openssl genrsa`) — so **nothing key-shaped is ever committed** to this repo (the `dev.sh` heredoc references a shell variable, and the generated file is gitignored in the Kong repo). The pre-commit secret scanner passes.
- A placeholder is sufficient: the local OIDC browser route never exercises the `upstream-google-id-token` plugin that would consume real GCP creds.

## 2. `QUICKSTART.md`
Concise top-level quickstart (clone the Kong sibling repo → `./dev.sh setup` → sign in at `https://web.127.0.0.1.nip.io` as `dev`/`dev`), with the endpoint table, everyday commands, and troubleshooting (Docker daemon, Kong repo, the new placeholder behavior, the cert warning).

## Verified
Reproduced the original failure with a fresh credential-less Kong clone, then ran `./dev.sh setup`: the placeholder was generated, the Kong build passed, the full stack came up healthy, and `dev`/`dev` logged in through Caddy→Kong→Keycloak with admin access (`GET /` → 200).

Builds on the setup automation merged in #439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)