### PR TITLE
Reduce DB load & latency on the v2 ingestion hot path

### DIFF
--- a/cdip_admin/api/v2/utils.py
+++ b/cdip_admin/api/v2/utils.py
@@ -112,7 +112,7 @@ def send_events_to_routing(events, gundi_ids):
                 data_provider_id=str(integration.id),
                 source_id=str(source.id),
                 external_source_id=str(source.external_id),
-                owner=str(integration.owner.id),  # Warning this can lead to the n+1 queries problem
+                owner=str(integration.owner_id),  # owner_id reads the FK value directly, no extra query
                 recorded_at=event.get("recorded_at"),  # ToDo: Convet to "2021-03-21 12:01:02-0700"
                 location=location,
                 annotations=event.get("annotations", {}),
@@ -191,7 +191,7 @@ def send_event_update_to_routing(event_trace, event_changes):
             related_to=str(event_trace.related_to),
             data_provider_id=str(integration.id),
             source_id=str(source.id if source else None),  # ToDo: Can be null?
-            external_source_id=str(source.external_id if source else None),                    owner=str(integration.owner.id),
+            external_source_id=str(source.external_id if source else None),                    owner=str(integration.owner_id),
             changes=event_changes,
         )
         # Log info for traffic anomaly detection.
@@ -342,7 +342,7 @@ def send_observations_to_routing(observations, gundi_ids):
             observation_obj = Observation(
                 gundi_id=str(gundi_id),
                 related_to=observation.get("related_to"),
-                owner=str(integration.owner.id),  # Warning this can lead to the n+1 queries problem
+                owner=str(integration.owner_id),  # owner_id reads the FK value directly, no extra query
                 data_provider_id=str(integration.id),
                 annotations=observation.get("annotations", {}),
                 source_id=str(source.id),
@@ -463,7 +463,7 @@ def send_text_messages_to_routing(text_messages, gundi_ids):
             text_message_obj = TextMessage(
                 gundi_id=str(gundi_id),
                 related_to=text_message.get("related_to"),
-                owner=str(integration.owner.id),  # Warning this can lead to the n+1 queries problem
+                owner=str(integration.owner_id),  # owner_id reads the FK value directly, no extra query
                 data_provider_id=str(integration.id),
                 source_id=str(source.id),
                 external_source_id=str(source.external_id),

--- a/cdip_admin/api/v2/utils.py
+++ b/cdip_admin/api/v2/utils.py
@@ -191,7 +191,8 @@ def send_event_update_to_routing(event_trace, event_changes):
             related_to=str(event_trace.related_to),
             data_provider_id=str(integration.id),
             source_id=str(source.id if source else None),  # ToDo: Can be null?
-            external_source_id=str(source.external_id if source else None),                    owner=str(integration.owner_id),
+            external_source_id=str(source.external_id if source else None),
+            owner=str(integration.owner_id),
             changes=event_changes,
         )
         # Log info for traffic anomaly detection.

--- a/cdip_admin/cdip_admin/auth/backends.py
+++ b/cdip_admin/cdip_admin/auth/backends.py
@@ -1,6 +1,9 @@
 import json
 import base64
+import hashlib
+from django.conf import settings
 from django.contrib.auth.backends import *
+from django.core.cache import cache
 
 from clients.models import ClientProfile
 
@@ -9,12 +12,17 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def _cache_key(prefix, value):
+    digest = hashlib.md5(str(value).encode("utf-8")).hexdigest()
+    return f"auth:{prefix}:{digest}"
+
+
 class SimpleUserInfoBackend(ModelBackend):
     def authenticate(self, request, user_info=None, **kwargs):
+        # Parsing the token is cheap and never touches the DB. A failure here
+        # means we genuinely can't identify the caller -> not authenticated.
         try:
-
             if not user_info:
-
                 if hasattr(request, "META"):
                     header = request.META.get("HTTP_X_USERINFO")
                     user_info = self.get_user_info(header=header)
@@ -23,33 +31,57 @@ class SimpleUserInfoBackend(ModelBackend):
 
             username = user_info.get("username") if user_info else None
             if not username:
-                return
+                return None
 
             email = user_info.get("email") if user_info else None
-
-            if not email or not "@" in email:
+            if not email or "@" not in email:
                 email = username if "@" in username else f"{username}@sintegrate.org"
 
             client_id = user_info.get("client_id") if user_info else None
-            if email:
-                user, created = UserModel.objects.get_or_create(
-                    email=email, defaults={"username": username}
-                )
+        except Exception:
+            logger.exception("Failure parsing user_info in remote user backend. user_info: %s", user_info)
+            return None
 
-            if client_id:
-                try:
-                    client_profile = ClientProfile.objects.get(client_id=client_id)
-                    if client_profile:
-                        request.session["client_id"] = client_id
-                except ClientProfile.DoesNotExist:
-                    pass
-        except Exception as e:
-            # Run the default password hasher once to reduce the timing
-            # difference between an existing and a nonexistent user (#20760).
-            logger.exception("Failure in remote user backend. user_info: %s", user_info)
-        else:
-            if self.user_can_authenticate(user):
+        # Identity resolution below hits the DB on every request. It is cached so
+        # the high-volume ingestion path doesn't query Postgres per request, and
+        # transient DB errors are allowed to propagate (surfaced as a retryable
+        # 5xx) rather than being swallowed into a misleading auth failure.
+        user = self._get_or_create_user(email, username)
+
+        if client_id and self._client_profile_exists(client_id):
+            request.session["client_id"] = client_id
+
+        if user is not None and self.user_can_authenticate(user):
+            return user
+        return None
+
+    def _get_or_create_user(self, email, username):
+        if not email:
+            return None
+        ttl = getattr(settings, "AUTH_IDENTITY_CACHE_TTL", 0)
+        cache_key = _cache_key("user", email) if ttl else None
+        if cache_key:
+            user = cache.get(cache_key)
+            if user is not None:
                 return user
+        user, _ = UserModel.objects.get_or_create(
+            email=email, defaults={"username": username}
+        )
+        if cache_key:
+            cache.set(cache_key, user, ttl)
+        return user
+
+    def _client_profile_exists(self, client_id):
+        ttl = getattr(settings, "AUTH_IDENTITY_CACHE_TTL", 0)
+        cache_key = _cache_key("client_profile_exists", client_id) if ttl else None
+        if cache_key:
+            exists = cache.get(cache_key)
+            if exists is not None:
+                return exists
+        exists = ClientProfile.objects.filter(client_id=client_id).exists()
+        if cache_key:
+            cache.set(cache_key, exists, ttl)
+        return exists
 
     def get_user_info(self, *, header=None):
         """

--- a/cdip_admin/cdip_admin/auth/backends.py
+++ b/cdip_admin/cdip_admin/auth/backends.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 def _cache_key(prefix, value):
-    digest = hashlib.md5(str(value).encode("utf-8")).hexdigest()
+    digest = hashlib.sha256(str(value).encode("utf-8")).hexdigest()
     return f"auth:{prefix}:{digest}"
 
 
@@ -59,7 +59,7 @@ class SimpleUserInfoBackend(ModelBackend):
         if not email:
             return None
         ttl = getattr(settings, "AUTH_IDENTITY_CACHE_TTL", 0)
-        cache_key = _cache_key("user", email) if ttl else None
+        cache_key = _cache_key("user", email) if ttl > 0 else None
         if cache_key:
             user = cache.get(cache_key)
             if user is not None:
@@ -73,7 +73,7 @@ class SimpleUserInfoBackend(ModelBackend):
 
     def _client_profile_exists(self, client_id):
         ttl = getattr(settings, "AUTH_IDENTITY_CACHE_TTL", 0)
-        cache_key = _cache_key("client_profile_exists", client_id) if ttl else None
+        cache_key = _cache_key("client_profile_exists", client_id) if ttl > 0 else None
         if cache_key:
             exists = cache.get(cache_key)
             if exists is not None:

--- a/cdip_admin/cdip_admin/auth/tests/test_backends.py
+++ b/cdip_admin/cdip_admin/auth/tests/test_backends.py
@@ -1,0 +1,61 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.db.utils import OperationalError
+from django.test import RequestFactory
+
+from cdip_admin.auth.backends import SimpleUserInfoBackend
+
+
+def _request():
+    req = RequestFactory().get("/")
+    req.session = {}
+    return req
+
+
+@pytest.mark.django_db
+def test_identity_lookup_is_cached(django_assert_num_queries):
+    """
+    Every authenticated request runs through this backend, including the
+    high-volume ingestion path. The user lookup must hit the DB only on the
+    first request for a given identity; subsequent requests are served from
+    the cache without querying Postgres.
+    """
+    User = get_user_model()
+    User.objects.create(username="svc", email="svc@example.com")
+    backend = SimpleUserInfoBackend()
+    user_info = {"username": "svc", "email": "svc@example.com"}
+
+    # First call resolves the user from the DB and populates the cache.
+    first = backend.authenticate(_request(), user_info=user_info)
+    assert first is not None and first.email == "svc@example.com"
+
+    # Second call must not touch the database for identity resolution.
+    with django_assert_num_queries(0):
+        second = backend.authenticate(_request(), user_info=user_info)
+    assert second.email == "svc@example.com"
+
+
+@pytest.mark.django_db
+def test_transient_db_error_propagates_and_is_not_masked_as_auth_failure(mocker):
+    """
+    A dropped DB connection during identity resolution must propagate (surfaced
+    as a retryable 5xx) rather than being swallowed into a silent None, which
+    the caller would render as a misleading 401/403 and clients would not retry.
+    """
+    mocker.patch.object(
+        SimpleUserInfoBackend,
+        "_get_or_create_user",
+        side_effect=OperationalError("server closed the connection unexpectedly"),
+    )
+    with pytest.raises(OperationalError):
+        SimpleUserInfoBackend().authenticate(
+            _request(), user_info={"username": "svc", "email": "svc@example.com"}
+        )
+
+
+@pytest.mark.django_db
+def test_unparseable_userinfo_is_a_normal_auth_failure():
+    """A missing/blank identity is a genuine auth failure -> None (not an error)."""
+    backend = SimpleUserInfoBackend()
+    assert backend.authenticate(_request(), user_info={}) is None
+    assert backend.authenticate(_request(), user_info={"email": "x@example.com"}) is None

--- a/cdip_admin/cdip_admin/settings.py
+++ b/cdip_admin/cdip_admin/settings.py
@@ -145,6 +145,11 @@ AUTHENTICATION_BACKENDS = {
     "cdip_admin.auth.backends.SimpleUserInfoBackend",
 }
 
+# TTL (seconds) for caching identity lookups (user + client profile) done on
+# every authenticated request by SimpleUserInfoBackend. Keeps the high-volume
+# ingestion path off the database. 0 disables the cache.
+AUTH_IDENTITY_CACHE_TTL = env.int("AUTH_IDENTITY_CACHE_TTL", 300)
+
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
@@ -199,6 +204,11 @@ DATABASES = {
         "PASSWORD": env.str("DB_PASSWORD", "cdip_dbpassword"),
         "HOST": env.str("DB_HOST", "cdip_dbhost"),
         "PORT": env.str("DB_PORT", "5432"),
+        # Reuse DB connections across requests instead of opening/closing one per
+        # request (CONN_MAX_AGE=0 default). CONN_HEALTH_CHECKS avoids handing a
+        # request a persistent connection that the server has since dropped.
+        "CONN_MAX_AGE": env.int("DB_CONN_MAX_AGE", 60),
+        "CONN_HEALTH_CHECKS": env.bool("DB_CONN_HEALTH_CHECKS", True),
         "OPTIONS": {
             "application_name": env.str("DB_APP_NAME", "portal"),
         }

--- a/cdip_admin/cdip_admin/settings.py
+++ b/cdip_admin/cdip_admin/settings.py
@@ -147,7 +147,7 @@ AUTHENTICATION_BACKENDS = {
 
 # TTL (seconds) for caching identity lookups (user + client profile) done on
 # every authenticated request by SimpleUserInfoBackend. Keeps the high-volume
-# ingestion path off the database. 0 disables the cache.
+# ingestion path off the database. 0 (or any non-positive value) disables it.
 AUTH_IDENTITY_CACHE_TTL = env.int("AUTH_IDENTITY_CACHE_TTL", 300)
 
 MIDDLEWARE = [

--- a/cdip_admin/conftest.py
+++ b/cdip_admin/conftest.py
@@ -58,6 +58,19 @@ def async_return(result):
     return f
 
 
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """
+    The default cache is a per-process LocMemCache that outlives individual
+    tests. SimpleUserInfoBackend now caches resolved users / client profiles,
+    so without this a User cached in one test (whose row is rolled back with
+    the test transaction) would be served to a later test. Clear before each.
+    """
+    from django.core.cache import cache
+    cache.clear()
+    yield
+
+
 @pytest.fixture
 def api_client():
     """


### PR DESCRIPTION
## Context

Triaged from a production admin-portal log sample. The `server closed the connection unexpectedly` errors in that sample were **not** caused by the database — Cloud SQL (`postgres-cdip-prod01`) was healthy throughout the incident window (CPU ~50–60%, memory ~43%, `up`=1, ~50–80 connections vs. a much higher limit; no restart/failover). Those drops most likely came from the proxy/pod lifecycle during a rollout.

However, the code read surfaced **real, evidence-backed inefficiencies on the ingestion hot path** that are worth fixing regardless. This PR addresses those. It does **not** claim to fix the connection-drop errors themselves.

## Changes

1. **Persistent DB connections** — `settings.py` now sets `CONN_MAX_AGE` (default 60s) and `CONN_HEALTH_CHECKS=True` (both env-overridable via `DB_CONN_MAX_AGE` / `DB_CONN_HEALTH_CHECKS`). Previously `CONN_MAX_AGE` was unset (=0), so Django opened+closed a fresh Postgres connection on every request.
2. **Cache identity lookups** — `SimpleUserInfoBackend` ran `User.get_or_create()` + `ClientProfile.get()` on **every** authenticated request (for a handful of service accounts). These are now cached (`AUTH_IDENTITY_CACHE_TTL`, default 300s), keeping the high-volume ingestion path off Postgres for identity.
3. **Transient errors no longer masquerade as auth failures** — a dropped DB connection during identity resolution used to be swallowed by a bare `except` and returned as `None` → misleading 401/403 (not retried by clients). Infra/DB errors now propagate as a retryable 5xx; token-parse failures remain a normal auth failure (`None`).
4. **N+1 fix** — `integration.owner.id` → `integration.owner_id` (4 sites in `api/v2/utils.py`), reading the FK value directly instead of loading the `Organization` row. This resolves the N+1 flagged in existing code comments.

Plus: an autouse cache-clear fixture (`conftest.py`) for test isolation now that the auth path caches, and regression tests (`auth/tests/test_backends.py`) for the caching and error-propagation behavior.

## Testing

- `cdip_admin/auth/tests/` — **6 passed** (incl. new caching + transient-error regression tests).
- `test_observations_api.py`, `test_events_api.py`, `test_attachments_api.py` — 23 passed, 1 failed.
  - The single failure, `test_create_single_event_with_provider_metadata`, is **pre-existing**: it fails identically on the untouched `release-20260630` baseline (the `provider_metadata` feature isn't fully in this branch). Unrelated to this PR; worth a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)