### PR TITLE
GUNDI-5470: Log the reason for v2 ingestion 4xx responses

### DIFF
--- a/cdip_admin/api/v2/exception_handler.py
+++ b/cdip_admin/api/v2/exception_handler.py
@@ -1,0 +1,46 @@
+import logging
+
+from rest_framework.views import exception_handler as drf_exception_handler
+
+logger = logging.getLogger(__name__)
+
+# Path prefix for the v2 ingestion/API surface. A 4xx here means a data provider
+# (connector) sent something we rejected; we log the detail so the cause is
+# diagnosable. Django's default `django.request` "Bad Request" line carries none.
+_V2_PREFIX = "/v2/"
+_MAX_DETAIL_CHARS = 2000
+
+
+def _truncate(value):
+    text = str(value)
+    if len(text) > _MAX_DETAIL_CHARS:
+        return text[:_MAX_DETAIL_CHARS] + "…(truncated)"
+    return text
+
+
+def logging_exception_handler(exc, context):
+    """DRF exception handler that additionally logs the *reason* for v2 4xx
+    responses (validation/parse errors), which the default handler swallows into
+    an opaque "Bad Request". Response behavior is unchanged."""
+    response = drf_exception_handler(exc, context)
+    if response is None:
+        return response
+
+    request = context.get("request")
+    path = getattr(request, "path", "") or ""
+    if 400 <= response.status_code < 500 and path.startswith(_V2_PREFIX):
+        logger.warning(
+            "gundi_api.v2.request_rejected:%s %s -> %s",
+            getattr(request, "method", "?"),
+            path,
+            response.status_code,
+            extra={
+                "status_code": response.status_code,
+                "path": path,
+                "integration_id": getattr(request, "integration_id", None),
+                # response.data holds the serializer/parse error detail. It is
+                # field names + messages, not the raw payload; truncated for safety.
+                "detail": _truncate(getattr(response, "data", None)),
+            },
+        )
+    return response

--- a/cdip_admin/api/v2/exception_handler.py
+++ b/cdip_admin/api/v2/exception_handler.py
@@ -9,10 +9,29 @@ logger = logging.getLogger(__name__)
 # diagnosable. Django's default `django.request` "Bad Request" line carries none.
 _V2_PREFIX = "/v2/"
 _MAX_DETAIL_CHARS = 2000
+_MAX_DETAIL_ITEMS = 20
 
 
-def _truncate(value):
-    text = str(value)
+def _summarize_detail(value):
+    """Render the error detail compactly.
+
+    Bulk endpoints (``SingleOrBulkCreateModelMixin``) return a per-item list that
+    is mostly empty ``{}`` for the valid items; a big batch would make
+    ``str(value)`` huge and pointless. Pull out just the error-bearing entries
+    (keyed by their index), capped, so we never stringify the whole batch, then
+    bound the final string length as a backstop.
+    """
+    if isinstance(value, list):
+        errors = {}
+        for index, item in enumerate(value):
+            if not item:  # valid items serialize to an empty {} — skip them
+                continue
+            errors[index] = item
+            if len(errors) >= _MAX_DETAIL_ITEMS:
+                break
+        text = str({"item_count": len(value), "errors": errors})
+    else:
+        text = str(value)
     if len(text) > _MAX_DETAIL_CHARS:
         return text[:_MAX_DETAIL_CHARS] + "…(truncated)"
     return text
@@ -39,8 +58,8 @@ def logging_exception_handler(exc, context):
                 "path": path,
                 "integration_id": getattr(request, "integration_id", None),
                 # response.data holds the serializer/parse error detail. It is
-                # field names + messages, not the raw payload; truncated for safety.
-                "detail": _truncate(getattr(response, "data", None)),
+                # field names + messages, not the raw payload; summarized+truncated.
+                "detail": _summarize_detail(getattr(response, "data", None)),
             },
         )
     return response

--- a/cdip_admin/api/v2/tests/test_exception_handler.py
+++ b/cdip_admin/api/v2/tests/test_exception_handler.py
@@ -1,0 +1,42 @@
+import logging
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+
+pytestmark = pytest.mark.django_db
+
+
+def test_rejected_observation_logs_validation_detail(
+    api_client, caplog, provider_trap_tagger, keyauth_headers_trap_tagger
+):
+    """A rejected v2 ingestion POST must log *why* (status, path, integration,
+    detail) instead of an opaque 'Bad Request' with no context."""
+    with caplog.at_level(logging.WARNING, logger="api.v2.exception_handler"):
+        response = api_client.post(
+            reverse("observations-list"),
+            data={"not": "a valid observation"},
+            format="json",
+            **keyauth_headers_trap_tagger,
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    records = [r for r in caplog.records if r.name == "api.v2.exception_handler"]
+    assert len(records) == 1, "expected exactly one rejection log line"
+    record = records[0]
+    assert "request_rejected" in record.getMessage()
+    assert record.status_code == 400
+    assert record.path == reverse("observations-list")
+    assert str(provider_trap_tagger.id) == record.integration_id
+    assert record.detail  # the serializer error detail is captured
+
+
+def test_successful_request_is_not_logged_as_rejected(caplog):
+    """The handler must only fire for 4xx responses, not successful ones."""
+    from api.v2.exception_handler import logging_exception_handler
+
+    # No exception path exercised here; a None response (nothing to handle)
+    # must be passed through untouched and produce no log line.
+    with caplog.at_level(logging.WARNING, logger="api.v2.exception_handler"):
+        assert logging_exception_handler(Exception("boom"), {"request": None}) is None
+    assert [r for r in caplog.records if r.name == "api.v2.exception_handler"] == []

--- a/cdip_admin/api/v2/tests/test_exception_handler.py
+++ b/cdip_admin/api/v2/tests/test_exception_handler.py
@@ -31,12 +31,28 @@ def test_rejected_observation_logs_validation_detail(
     assert record.detail  # the serializer error detail is captured
 
 
-def test_successful_request_is_not_logged_as_rejected(caplog):
-    """The handler must only fire for 4xx responses, not successful ones."""
+def test_unhandled_exception_passes_through_without_logging(caplog):
+    """When DRF's handler returns None (exception it doesn't turn into a response),
+    ours must pass the None through untouched and emit no log line."""
     from api.v2.exception_handler import logging_exception_handler
 
-    # No exception path exercised here; a None response (nothing to handle)
-    # must be passed through untouched and produce no log line.
     with caplog.at_level(logging.WARNING, logger="api.v2.exception_handler"):
         assert logging_exception_handler(Exception("boom"), {"request": None}) is None
     assert [r for r in caplog.records if r.name == "api.v2.exception_handler"] == []
+
+
+def test_summarize_detail_skips_valid_items_and_caps_large_batches():
+    """Bulk error detail must surface only error-bearing items (by index) without
+    stringifying the whole batch, and stay bounded."""
+    from api.v2 import exception_handler as eh
+
+    # A large batch that is valid except for two items.
+    batch = [{} for _ in range(5000)]
+    batch[3] = {"recorded_at": ["This field is required."]}
+    batch[4] = {"location": ["Invalid location."]}
+
+    summary = eh._summarize_detail(batch)
+
+    assert "5000" in summary  # item_count reported
+    assert "recorded_at" in summary and "location" in summary  # the real errors
+    assert len(summary) <= eh._MAX_DETAIL_CHARS + len("…(truncated)")

--- a/cdip_admin/cdip_admin/settings.py
+++ b/cdip_admin/cdip_admin/settings.py
@@ -127,6 +127,7 @@ REST_FRAMEWORK = {
         "rest_framework.authentication.BasicAuthentication",
     ),
     "DEFAULT_SCHEMA_CLASS": "rest_framework.schemas.coreapi.AutoSchema",
+    "EXCEPTION_HANDLER": "api.v2.exception_handler.logging_exception_handler",
     "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
     "DEFAULT_PAGINATION_CLASS": "proxy_pagination.ProxyPagination",
     'PAGE_SIZE': 20


### PR DESCRIPTION
This should cover one area where we're often left wondering what's failing for a particular push API user.

## Context

Prod (`gundi-prod` / `application` / `admin-portal`) shows a steady stream of `Bad Request: /v2/observations/` (HTTP 400) across all pods. These are DRF payload-validation rejections (`ObservationsView` has `authentication_classes = []` — auth is handled upstream by Kong — so they're unrelated to the auth/DB work in #442).

The problem: Django's default `django.request` logger records only `Bad Request: /v2/observations/` with **no detail**. The validation reason goes back to the client but is never logged server-side, so we can't tell *which field* failed or *which integration* sent the bad payload — the 400s are undiagnosable from logs.

## Change

Register a custom DRF `EXCEPTION_HANDLER` (`api/v2/exception_handler.py`) that:
- delegates to DRF's default handler (so **response behavior is unchanged**), and
- for **4xx** responses on the `/v2/` surface, logs a `WARNING` (`gundi_api.v2.request_rejected`) with the method, path, `integration_id` (resolved from Kong headers by `ApiIntegrationIdMiddleware`), and the error detail.

The logged detail is the serializer/parse error (field names + messages), **not** the raw payload, and is truncated to 2000 chars to bound log volume and avoid dumping PII.

This is an **observability** change to enable diagnosing the 400s — the actual fix (likely a specific connector sending malformed data, or a schema mismatch) comes after we can see the cause.

## Testing

`api/v2/tests/test_exception_handler.py` (new):
- a rejected observation POST returns 400 **and** emits exactly one rejection log line carrying `status_code`, `path`, `integration_id`, and `detail`;
- a non-handled exception (`None` response) passes through with no log line.

Both pass; the observations happy-path test still passes (handler is a no-op on 2xx).

## Note

Separate from the proxy-shutdown 500s seen in the same logs — those are a cloud-sql-proxy sidecar graceful-shutdown race during pod termination, fixed in the deployment manifest (not this repo), tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)