### PR TITLE
Enforce integration slug charset (^[a-z0-9_]+$) on create

### DIFF
--- a/cdip_admin/api/v2/serializers.py
+++ b/cdip_admin/api/v2/serializers.py
@@ -1,3 +1,4 @@
+import re
 import uuid
 from datetime import datetime
 from typing import Any, Iterable
@@ -326,6 +327,23 @@ class IntegrationWebhookFullSerializer(serializers.ModelSerializer):
         )
 
 
+# Integration slug charset, shared by the API and gundi-core's schemas
+# (IntegrationType/Action/Webhook `.value` all use regex="^[a-z0-9_]+$").
+# Enforced here so the API rejects slugs the client cannot parse, rather than
+# silently storing them via update_or_create (which bypasses the model
+# SlugField validators).
+SLUG_VALUE_REGEX = re.compile(r"^[a-z0-9_]+$")
+
+
+def validate_slug_value(value):
+    if not SLUG_VALUE_REGEX.match(value or ""):
+        raise serializers.ValidationError(
+            "Must contain only lowercase letters, digits, and underscores "
+            "(matching ^[a-z0-9_]+$)."
+        )
+    return value
+
+
 class IntegrationWebhookCreateUpdateSerializer(serializers.ModelSerializer):
     class Meta:
         model = IntegrationWebhook
@@ -336,6 +354,9 @@ class IntegrationWebhookCreateUpdateSerializer(serializers.ModelSerializer):
             "schema",
             "ui_schema",
         )
+
+    def validate_value(self, value):
+        return validate_slug_value(value)
 
 
 class IntegrationActionCreateUpdateSerializer(serializers.ModelSerializer):
@@ -353,6 +374,9 @@ class IntegrationActionCreateUpdateSerializer(serializers.ModelSerializer):
             "is_periodic_action",
             "crontab_schedule"
         )
+
+    def validate_value(self, value):
+        return validate_slug_value(value)
 
 
 class IntegrationTypeFullSerializer(serializers.ModelSerializer):
@@ -391,8 +415,9 @@ class IntegrationTypeIdempotentCreateSerializer(serializers.ModelSerializer):
         )
 
     def validate_value(self, value):
-        # Skip uniqueness validation for idempotent creation
-        return value
+        # Skip uniqueness validation for idempotent creation, but enforce the
+        # slug charset (matches gundi-core's IntegrationType.value regex).
+        return validate_slug_value(value)
 
     def validate(self, data):
         """

--- a/cdip_admin/api/v2/serializers.py
+++ b/cdip_admin/api/v2/serializers.py
@@ -332,11 +332,14 @@ class IntegrationWebhookFullSerializer(serializers.ModelSerializer):
 # Enforced here so the API rejects slugs the client cannot parse, rather than
 # silently storing them via update_or_create (which bypasses the model
 # SlugField validators).
-SLUG_VALUE_REGEX = re.compile(r"^[a-z0-9_]+$")
+SLUG_VALUE_REGEX = re.compile(r"[a-z0-9_]+")
 
 
 def validate_slug_value(value):
-    if not SLUG_VALUE_REGEX.match(value or ""):
+    # fullmatch, not match: `match` against a `...$` pattern would accept a
+    # trailing newline (e.g. "tech_x\n"), since Python's `$` matches just before
+    # a final \n. fullmatch requires the ENTIRE string to be the slug.
+    if not SLUG_VALUE_REGEX.fullmatch(value or ""):
         raise serializers.ValidationError(
             "Must contain only lowercase letters, digits, and underscores "
             "(matching ^[a-z0-9_]+$)."

--- a/cdip_admin/api/v2/tests/test_integrations_api.py
+++ b/cdip_admin/api/v2/tests/test_integrations_api.py
@@ -1830,14 +1830,31 @@ def _minimal_type_payload(value="tech_x", action_value="auth"):
     }
 
 
-def test_register_integration_type_rejects_invalid_type_slug(api_client, superuser):
+@pytest.mark.parametrize("bad_value", ["tech-x", "TechX", "tech x"])
+def test_register_integration_type_rejects_invalid_type_slug(
+    api_client, superuser, bad_value
+):
+    # hyphen / uppercase / space all violate ^[a-z0-9_]+$
     api_client.force_authenticate(superuser)
-    payload = _minimal_type_payload(value="tech-x")  # hyphen violates ^[a-z0-9_]+$
+    payload = _minimal_type_payload(value=bad_value)
     response = api_client.post(
         reverse("integration-types-list"), data=payload, format="json"
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
-    assert not IntegrationType.objects.filter(value="tech-x").exists()
+    assert not IntegrationType.objects.filter(value=bad_value).exists()
+
+
+def test_validate_slug_value_uses_fullmatch_rejecting_trailing_newline():
+    # Guards the fullmatch fix directly (CharField.trim_whitespace would strip a
+    # trailing newline before the serializer field validator, masking it at the
+    # endpoint level — so assert on the validator itself).
+    from rest_framework import serializers as drf_serializers
+
+    from api.v2.serializers import validate_slug_value
+
+    assert validate_slug_value("earth_ranger") == "earth_ranger"
+    with pytest.raises(drf_serializers.ValidationError):
+        validate_slug_value("tech_x\n")
 
 
 def test_register_integration_type_rejects_invalid_action_slug(api_client, superuser):

--- a/cdip_admin/api/v2/tests/test_integrations_api.py
+++ b/cdip_admin/api/v2/tests/test_integrations_api.py
@@ -1809,3 +1809,59 @@ def test_filter_integrations_by_is_used_as_provider(
         },
         expected_integrations=providers if is_used_as_provider else destinations
     )
+
+
+def _minimal_type_payload(value="tech_x", action_value="auth"):
+    return {
+        "name": "Technology X",
+        "value": value,
+        "description": "Default type for Technology X",
+        "service_url": "https://techx.example.com",
+        "actions": [
+            {
+                "type": IntegrationAction.ActionTypes.AUTHENTICATION.value,
+                "name": "Authenticate",
+                "value": action_value,
+                "description": "auth",
+                "schema": {"type": "object", "properties": {}},
+                "is_periodic_action": False,
+            }
+        ],
+    }
+
+
+def test_register_integration_type_rejects_invalid_type_slug(api_client, superuser):
+    api_client.force_authenticate(superuser)
+    payload = _minimal_type_payload(value="tech-x")  # hyphen violates ^[a-z0-9_]+$
+    response = api_client.post(
+        reverse("integration-types-list"), data=payload, format="json"
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
+    assert not IntegrationType.objects.filter(value="tech-x").exists()
+
+
+def test_register_integration_type_rejects_invalid_action_slug(api_client, superuser):
+    api_client.force_authenticate(superuser)
+    payload = _minimal_type_payload(value="tech_x", action_value="pull-data")  # hyphen
+    response = api_client.post(
+        reverse("integration-types-list"), data=payload, format="json"
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
+    assert not IntegrationType.objects.filter(value="tech_x").exists()
+
+
+def test_register_integration_type_rejects_invalid_webhook_slug(api_client, superuser):
+    api_client.force_authenticate(superuser)
+    payload = _minimal_type_payload(value="tech_x")
+    payload["register_webhook_in_kong"] = False
+    payload["webhook"] = {
+        "name": "Webhook",
+        "value": "bad-webhook",  # hyphen violates ^[a-z0-9_]+$
+        "description": "wh",
+        "schema": {"type": "object", "properties": {}},
+    }
+    response = api_client.post(
+        reverse("integration-types-list"), data=payload, format="json"
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
+    assert not IntegrationType.objects.filter(value="tech_x").exists()


### PR DESCRIPTION
## Problem

The v2 integration-type create endpoint accepts **any string** as a `value` (slug) for types, actions, and webhooks:
- `IntegrationTypeIdempotentCreateSerializer.value` is a plain `CharField` and its `validate_value` is a no-op (`return value`).
- Persistence goes through `update_or_create`, which **bypasses the model `SlugField` validators** (Django only runs those on `full_clean()`).

So malformed slugs get stored. On stage this produced types like `kenwood-radios` and `marcosIntegrationType` — values that `gundi_core`'s schema (`regex="^[a-z0-9_]+$"`) rejects, which **crashes the `gundi` CLI** (`gundi integrations types` / `--type`) with a pydantic `ValidationError`. All conforming **prod** types already match `^[a-z0-9_]+$`, so this tightens the API to the convention prod and the client already assume.

## Fix

Add a shared `validate_slug_value` enforcing `^[a-z0-9_]+$` and apply it via `validate_value` on the three create/update serializers: `IntegrationTypeIdempotentCreateSerializer`, `IntegrationActionCreateUpdateSerializer`, `IntegrationWebhookCreateUpdateSerializer`. Non-conforming slugs now return **400** at creation instead of being silently stored.

**Behavior change:** the create endpoint will now reject slugs it previously accepted (hyphens, uppercase, spaces, etc.). This is intentional — it aligns the server with `gundi_core` and the de-facto prod convention.

## Tests

`test_integrations_api.py`:
- reject invalid **type** slug (`tech-x`) → 400, not created
- reject invalid **action** slug (`pull-data`) → 400
- reject invalid **webhook** slug (`bad-webhook`) → 400
- existing valid-create tests (type + type-with-webhook) still 201 — no regression

5 targeted tests pass.

## Related

- `gundi-client` companion (defense/UX): render a clean error instead of a traceback when the API returns an unparseable slug — PADAS/gundi-client#56.
- Existing non-conforming stage test types are being cleaned up separately.
- Does **not** touch existing data — only new/updated creates are validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)