### PR TITLE
Shared dispatcher pool: default for new ER destinations + fleet migration tooling

### DIFF
--- a/.github/workflows/values/stage.yml
+++ b/.github/workflows/values/stage.yml
@@ -29,6 +29,7 @@ admin_portal:
     GS_BUCKET_NAME: "cdip-files-stage"
     BUCKET_NAME: "cdip-files-stage"
     DISPATCHER_DEFAULTS_SECRET: "er-dispatcher-defaults-stage"  # pragma: allowlist secret
+    ER_SHARED_DISPATCHER_TOPIC: "destination-earthranger-stage"
     MOVEBANK_DISPATCHER_DEFAULT_TOPIC: "destination-movebank-stage"
     DISPATCHER_DEFAULTS_SECRET_SMART: "sm-dispatcher-defaults-stage"  # pragma: allowlist secret
     DISPATCHER_DEFAULTS_SECRET_WPSWATCH: "wps-dispatcher-defaults-stage"  # pragma: allowlist secret

--- a/cdip_admin/cdip_admin/settings.py
+++ b/cdip_admin/cdip_admin/settings.py
@@ -462,6 +462,11 @@ DISPATCHER_DEFAULTS_SECRET_SMART = env.str("DISPATCHER_DEFAULTS_SECRET_SMART", "
 DISPATCHER_DEFAULTS_SECRET_WPSWATCH = env.str("DISPATCHER_DEFAULTS_SECRET_WPSWATCH", "wps-dispatcher-defaults-prod")
 DISPATCHER_DEFAULTS_SECRET_TRAPTAGGER = env.str("DISPATCHER_DEFAULTS_SECRET_TRAPTAGGER", "tt-dispatcher-defaults-prod")
 MOVEBANK_DISPATCHER_DEFAULT_TOPIC = env.str("MOVEBANK_DISPATCHER_DEFAULT_TOPIC", "movebank-dispatcher-topic-prod")
+# Shared ER dispatcher pool. When set, new EarthRanger destinations are
+# attached to this topic instead of getting a dedicated dispatcher, and the
+# `dispatchers` command's shared-pool migration verbs operate against it.
+# Empty string = feature disabled.
+ER_SHARED_DISPATCHER_TOPIC = env.str("ER_SHARED_DISPATCHER_TOPIC", default="")
 
 # Sensors API to Routing
 RAW_OBSERVATIONS_TOPIC = env.str("RAW_OBSERVATIONS_TOPIC", "raw-observations-prod")

--- a/cdip_admin/deployments/management/commands/dispatchers.py
+++ b/cdip_admin/deployments/management/commands/dispatchers.py
@@ -7,6 +7,7 @@ from deployments.utils import (
     create_dispatcher_for_integration,
     get_dispatcher_defaults_from_gcp_secrets,
     get_default_dispatcher_name,
+    subscription_is_drained,
 )
 from deployments.tasks import deploy_serverless_dispatcher
 from integrations.models import Integration, OutboundIntegrationConfiguration
@@ -599,5 +600,79 @@ class Command(BaseCommand):
             f"Rolled back {integration.name} to {pre_migration_topic}. The dormant dispatcher resumes consuming."
         ))
 
-    def teardown_migrated(self, options=None):
-        self.stderr.write("teardown_migrated: not implemented yet")
+    def teardown_migrated(self, options):
+        from datetime import timedelta
+        from django.utils import timezone
+
+        shared = settings.ER_SHARED_DISPATCHER_TOPIC
+        cooling_days = options.get("cooling_days")
+        if cooling_days is None:
+            cooling_days = SHARED_POOL_COOLING_DAYS
+        else:
+            self.stdout.write(self.style.WARNING(
+                f"Cooling period OVERRIDDEN to {cooling_days} days (default {SHARED_POOL_COOLING_DAYS})."
+            ))
+        cutoff = timezone.now() - timedelta(days=cooling_days)
+
+        qs = Integration.objects.filter(dispatcher_by_integration__isnull=False)
+        if integration_id := options.get("integration"):
+            qs = qs.filter(id=integration_id)
+        processed = 0
+        for integration in qs.order_by("name"):
+            if processed >= options["max"]:
+                break
+            if not integration.is_er_site:
+                continue
+            additional = integration.additional or {}
+            if additional.get("topic") != shared:
+                continue  # not migrated
+            deployment = integration.dispatcher_by_integration
+            stamp = additional.get("shared_pool_migrated_at")
+            if not stamp:
+                # Manually migrated before this tooling existed: start its
+                # cooling clock now instead of tearing down blind.
+                Integration.objects.filter(pk=integration.pk).update(additional={
+                    **additional, "shared_pool_migrated_at": timezone.now().isoformat(),
+                })
+                self.stdout.write(
+                    f"{integration.name}: no migration stamp; stamped now, teardown after cooling period."
+                )
+                processed += 1
+                continue
+            from datetime import datetime
+            migrated_at = datetime.fromisoformat(stamp)
+            if migrated_at > cutoff:
+                continue  # still cooling
+            # SAFETY: deleting a deployment deletes its recorded topic
+            # (deployments/tasks.py). Never delete one recording the shared topic.
+            if deployment.topic_name and deployment.topic_name == shared:
+                self.stderr.write(self.style.ERROR(
+                    f"REFUSING teardown for {integration.name}: deployment {deployment.name} records the "
+                    f"SHARED TOPIC as its own topic. Deleting it would destroy the shared pipeline. "
+                    "Fix the deployment row manually."
+                ))
+                processed += 1
+                continue
+            subscription_name = f"{deployment.name[:250]}-sub".replace("--", "-")
+            try:
+                if not subscription_is_drained(subscription_name, deployment.configuration):
+                    self.stdout.write(
+                        f"{integration.name}: old subscription {subscription_name} not drained yet; skipping."
+                    )
+                    processed += 1
+                    continue
+            except Exception as e:
+                self.stderr.write(f"{integration.name}: drain check failed ({e}); skipping.")
+                processed += 1
+                continue
+            # Detach without save signals, then delete (fires the teardown task)
+            DispatcherDeployment.objects.filter(pk=deployment.pk).update(integration=None)
+            deployment.refresh_from_db()
+            deployment.delete()
+            cleaned = {k: v for k, v in additional.items() if k not in ("pre_migration_topic", "shared_pool_migrated_at")}
+            Integration.objects.filter(pk=integration.pk).update(additional=cleaned)
+            self.stdout.write(self.style.SUCCESS(
+                f"Teardown triggered for {integration.name}'s old dispatcher {deployment.name} "
+                f"(topic {deployment.topic_name})."
+            ))
+            processed += 1

--- a/cdip_admin/deployments/management/commands/dispatchers.py
+++ b/cdip_admin/deployments/management/commands/dispatchers.py
@@ -175,15 +175,27 @@ class Command(BaseCommand):
                     source_field = "source_code_path" if type_cleaned == "earth_ranger"  else "docker_image_url"
                     source_lookup = f"{related_dispatcher_field}__configuration__deployment_settings__{source_field}"
                     source_outdated_q = ~Q(**{source_lookup: source})
-                    integrations_to_update = IntegrationModel.objects.filter(
+                    integrations_qs = IntegrationModel.objects.filter(
                         integration_type_q & source_outdated_q
-                    ).order_by("name")[:options["max"]]
+                    )
                     new_settings = {"source_code_path": source} if type_cleaned == "earth_ranger" else {"docker_image_url": source}
                 else:
-                    integrations_to_update = IntegrationModel.objects.filter(
+                    integrations_qs = IntegrationModel.objects.filter(
                         integration_type_q
-                    ).order_by("name")[:options["max"]]
+                    )
                     new_settings = None
+                if options.get("v2") and settings.ER_SHARED_DISPATCHER_TOPIC:
+                    # Redeploying (--update-source/--recreate) a migrated integration's
+                    # old function would re-derive its topic from additional.topic -
+                    # which is now the SHARED topic - attaching a zombie push
+                    # subscription to the shared root and duplicating delivery of
+                    # all shared-pool traffic. Exclude anything already on, or
+                    # migrated onto, the shared pool.
+                    shared = settings.ER_SHARED_DISPATCHER_TOPIC
+                    integrations_qs = integrations_qs.exclude(
+                        Q(additional__topic=shared) | Q(additional__has_key="shared_pool_migrated_at")
+                    )
+                integrations_to_update = integrations_qs.order_by("name")[:options["max"]]
             else:
                 self.stdout.write("Please specify an integration ID or a type")
                 return
@@ -558,6 +570,12 @@ class Command(BaseCommand):
                 additional = integration.additional or {}
                 deployment = integration.dispatcher_by_integration
                 pre_migration_topic = additional.get("topic") or deployment.topic_name
+                if not pre_migration_topic:
+                    self.stderr.write(
+                        f"Error migrating {integration.name} ({integration.id}): "
+                        "cannot determine pre-migration topic; skipping."
+                    )
+                    continue
                 updated = {
                     **additional,
                     "broker": "gcp_pubsub",
@@ -601,6 +619,17 @@ class Command(BaseCommand):
         ))
 
     def teardown_migrated(self, options):
+        """Tear down the pre-migration dispatcher for ER integrations that
+        have been on the shared pool long enough for their old push
+        subscription to be confidently drained.
+
+        ``--max`` semantics: items that consume the batch are ones where a
+        real decision got made - refused (deployment records the shared
+        topic), undrained (or the drain check errored), or freshly stamped
+        on first sight. Items that are scanned but not counted are the ones
+        skipped before any such decision: not an ER site, not migrated, or
+        still within the cooling period.
+        """
         from datetime import timedelta
         from django.utils import timezone
 
@@ -626,53 +655,55 @@ class Command(BaseCommand):
             additional = integration.additional or {}
             if additional.get("topic") != shared:
                 continue  # not migrated
-            deployment = integration.dispatcher_by_integration
-            stamp = additional.get("shared_pool_migrated_at")
-            if not stamp:
-                # Manually migrated before this tooling existed: start its
-                # cooling clock now instead of tearing down blind.
-                Integration.objects.filter(pk=integration.pk).update(additional={
-                    **additional, "shared_pool_migrated_at": timezone.now().isoformat(),
-                })
-                self.stdout.write(
-                    f"{integration.name}: no migration stamp; stamped now, teardown after cooling period."
-                )
-                processed += 1
-                continue
-            from datetime import datetime
-            migrated_at = datetime.fromisoformat(stamp)
-            if migrated_at > cutoff:
-                continue  # still cooling
-            # SAFETY: deleting a deployment deletes its recorded topic
-            # (deployments/tasks.py). Never delete one recording the shared topic.
-            if deployment.topic_name and deployment.topic_name == shared:
-                self.stderr.write(self.style.ERROR(
-                    f"REFUSING teardown for {integration.name}: deployment {deployment.name} records the "
-                    f"SHARED TOPIC as its own topic. Deleting it would destroy the shared pipeline. "
-                    "Fix the deployment row manually."
-                ))
-                processed += 1
-                continue
-            subscription_name = f"{deployment.name[:250]}-sub".replace("--", "-")
             try:
+                deployment = integration.dispatcher_by_integration
+                stamp = additional.get("shared_pool_migrated_at")
+                if not stamp:
+                    # Manually migrated before this tooling existed: start its
+                    # cooling clock now instead of tearing down blind.
+                    Integration.objects.filter(pk=integration.pk).update(additional={
+                        **additional, "shared_pool_migrated_at": timezone.now().isoformat(),
+                    })
+                    self.stdout.write(
+                        f"{integration.name}: no migration stamp; stamped now, teardown after cooling period."
+                    )
+                    processed += 1
+                    continue
+                from datetime import datetime
+                migrated_at = datetime.fromisoformat(stamp)
+                if migrated_at > cutoff:
+                    continue  # still cooling
+                # SAFETY: deleting a deployment deletes its recorded topic
+                # (deployments/tasks.py). Never delete one recording the shared
+                # topic. _require_shared_topic already guarantees `shared` is
+                # non-empty, so the equality check alone is sufficient here.
+                if deployment.topic_name == shared:
+                    self.stderr.write(self.style.ERROR(
+                        f"REFUSING teardown for {integration.name}: deployment {deployment.name} records the "
+                        f"SHARED TOPIC as its own topic. Deleting it would destroy the shared pipeline. "
+                        "Fix the deployment row manually."
+                    ))
+                    processed += 1
+                    continue
+                subscription_name = f"{deployment.name[:250]}-sub".replace("--", "-")
                 if not subscription_is_drained(subscription_name, deployment.configuration):
                     self.stdout.write(
                         f"{integration.name}: old subscription {subscription_name} not drained yet; skipping."
                     )
                     processed += 1
                     continue
+                # Detach without save signals, then delete (fires the teardown task)
+                DispatcherDeployment.objects.filter(pk=deployment.pk).update(integration=None)
+                deployment.refresh_from_db()
+                deployment.delete()
+                cleaned = {k: v for k, v in additional.items() if k not in ("pre_migration_topic", "shared_pool_migrated_at")}
+                Integration.objects.filter(pk=integration.pk).update(additional=cleaned)
+                self.stdout.write(self.style.SUCCESS(
+                    f"Teardown triggered for {integration.name}'s old dispatcher {deployment.name} "
+                    f"(topic {deployment.topic_name})."
+                ))
+                processed += 1
             except Exception as e:
-                self.stderr.write(f"{integration.name}: drain check failed ({e}); skipping.")
+                self.stderr.write(f"Error tearing down {integration.name} ({integration.id}): {e}")
                 processed += 1
                 continue
-            # Detach without save signals, then delete (fires the teardown task)
-            DispatcherDeployment.objects.filter(pk=deployment.pk).update(integration=None)
-            deployment.refresh_from_db()
-            deployment.delete()
-            cleaned = {k: v for k, v in additional.items() if k not in ("pre_migration_topic", "shared_pool_migrated_at")}
-            Integration.objects.filter(pk=integration.pk).update(additional=cleaned)
-            self.stdout.write(self.style.SUCCESS(
-                f"Teardown triggered for {integration.name}'s old dispatcher {deployment.name} "
-                f"(topic {deployment.topic_name})."
-            ))
-            processed += 1

--- a/cdip_admin/deployments/management/commands/dispatchers.py
+++ b/cdip_admin/deployments/management/commands/dispatchers.py
@@ -184,13 +184,17 @@ class Command(BaseCommand):
                         integration_type_q
                     )
                     new_settings = None
-                if options.get("v2") and settings.ER_SHARED_DISPATCHER_TOPIC:
+                if options.get("v2") and type_cleaned == "earth_ranger" and settings.ER_SHARED_DISPATCHER_TOPIC:
                     # Redeploying (--update-source/--recreate) a migrated integration's
                     # old function would re-derive its topic from additional.topic -
                     # which is now the SHARED topic - attaching a zombie push
                     # subscription to the shared root and duplicating delivery of
-                    # all shared-pool traffic. Exclude anything already on, or
-                    # migrated onto, the shared pool.
+                    # all shared-pool traffic. This hazard is ER-specific (only ER
+                    # integrations are migrated onto ER_SHARED_DISPATCHER_TOPIC), so
+                    # scope the exclusion to the earth_ranger type - otherwise a
+                    # non-ER integration whose topic happens to coincide with the
+                    # shared topic value could be filtered out incorrectly. Exclude
+                    # anything already on, or migrated onto, the shared pool.
                     shared = settings.ER_SHARED_DISPATCHER_TOPIC
                     integrations_qs = integrations_qs.exclude(
                         Q(additional__topic=shared) | Q(additional__has_key="shared_pool_migrated_at")
@@ -669,8 +673,15 @@ class Command(BaseCommand):
                     )
                     processed += 1
                     continue
-                from datetime import datetime
+                from datetime import datetime, timezone as dt_timezone
                 migrated_at = datetime.fromisoformat(stamp)
+                if timezone.is_naive(migrated_at):
+                    # Hand-edited stamps (e.g. set manually before this tooling
+                    # existed) may lack a timezone offset. Treat them as UTC
+                    # rather than skipping the integration forever, since
+                    # `cutoff` (derived from timezone.now()) is always aware
+                    # and an aware/naive comparison would raise TypeError.
+                    migrated_at = timezone.make_aware(migrated_at, dt_timezone.utc)
                 if migrated_at > cutoff:
                     continue  # still cooling
                 # SAFETY: deleting a deployment deletes its recorded topic

--- a/cdip_admin/deployments/management/commands/dispatchers.py
+++ b/cdip_admin/deployments/management/commands/dispatchers.py
@@ -526,6 +526,8 @@ class Command(BaseCommand):
         return True
 
     def _get_migratable_er_integrations(self, max_count, integration_id=None):
+        if max_count is not None and max_count <= 0:
+            return []
         shared = settings.ER_SHARED_DISPATCHER_TOPIC
         qs = Integration.objects.filter(dispatcher_by_integration__isnull=False)
         if integration_id:

--- a/cdip_admin/deployments/management/commands/dispatchers.py
+++ b/cdip_admin/deployments/management/commands/dispatchers.py
@@ -608,7 +608,7 @@ class Command(BaseCommand):
         if not Integration.objects.filter(pk=integration.pk, dispatcher_by_integration__isnull=False).exists():
             self.stderr.write(
                 f"The old dispatcher for {integration.name} no longer exists (torn down). "
-                "Rollback now requires redeploying a dedicated dispatcher (--deploy) before flipping the topic back."
+                "Recovery is manual: restore additional[\"topic\"] to the old dedicated topic first, then deploy a dedicated dispatcher (--deploy skips integrations with broker=gcp_pubsub, so adjust additional accordingly)."
             )
             return
         updated = {k: v for k, v in additional.items() if k not in ("pre_migration_topic", "shared_pool_migrated_at")}

--- a/cdip_admin/deployments/management/commands/dispatchers.py
+++ b/cdip_admin/deployments/management/commands/dispatchers.py
@@ -696,7 +696,11 @@ class Command(BaseCommand):
                     ))
                     processed += 1
                     continue
-                subscription_name = f"{deployment.name[:250]}-sub".replace("--", "-")
+                # deployment.name is nullable; deploy derives a default via
+                # get_default_dispatcher_name when it's falsy without persisting
+                # it. Mirror that here so a name-less row is still teardownable.
+                deployment_name = deployment.name or get_default_dispatcher_name(integration=integration)
+                subscription_name = f"{deployment_name[:250]}-sub".replace("--", "-")
                 if not subscription_is_drained(subscription_name, deployment.configuration):
                     self.stdout.write(
                         f"{integration.name}: old subscription {subscription_name} not drained yet; skipping."

--- a/cdip_admin/deployments/management/commands/dispatchers.py
+++ b/cdip_admin/deployments/management/commands/dispatchers.py
@@ -13,6 +13,9 @@ from integrations.models import Integration, OutboundIntegrationConfiguration
 from integrations.utils import get_dispatcher_topic_default_name
 
 
+SHARED_POOL_COOLING_DAYS = 7
+
+
 class Command(BaseCommand):
     help = "Manage serverless dispatcher deployments."
 
@@ -97,6 +100,30 @@ class Command(BaseCommand):
             type=str,
             help="Select a single integration by ID",
         )
+        parser.add_argument(
+            "--migrate-to-shared",
+            action="store_true",
+            default=False,
+            help="Move ER integrations onto the shared dispatcher pool topic (old dispatchers are kept for rollback)",
+        )
+        parser.add_argument(
+            "--rollback-shared",
+            action="store_true",
+            default=False,
+            help="Restore an integration's pre-migration topic (requires --integration; only while the old dispatcher still exists)",
+        )
+        parser.add_argument(
+            "--teardown-migrated",
+            action="store_true",
+            default=False,
+            help="Tear down old dispatchers of integrations migrated to the shared pool after the cooling period",
+        )
+        parser.add_argument(
+            "--cooling-days",
+            type=int,
+            default=None,
+            help="Override the shared-pool teardown cooling period (default 7 days). Use with care.",
+        )
 
     def handle(self, *args, **options):
 
@@ -169,6 +196,22 @@ class Command(BaseCommand):
                     integrations=integrations_to_update,
                     deployment_settings=new_settings
                 )
+        elif options["migrate_to_shared"]:
+            if not self._require_shared_topic():
+                return
+            self.migrate_to_shared(
+                self._get_migratable_er_integrations(
+                    max_count=options["max"], integration_id=options.get("integration")
+                )
+            )
+        elif options["rollback_shared"]:
+            if not self._require_shared_topic():
+                return
+            self.rollback_shared(integration_id=options.get("integration"))
+        elif options["teardown_migrated"]:
+            if not self._require_shared_topic():
+                return
+            self.teardown_migrated(options=options)
         self.stdout.write(self.style.SUCCESS("Done."))
 
     def list_deployments(self, options):
@@ -473,3 +516,63 @@ class Command(BaseCommand):
                 self.stdout.write(f"Integration {integration_id} v2 not found")
                 return None
         return integration
+
+    def _require_shared_topic(self):
+        if not settings.ER_SHARED_DISPATCHER_TOPIC:
+            self.stderr.write(
+                "ER_SHARED_DISPATCHER_TOPIC is not set - shared-pool verbs are disabled in this environment."
+            )
+            return False
+        return True
+
+    def _get_migratable_er_integrations(self, max_count, integration_id=None):
+        shared = settings.ER_SHARED_DISPATCHER_TOPIC
+        qs = Integration.objects.filter(dispatcher_by_integration__isnull=False)
+        if integration_id:
+            qs = qs.filter(id=integration_id)
+        candidates = []
+        for integration in qs.order_by("name"):
+            if not integration.is_er_site:
+                continue
+            additional = integration.additional or {}
+            if additional.get("dedicated_dispatcher"):
+                continue
+            if additional.get("topic") == shared:
+                continue  # already migrated (or manually moved); teardown handles it
+            candidates.append(integration)
+            if len(candidates) >= max_count:
+                break
+        return candidates
+
+    def migrate_to_shared(self, integrations):
+        from django.utils import timezone
+        shared = settings.ER_SHARED_DISPATCHER_TOPIC
+        self.stdout.write(self.style.SUCCESS(
+            f"Migrating {len(integrations)} ER integrations to shared topic {shared}..."
+        ))
+        for integration in integrations:
+            try:
+                additional = integration.additional or {}
+                deployment = integration.dispatcher_by_integration
+                pre_migration_topic = additional.get("topic") or deployment.topic_name
+                updated = {
+                    **additional,
+                    "broker": "gcp_pubsub",
+                    "topic": shared,
+                    "pre_migration_topic": pre_migration_topic,
+                    "shared_pool_migrated_at": timezone.now().isoformat(),
+                }
+                Integration.objects.filter(pk=integration.pk).update(additional=updated)
+                self.stdout.write(
+                    f"Migrated {integration.name} ({integration.id}) from {pre_migration_topic}. "
+                    f"Old dispatcher {deployment.name} kept for rollback."
+                )
+            except Exception as e:
+                self.stderr.write(f"Error migrating {integration.name} ({integration.id}): {e}")
+                continue
+
+    def rollback_shared(self, integration_id=None):
+        self.stderr.write("rollback_shared: not implemented yet")
+
+    def teardown_migrated(self, options=None):
+        self.stderr.write("teardown_migrated: not implemented yet")

--- a/cdip_admin/deployments/management/commands/dispatchers.py
+++ b/cdip_admin/deployments/management/commands/dispatchers.py
@@ -573,8 +573,31 @@ class Command(BaseCommand):
                 self.stderr.write(f"Error migrating {integration.name} ({integration.id}): {e}")
                 continue
 
-    def rollback_shared(self, integration_id=None):
-        self.stderr.write("rollback_shared: not implemented yet")
+    def rollback_shared(self, integration_id):
+        if not integration_id:
+            self.stderr.write("--rollback-shared requires --integration <id>")
+            return
+        integration = Integration.objects.filter(id=integration_id).first()
+        if not integration:
+            self.stderr.write(f"Integration {integration_id} not found")
+            return
+        additional = integration.additional or {}
+        pre_migration_topic = additional.get("pre_migration_topic")
+        if not pre_migration_topic:
+            self.stderr.write(f"{integration.name} has no pre_migration_topic recorded - nothing to roll back")
+            return
+        if not Integration.objects.filter(pk=integration.pk, dispatcher_by_integration__isnull=False).exists():
+            self.stderr.write(
+                f"The old dispatcher for {integration.name} no longer exists (torn down). "
+                "Rollback now requires redeploying a dedicated dispatcher (--deploy) before flipping the topic back."
+            )
+            return
+        updated = {k: v for k, v in additional.items() if k not in ("pre_migration_topic", "shared_pool_migrated_at")}
+        updated["topic"] = pre_migration_topic
+        Integration.objects.filter(pk=integration.pk).update(additional=updated)
+        self.stdout.write(self.style.SUCCESS(
+            f"Rolled back {integration.name} to {pre_migration_topic}. The dormant dispatcher resumes consuming."
+        ))
 
     def teardown_migrated(self, options=None):
         self.stderr.write("teardown_migrated: not implemented yet")

--- a/cdip_admin/deployments/tests/test_automatic_deployments.py
+++ b/cdip_admin/deployments/tests/test_automatic_deployments.py
@@ -84,3 +84,85 @@ def test_automatic_dispatcher_deployments_v2(
     assert integration.dispatcher_by_integration
     # Check that the task to trigger the dispatcher deployment was created
     mocked_deployment_task.delay.assert_called_once_with(deployment_id=integration.dispatcher_by_integration.id)
+
+
+@override_settings(GCP_ENVIRONMENT_ENABLED=True, ER_SHARED_DISPATCHER_TOPIC="root-er-test-topic")
+def test_new_er_integration_defaults_to_shared_pool(
+        mocker, organization, integration_type_er, er_action_push_positions,
+        mock_get_dispatcher_defaults_from_gcp_secrets
+):
+    mocked_deployment_task = mocker.MagicMock()
+    mocker.patch("deployments.models.deploy_serverless_dispatcher", mocked_deployment_task)
+    mocker.patch(
+        "deployments.utils.get_dispatcher_defaults_from_gcp_secrets",
+        mock_get_dispatcher_defaults_from_gcp_secrets,
+    )
+    mocker.patch("deployments.models.transaction.on_commit", lambda fn: fn())
+
+    integration = Integration.objects.create(
+        type=integration_type_er,
+        name="Shared Pool Reserve",
+        owner=organization,
+        base_url="https://sharedpool.pamdas.org",
+    )
+
+    integration.refresh_from_db()
+    assert integration.additional.get("broker") == "gcp_pubsub"
+    assert integration.additional.get("topic") == "root-er-test-topic"
+    # No dedicated dispatcher was created or deployed
+    assert not hasattr(integration, "dispatcher_by_integration") or \
+        Integration.objects.filter(pk=integration.pk, dispatcher_by_integration__isnull=True).exists()
+    mocked_deployment_task.delay.assert_not_called()
+
+
+@override_settings(GCP_ENVIRONMENT_ENABLED=True, ER_SHARED_DISPATCHER_TOPIC="root-er-test-topic")
+def test_dedicated_dispatcher_flag_preserves_old_behavior(
+        mocker, organization, integration_type_er, er_action_push_positions,
+        mock_get_dispatcher_defaults_from_gcp_secrets
+):
+    mocked_deployment_task = mocker.MagicMock()
+    mocker.patch("deployments.models.deploy_serverless_dispatcher", mocked_deployment_task)
+    mocker.patch(
+        "deployments.utils.get_dispatcher_defaults_from_gcp_secrets",
+        mock_get_dispatcher_defaults_from_gcp_secrets,
+    )
+    mocker.patch("deployments.models.transaction.on_commit", lambda fn: fn())
+
+    integration = Integration.objects.create(
+        type=integration_type_er,
+        name="Dedicated Reserve",
+        owner=organization,
+        base_url="https://dedicated.pamdas.org",
+        additional={"dedicated_dispatcher": True},
+    )
+
+    integration.refresh_from_db()
+    assert integration.additional.get("topic") != "root-er-test-topic"
+    assert Integration.objects.filter(pk=integration.pk, dispatcher_by_integration__isnull=False).exists()
+    mocked_deployment_task.delay.assert_called_once()
+
+
+@override_settings(GCP_ENVIRONMENT_ENABLED=True, ER_SHARED_DISPATCHER_TOPIC="root-er-test-topic")
+def test_non_er_sites_unaffected_by_shared_pool_setting(
+        mocker, organization, integration_type_smart, smart_action_push_events,
+        mock_get_dispatcher_defaults_from_gcp_secrets
+):
+    mocked_deployment_task = mocker.MagicMock()
+    mocker.patch("deployments.models.deploy_serverless_dispatcher", mocked_deployment_task)
+    mocker.patch(
+        "deployments.utils.get_dispatcher_defaults_from_gcp_secrets",
+        mock_get_dispatcher_defaults_from_gcp_secrets,
+    )
+    mocker.patch("deployments.models.transaction.on_commit", lambda fn: fn())
+
+    integration = Integration.objects.create(
+        type=integration_type_smart,
+        name="Smart Site",
+        owner=organization,
+        base_url="https://smart.example.org",
+    )
+
+    integration.refresh_from_db()
+    assert integration.additional.get("topic") != "root-er-test-topic"
+    assert Integration.objects.filter(pk=integration.pk, dispatcher_by_integration__isnull=False).exists()
+    mocked_deployment_task.delay.assert_called_once()

--- a/cdip_admin/deployments/tests/test_commands.py
+++ b/cdip_admin/deployments/tests/test_commands.py
@@ -706,10 +706,27 @@ def test_teardown_survives_malformed_migration_stamp(request, mocker, capsys):
     """A corrupt shared_pool_migrated_at (not ISO-parseable) must be reported
     and skipped, not crash the whole command - it should still process later
     integrations in the queryset."""
+    from datetime import timedelta
+    from django.utils import timezone
+    from deployments.models import DispatcherDeployment
+
+    # Integration with malformed timestamp
     integration, deployment = _make_er_destination_with_deployment(request, "Reserve K", topic=SHARED)
     Integration.objects.filter(pk=integration.pk).update(additional={
         **integration.additional, "shared_pool_migrated_at": "not-a-real-timestamp",
     })
+
+    # Healthy integration that should be processed normally
+    # Create with old dedicated topic first, then migrate to shared pool
+    healthy_integration, healthy_deployment = _make_er_destination_with_deployment(request, "Reserve K2", topic="old-dedicated-topic")
+    # Update to simulate being migrated to shared pool
+    Integration.objects.filter(pk=healthy_integration.pk).update(additional={
+        "broker": "gcp_pubsub",
+        "topic": SHARED,
+        "pre_migration_topic": "old-dedicated-topic",
+        "shared_pool_migrated_at": (timezone.now() - timedelta(days=8)).isoformat(),
+    })
+
     mocker.patch("deployments.management.commands.dispatchers.subscription_is_drained", return_value=True)
     mock_delete_task = mocker.patch("deployments.models.delete_serverless_dispatcher")
 
@@ -719,7 +736,10 @@ def test_teardown_survives_malformed_migration_stamp(request, mocker, capsys):
     assert f"Error tearing down {integration.name}" in (out.out + out.err)
     # Nothing was torn down; the malformed row is left alone for manual fixing
     assert DispatcherDeployment.objects.filter(pk=deployment.pk).exists()
-    mock_delete_task.delay.assert_not_called()
+
+    # Healthy integration should still be processed
+    assert not DispatcherDeployment.objects.filter(pk=healthy_deployment.pk, integration__isnull=False).exists()
+    mock_delete_task.delay.assert_called_once()
 
 
 @pytest.mark.django_db

--- a/cdip_admin/deployments/tests/test_commands.py
+++ b/cdip_admin/deployments/tests/test_commands.py
@@ -744,6 +744,36 @@ def test_teardown_survives_malformed_migration_stamp(request, mocker, capsys):
 
 @pytest.mark.django_db
 @override_settings(ER_SHARED_DISPATCHER_TOPIC=SHARED)
+def test_teardown_handles_naive_migration_stamp(request, mocker, capsys):
+    """A hand-edited shared_pool_migrated_at without a timezone offset (naive)
+    must be treated as UTC and compared normally against the (aware) cooling
+    cutoff, rather than being skipped forever with an aware/naive TypeError."""
+    from datetime import timedelta
+    from django.utils import timezone
+
+    # Deployment records a dedicated topic; the integration was migrated onto
+    # the shared pool. The migration stamp is naive (no tz offset).
+    integration, deployment = _make_er_destination_with_deployment(request, "Reserve L", topic="old-dedicated-topic")
+    naive_stamp = (timezone.now() - timedelta(days=8)).replace(tzinfo=None).isoformat()
+    Integration.objects.filter(pk=integration.pk).update(additional={
+        "broker": "gcp_pubsub",
+        "topic": SHARED,
+        "pre_migration_topic": "old-dedicated-topic",
+        "shared_pool_migrated_at": naive_stamp,
+    })
+    mocker.patch("deployments.management.commands.dispatchers.subscription_is_drained", return_value=True)
+    mock_delete_task = mocker.patch("deployments.models.delete_serverless_dispatcher")
+
+    call_command("dispatchers", "--teardown-migrated", "--max", "10")
+    out = capsys.readouterr()
+
+    assert "Error tearing down" not in (out.out + out.err)
+    assert not DispatcherDeployment.objects.filter(pk=deployment.pk, integration__isnull=False).exists()
+    mock_delete_task.delay.assert_called_once()
+
+
+@pytest.mark.django_db
+@override_settings(ER_SHARED_DISPATCHER_TOPIC=SHARED)
 def test_migrate_to_shared_skips_when_pre_migration_topic_is_falsy(request, capsys):
     """If neither additional.topic nor the deployment's recorded topic_name
     are set, we can't compute a rollback lever - migrating anyway would

--- a/cdip_admin/deployments/tests/test_commands.py
+++ b/cdip_admin/deployments/tests/test_commands.py
@@ -603,3 +603,98 @@ def test_rollback_shared_refuses_after_teardown(request, capsys):
     assert "no longer exists" in (out.out + out.err)
     integration.refresh_from_db()
     assert integration.additional["topic"] == SHARED  # unchanged
+
+
+@pytest.mark.django_db
+@override_settings(ER_SHARED_DISPATCHER_TOPIC=SHARED)
+def test_teardown_respects_cooling_period(request, mocker, capsys):
+    integration, deployment = _make_er_destination_with_deployment(request, "Reserve G")
+    call_command("dispatchers", "--migrate-to-shared", "--integration", str(integration.id), "--max", "1")
+    mock_drained = mocker.patch(
+        "deployments.management.commands.dispatchers.subscription_is_drained", return_value=True
+    )
+    mock_delete_task = mocker.patch("deployments.models.delete_serverless_dispatcher")
+
+    # Migrated seconds ago: inside the cooling period -> nothing torn down
+    call_command("dispatchers", "--teardown-migrated", "--max", "10")
+
+    assert DispatcherDeployment.objects.filter(pk=deployment.pk).exists()
+    mock_delete_task.delay.assert_not_called()
+
+    # Backdate the stamp beyond the cooling period -> teardown proceeds
+    integration.refresh_from_db()
+    from datetime import timedelta
+    from django.utils import timezone
+    old = (timezone.now() - timedelta(days=8)).isoformat()
+    integration.additional["shared_pool_migrated_at"] = old
+    Integration.objects.filter(pk=integration.pk).update(additional=integration.additional)
+
+    call_command("dispatchers", "--teardown-migrated", "--max", "10")
+
+    integration.refresh_from_db()
+    assert "shared_pool_migrated_at" not in integration.additional
+    assert mock_drained.called
+    assert not DispatcherDeployment.objects.filter(pk=deployment.pk, integration__isnull=False).exists()
+    mock_delete_task.delay.assert_called_once()  # teardown task actually fired
+
+
+@pytest.mark.django_db
+@override_settings(ER_SHARED_DISPATCHER_TOPIC=SHARED)
+def test_teardown_hard_skips_deployment_recording_shared_topic(request, mocker, capsys):
+    integration, deployment = _make_er_destination_with_deployment(request, "Reserve H", topic=SHARED)
+    # Corrupt state: deployment records the shared topic as its own
+    DispatcherDeployment.objects.filter(pk=deployment.pk).update(topic_name=SHARED)
+    from datetime import timedelta
+    from django.utils import timezone
+    Integration.objects.filter(pk=integration.pk).update(additional={
+        **integration.additional,
+        "shared_pool_migrated_at": (timezone.now() - timedelta(days=8)).isoformat(),
+    })
+    mocker.patch("deployments.management.commands.dispatchers.subscription_is_drained", return_value=True)
+    mock_delete_task = mocker.patch("deployments.models.delete_serverless_dispatcher")
+
+    call_command("dispatchers", "--teardown-migrated", "--max", "10")
+
+    out = capsys.readouterr()
+    assert "shared topic" in (out.out + out.err).lower()
+    assert DispatcherDeployment.objects.filter(pk=deployment.pk).exists()
+    mock_delete_task.delay.assert_not_called()
+
+
+@pytest.mark.django_db
+@override_settings(ER_SHARED_DISPATCHER_TOPIC=SHARED)
+def test_teardown_skips_undrained_subscription(request, mocker, capsys):
+    integration, deployment = _make_er_destination_with_deployment(request, "Reserve I")
+    call_command("dispatchers", "--migrate-to-shared", "--integration", str(integration.id), "--max", "1")
+    from datetime import timedelta
+    from django.utils import timezone
+    integration.refresh_from_db()
+    Integration.objects.filter(pk=integration.pk).update(additional={
+        **integration.additional,
+        "shared_pool_migrated_at": (timezone.now() - timedelta(days=8)).isoformat(),
+    })
+    mocker.patch(
+        "deployments.management.commands.dispatchers.subscription_is_drained", return_value=False
+    )
+    mock_delete_task = mocker.patch("deployments.models.delete_serverless_dispatcher")
+
+    call_command("dispatchers", "--teardown-migrated", "--max", "10")
+
+    assert DispatcherDeployment.objects.filter(pk=deployment.pk, integration__isnull=False).exists()
+    mock_delete_task.delay.assert_not_called()
+
+
+@pytest.mark.django_db
+@override_settings(ER_SHARED_DISPATCHER_TOPIC=SHARED)
+def test_teardown_stamps_manually_migrated_on_first_sight(request, mocker, capsys):
+    # Manually moved to the shared topic previously: no stamp yet
+    integration, deployment = _make_er_destination_with_deployment(request, "Reserve J", topic=SHARED)
+    mocker.patch("deployments.management.commands.dispatchers.subscription_is_drained", return_value=True)
+    mock_delete_task = mocker.patch("deployments.models.delete_serverless_dispatcher")
+
+    call_command("dispatchers", "--teardown-migrated", "--max", "10")
+
+    integration.refresh_from_db()
+    assert integration.additional.get("shared_pool_migrated_at")  # stamped, not torn down
+    assert DispatcherDeployment.objects.filter(pk=deployment.pk).exists()
+    mock_delete_task.delay.assert_not_called()

--- a/cdip_admin/deployments/tests/test_commands.py
+++ b/cdip_admin/deployments/tests/test_commands.py
@@ -698,3 +698,132 @@ def test_teardown_stamps_manually_migrated_on_first_sight(request, mocker, capsy
     assert integration.additional.get("shared_pool_migrated_at")  # stamped, not torn down
     assert DispatcherDeployment.objects.filter(pk=deployment.pk).exists()
     mock_delete_task.delay.assert_not_called()
+
+
+@pytest.mark.django_db
+@override_settings(ER_SHARED_DISPATCHER_TOPIC=SHARED)
+def test_teardown_survives_malformed_migration_stamp(request, mocker, capsys):
+    """A corrupt shared_pool_migrated_at (not ISO-parseable) must be reported
+    and skipped, not crash the whole command - it should still process later
+    integrations in the queryset."""
+    integration, deployment = _make_er_destination_with_deployment(request, "Reserve K", topic=SHARED)
+    Integration.objects.filter(pk=integration.pk).update(additional={
+        **integration.additional, "shared_pool_migrated_at": "not-a-real-timestamp",
+    })
+    mocker.patch("deployments.management.commands.dispatchers.subscription_is_drained", return_value=True)
+    mock_delete_task = mocker.patch("deployments.models.delete_serverless_dispatcher")
+
+    call_command("dispatchers", "--teardown-migrated", "--max", "10")
+    out = capsys.readouterr()
+
+    assert f"Error tearing down {integration.name}" in (out.out + out.err)
+    # Nothing was torn down; the malformed row is left alone for manual fixing
+    assert DispatcherDeployment.objects.filter(pk=deployment.pk).exists()
+    mock_delete_task.delay.assert_not_called()
+
+
+@pytest.mark.django_db
+@override_settings(ER_SHARED_DISPATCHER_TOPIC=SHARED)
+def test_migrate_to_shared_skips_when_pre_migration_topic_is_falsy(request, capsys):
+    """If neither additional.topic nor the deployment's recorded topic_name
+    are set, we can't compute a rollback lever - migrating anyway would
+    brick --rollback-shared. The integration must be skipped, not migrated
+    with a falsy pre_migration_topic."""
+    integration_type_er = request.getfixturevalue("integration_type_er")
+    organization = request.getfixturevalue("organization")
+    from deployments.models import DispatcherDeployment
+    integration = Integration.objects.create(
+        type=integration_type_er,
+        name="Reserve L",
+        owner=organization,
+        base_url="https://reservel.pamdas.org",
+        additional={"broker": "gcp_pubsub"},  # no "topic" key at all
+    )
+    DispatcherDeployment.objects.create(
+        name="dispatcher-reserve-l",
+        integration=integration,
+        topic_name=None,  # nothing to fall back on either
+        configuration={"env_vars": {"GCP_PROJECT_ID": "test-project"}},
+    )
+
+    call_command("dispatchers", "--migrate-to-shared", "--integration", str(integration.id), "--max", "1")
+    out = capsys.readouterr()
+
+    assert "cannot determine pre-migration topic" in (out.out + out.err)
+    integration.refresh_from_db()
+    assert "pre_migration_topic" not in integration.additional
+    assert "shared_pool_migrated_at" not in integration.additional
+    assert integration.additional.get("topic") != SHARED  # not migrated
+
+
+@pytest.mark.django_db
+@override_settings(ER_SHARED_DISPATCHER_TOPIC=SHARED)
+def test_update_source_excludes_migrated_integrations(
+    request, mocker, capsys, dispatcher_source_release_1, dispatcher_source_release_2
+):
+    """--update-source/--recreate must not select integrations already on
+    (or migrated to) the shared pool topic: redeploying their old function
+    would re-derive its topic from additional.topic - now SHARED - attaching
+    a zombie push subscription to the shared root."""
+    from deployments.models import DispatcherDeployment
+    integration_type_er = request.getfixturevalue("integration_type_er")
+    organization = request.getfixturevalue("organization")
+
+    normal = Integration.objects.create(
+        type=integration_type_er,
+        name="Normal ER Site",
+        owner=organization,
+        base_url="https://normal.pamdas.org",
+        additional={"broker": "gcp_pubsub", "topic": "destination-old-topic"},
+    )
+    DispatcherDeployment.objects.create(
+        name="dispatcher-normal",
+        integration=normal,
+        topic_name="destination-old-topic",
+        configuration={
+            "env_vars": {"GCP_PROJECT_ID": "test-project"},
+            "deployment_settings": {"source_code_path": dispatcher_source_release_1},
+        },
+    )
+
+    migrated = Integration.objects.create(
+        type=integration_type_er,
+        name="Migrated ER Site",
+        owner=organization,
+        base_url="https://migrated.pamdas.org",
+        additional={
+            "broker": "gcp_pubsub",
+            "topic": SHARED,
+            "pre_migration_topic": "destination-old-topic-2",
+            "shared_pool_migrated_at": "2024-01-01T00:00:00+00:00",
+        },
+    )
+    DispatcherDeployment.objects.create(
+        name="dispatcher-migrated",
+        integration=migrated,
+        topic_name="destination-old-topic-2",
+        configuration={
+            "env_vars": {"GCP_PROJECT_ID": "test-project"},
+            "deployment_settings": {"source_code_path": dispatcher_source_release_1},
+        },
+    )
+
+    mocker.patch("deployments.models.transaction.on_commit", lambda fn: fn())
+    mock_deploy_serverless_dispatcher = mocker.MagicMock()
+    mocker.patch(
+        "deployments.models.deploy_serverless_dispatcher", mock_deploy_serverless_dispatcher
+    )
+
+    call_command(
+        "dispatchers", "--v2", "--type", "earth_ranger", "--max", "10",
+        "--update-source", dispatcher_source_release_2,
+    )
+    captured = capsys.readouterr()
+
+    normal.refresh_from_db()
+    assert normal.dispatcher_by_integration.configuration["deployment_settings"]["source_code_path"] == dispatcher_source_release_2
+    assert f"Update triggered for {normal.name}" in captured.out
+
+    migrated.refresh_from_db()
+    assert migrated.dispatcher_by_integration.configuration["deployment_settings"]["source_code_path"] == dispatcher_source_release_1
+    assert f"Update triggered for {migrated.name}" not in captured.out

--- a/cdip_admin/deployments/tests/test_commands.py
+++ b/cdip_admin/deployments/tests/test_commands.py
@@ -244,7 +244,11 @@ def test_call_dispatchers_command_deploy_with_integration_id(
     "smart_connect",
     "wps_watch"
 ])
-@override_settings(GCP_ENVIRONMENT_ENABLED=True)
+# No @override_settings(GCP_ENVIRONMENT_ENABLED=True) here: the list fixtures
+# (instantiated mid-test via request.getfixturevalue) already set it through the
+# pytest-django settings fixture. Combining both makes the decorator's disable()
+# and the fixture's finalizer run out of order, leaking GCP_ENVIRONMENT_ENABLED=True
+# into every later test in the session.
 def test_call_dispatchers_command_update_source_by_type_with_max_v1(
     request,
     gundi_version,
@@ -364,7 +368,8 @@ def test_call_dispatchers_command_update_source_by_id_v1(
     "smart_connect",
     "wps_watch"
 ])
-@override_settings(GCP_ENVIRONMENT_ENABLED=True)
+# See note on test_call_dispatchers_command_update_source_by_type_with_max_v1
+# about why there is no GCP_ENVIRONMENT_ENABLED override here.
 def test_call_dispatchers_command_recreate_by_type_with_max_v1(
     request,
     gundi_version,
@@ -430,7 +435,8 @@ def test_call_dispatchers_command_recreate_by_type_with_max_v1(
     "wps_watch",
     "trap_tagger"
 ])
-@override_settings(GCP_ENVIRONMENT_ENABLED=True)
+# See note on test_call_dispatchers_command_update_source_by_type_with_max_v1
+# about why there is no GCP_ENVIRONMENT_ENABLED override here.
 def test_call_dispatchers_command_recreate_and_update_source_by_type_with_max_v1(
     request,
     gundi_version,
@@ -502,68 +508,67 @@ def test_call_dispatchers_command_recreate_and_update_source_by_type_with_max_v1
 SHARED = "root-er-test-topic"
 
 
+def _make_er_destination_with_deployment(request, name, topic="destination-old-topic"):
+    # Build an ER integration with a linked deployment, without triggering
+    # real deploys (GCP_ENVIRONMENT_ENABLED is False by default in tests).
+    integration_type_er = request.getfixturevalue("integration_type_er")
+    organization = request.getfixturevalue("organization")
+    from deployments.models import DispatcherDeployment
+    integration = Integration.objects.create(
+        type=integration_type_er,
+        name=name,
+        owner=organization,
+        base_url=f"https://{name.lower().replace(' ', '')}.pamdas.org",
+        additional={"broker": "gcp_pubsub", "topic": topic},
+    )
+    deployment = DispatcherDeployment.objects.create(
+        name=f"dispatcher-{name.lower().replace(' ', '-')}",
+        integration=integration,
+        topic_name=topic,
+        configuration={"env_vars": {"GCP_PROJECT_ID": "test-project"}},
+    )
+    return integration, deployment
+
+
 @pytest.mark.django_db
 @override_settings(ER_SHARED_DISPATCHER_TOPIC=SHARED)
-def test_migrate_to_shared_flips_topic_and_stamps_bookkeeping(mocker, capsys, integrations_list_er):
-    mocker.patch("deployments.models.transaction.on_commit", lambda fn: fn())
-    mocker.patch("deployments.models.deploy_serverless_dispatcher", mocker.MagicMock())
-
-    # Use the first integration from the fixture
-    integration = integrations_list_er[0]
-    old_topic = integration.additional.get("topic")
+def test_migrate_to_shared_flips_topic_and_stamps_bookkeeping(request, capsys):
+    integration, deployment = _make_er_destination_with_deployment(request, "Reserve A")
 
     call_command("dispatchers", "--migrate-to-shared", "--max", "10")
 
     integration.refresh_from_db()
     assert integration.additional["topic"] == SHARED
-    assert integration.additional["pre_migration_topic"] == old_topic
+    assert integration.additional["pre_migration_topic"] == "destination-old-topic"
     assert integration.additional["shared_pool_migrated_at"]  # ISO timestamp
-    # Deployment should still exist
-    assert integration.dispatcher_by_integration is not None
+    # Nothing deleted: the old deployment is the rollback lever
+    deployment.refresh_from_db()
+    assert deployment.integration_id == integration.id
 
 
 @pytest.mark.django_db
 @override_settings(ER_SHARED_DISPATCHER_TOPIC=SHARED)
-def test_migrate_to_shared_skips_dedicated_and_already_migrated(mocker, capsys, integrations_list_er):
-    mocker.patch("deployments.models.transaction.on_commit", lambda fn: fn())
-    mocker.patch("deployments.models.deploy_serverless_dispatcher", mocker.MagicMock())
-
-    dedicated = integrations_list_er[0]
-    migrated = integrations_list_er[1]
-
-    # Mark one as dedicated
-    Integration.objects.filter(pk=dedicated.pk).update(
-        additional={**dedicated.additional, "dedicated_dispatcher": True}
-    )
-    dedicated.refresh_from_db()
-
-    # Mark one as already migrated to shared
-    Integration.objects.filter(pk=migrated.pk).update(
-        additional={**migrated.additional, "topic": SHARED}
-    )
-    migrated.refresh_from_db()
-
-    old_topic_dedicated = dedicated.additional.get("topic")
+def test_migrate_to_shared_skips_dedicated_and_already_migrated(request, capsys):
+    dedicated, _ = _make_er_destination_with_deployment(request, "Dedicated B")
+    dedicated.additional["dedicated_dispatcher"] = True
+    dedicated.save()
+    migrated, _ = _make_er_destination_with_deployment(request, "Done C", topic=SHARED)
 
     call_command("dispatchers", "--migrate-to-shared", "--max", "10")
 
     dedicated.refresh_from_db()
-    assert dedicated.additional["topic"] == old_topic_dedicated  # not migrated
+    assert dedicated.additional["topic"] == "destination-old-topic"
     migrated.refresh_from_db()
     assert "pre_migration_topic" not in migrated.additional  # untouched
 
 
 @pytest.mark.django_db
-def test_migrate_to_shared_refuses_when_setting_empty(mocker, capsys, integrations_list_er):
-    mocker.patch("deployments.models.transaction.on_commit", lambda fn: fn())
-    mocker.patch("deployments.models.deploy_serverless_dispatcher", mocker.MagicMock())
-
-    integration = integrations_list_er[0]
-    old_topic = integration.additional.get("topic")
+def test_migrate_to_shared_refuses_when_setting_empty(request, capsys):
+    _make_er_destination_with_deployment(request, "Reserve D")
 
     call_command("dispatchers", "--migrate-to-shared", "--max", "10")
 
     out = capsys.readouterr()
     assert "ER_SHARED_DISPATCHER_TOPIC" in (out.out + out.err)
-    integration.refresh_from_db()
-    assert integration.additional["topic"] == old_topic  # unchanged
+    integration = Integration.objects.get(name="Reserve D")
+    assert integration.additional["topic"] == "destination-old-topic"

--- a/cdip_admin/deployments/tests/test_commands.py
+++ b/cdip_admin/deployments/tests/test_commands.py
@@ -3,6 +3,7 @@ from django.core.management import call_command
 from django.test import override_settings
 
 from deployments.models import DispatcherDeployment
+from integrations.models import Integration
 
 
 pytestmark = pytest.mark.django_db
@@ -496,3 +497,73 @@ def test_call_dispatchers_command_recreate_and_update_source_by_type_with_max_v1
                 force_recreate=True,
                 deployment_settings={source_key: dispatcher_source_release_2}
             )
+
+
+SHARED = "root-er-test-topic"
+
+
+@pytest.mark.django_db
+@override_settings(ER_SHARED_DISPATCHER_TOPIC=SHARED)
+def test_migrate_to_shared_flips_topic_and_stamps_bookkeeping(mocker, capsys, integrations_list_er):
+    mocker.patch("deployments.models.transaction.on_commit", lambda fn: fn())
+    mocker.patch("deployments.models.deploy_serverless_dispatcher", mocker.MagicMock())
+
+    # Use the first integration from the fixture
+    integration = integrations_list_er[0]
+    old_topic = integration.additional.get("topic")
+
+    call_command("dispatchers", "--migrate-to-shared", "--max", "10")
+
+    integration.refresh_from_db()
+    assert integration.additional["topic"] == SHARED
+    assert integration.additional["pre_migration_topic"] == old_topic
+    assert integration.additional["shared_pool_migrated_at"]  # ISO timestamp
+    # Deployment should still exist
+    assert integration.dispatcher_by_integration is not None
+
+
+@pytest.mark.django_db
+@override_settings(ER_SHARED_DISPATCHER_TOPIC=SHARED)
+def test_migrate_to_shared_skips_dedicated_and_already_migrated(mocker, capsys, integrations_list_er):
+    mocker.patch("deployments.models.transaction.on_commit", lambda fn: fn())
+    mocker.patch("deployments.models.deploy_serverless_dispatcher", mocker.MagicMock())
+
+    dedicated = integrations_list_er[0]
+    migrated = integrations_list_er[1]
+
+    # Mark one as dedicated
+    Integration.objects.filter(pk=dedicated.pk).update(
+        additional={**dedicated.additional, "dedicated_dispatcher": True}
+    )
+    dedicated.refresh_from_db()
+
+    # Mark one as already migrated to shared
+    Integration.objects.filter(pk=migrated.pk).update(
+        additional={**migrated.additional, "topic": SHARED}
+    )
+    migrated.refresh_from_db()
+
+    old_topic_dedicated = dedicated.additional.get("topic")
+
+    call_command("dispatchers", "--migrate-to-shared", "--max", "10")
+
+    dedicated.refresh_from_db()
+    assert dedicated.additional["topic"] == old_topic_dedicated  # not migrated
+    migrated.refresh_from_db()
+    assert "pre_migration_topic" not in migrated.additional  # untouched
+
+
+@pytest.mark.django_db
+def test_migrate_to_shared_refuses_when_setting_empty(mocker, capsys, integrations_list_er):
+    mocker.patch("deployments.models.transaction.on_commit", lambda fn: fn())
+    mocker.patch("deployments.models.deploy_serverless_dispatcher", mocker.MagicMock())
+
+    integration = integrations_list_er[0]
+    old_topic = integration.additional.get("topic")
+
+    call_command("dispatchers", "--migrate-to-shared", "--max", "10")
+
+    out = capsys.readouterr()
+    assert "ER_SHARED_DISPATCHER_TOPIC" in (out.out + out.err)
+    integration.refresh_from_db()
+    assert integration.additional["topic"] == old_topic  # unchanged

--- a/cdip_admin/deployments/tests/test_commands.py
+++ b/cdip_admin/deployments/tests/test_commands.py
@@ -572,3 +572,34 @@ def test_migrate_to_shared_refuses_when_setting_empty(request, capsys):
     assert "ER_SHARED_DISPATCHER_TOPIC" in (out.out + out.err)
     integration = Integration.objects.get(name="Reserve D")
     assert integration.additional["topic"] == "destination-old-topic"
+
+
+@pytest.mark.django_db
+@override_settings(ER_SHARED_DISPATCHER_TOPIC=SHARED)
+def test_rollback_shared_restores_topic(request, capsys):
+    integration, _ = _make_er_destination_with_deployment(request, "Reserve E")
+    call_command("dispatchers", "--migrate-to-shared", "--integration", str(integration.id), "--max", "1")
+
+    call_command("dispatchers", "--rollback-shared", "--integration", str(integration.id))
+
+    integration.refresh_from_db()
+    assert integration.additional["topic"] == "destination-old-topic"
+    assert "pre_migration_topic" not in integration.additional
+    assert "shared_pool_migrated_at" not in integration.additional
+
+
+@pytest.mark.django_db
+@override_settings(ER_SHARED_DISPATCHER_TOPIC=SHARED)
+def test_rollback_shared_refuses_after_teardown(request, capsys):
+    integration, deployment = _make_er_destination_with_deployment(request, "Reserve F")
+    call_command("dispatchers", "--migrate-to-shared", "--integration", str(integration.id), "--max", "1")
+    # Simulate teardown having removed the deployment
+    from deployments.models import DispatcherDeployment
+    DispatcherDeployment.objects.filter(pk=deployment.pk).delete()
+
+    call_command("dispatchers", "--rollback-shared", "--integration", str(integration.id))
+
+    out = capsys.readouterr()
+    assert "no longer exists" in (out.out + out.err)
+    integration.refresh_from_db()
+    assert integration.additional["topic"] == SHARED  # unchanged

--- a/cdip_admin/deployments/tests/test_drain_check.py
+++ b/cdip_admin/deployments/tests/test_drain_check.py
@@ -68,3 +68,23 @@ def test_subscription_is_drained_false_when_no_data_points(mocker):
     mock_monitoring_v3.MetricServiceClient.return_value = mock_client
 
     assert subscription_is_drained("some-sub", _configuration()) is False
+
+
+def test_subscription_is_drained_false_when_project_id_missing(mocker):
+    # No GCP_PROJECT_ID configured: must bail out before ever touching
+    # monitoring_v3 (no "projects/None" request), and log a warning.
+    mock_monitoring_v3 = mocker.patch("deployments.utils.monitoring_v3")
+
+    result = subscription_is_drained("some-sub", {"env_vars": {}})
+
+    assert result is False
+    mock_monitoring_v3.MetricServiceClient.assert_not_called()
+
+
+def test_subscription_is_drained_false_when_configuration_missing_env_vars(mocker):
+    mock_monitoring_v3 = mocker.patch("deployments.utils.monitoring_v3")
+
+    result = subscription_is_drained("some-sub", {})
+
+    assert result is False
+    mock_monitoring_v3.MetricServiceClient.assert_not_called()

--- a/cdip_admin/deployments/tests/test_drain_check.py
+++ b/cdip_admin/deployments/tests/test_drain_check.py
@@ -1,0 +1,70 @@
+"""Unit tests for deployments.utils.subscription_is_drained.
+
+Portal subscriptions are push subscriptions, so a subscriber-side pull can
+never succeed against them (Pub/Sub returns FAILED_PRECONDITION). These tests
+cover the Cloud Monitoring based replacement: it reads the
+``pubsub.googleapis.com/subscription/num_undelivered_messages`` metric and
+looks at the most recent data point across whatever time series come back.
+
+The ``google.cloud.monitoring_v3`` module is mocked at the point it's
+imported into ``deployments.utils`` (``deployments.utils.monitoring_v3``), not
+in the real client library, so these tests never make a network call.
+"""
+from unittest.mock import MagicMock
+
+from deployments.utils import subscription_is_drained
+
+
+def _make_point(end_seconds, value):
+    point = MagicMock()
+    point.interval.end_time.seconds = end_seconds
+    point.value.int64_value = value
+    return point
+
+
+def _make_series(*points):
+    series = MagicMock()
+    series.points = list(points)
+    return series
+
+
+def _configuration():
+    return {"env_vars": {"GCP_PROJECT_ID": "test-project"}}
+
+
+def _mock_client():
+    client = MagicMock()
+    client.__enter__.return_value = client
+    client.__exit__.return_value = False
+    return client
+
+
+def test_subscription_is_drained_true_when_latest_point_is_zero(mocker):
+    mock_client = _mock_client()
+    mock_client.list_time_series.return_value = [
+        _make_series(_make_point(end_seconds=100, value=5), _make_point(end_seconds=200, value=0)),
+    ]
+    mock_monitoring_v3 = mocker.patch("deployments.utils.monitoring_v3")
+    mock_monitoring_v3.MetricServiceClient.return_value = mock_client
+
+    assert subscription_is_drained("some-sub", _configuration()) is True
+
+
+def test_subscription_is_drained_false_when_latest_point_is_nonzero(mocker):
+    mock_client = _mock_client()
+    mock_client.list_time_series.return_value = [
+        _make_series(_make_point(end_seconds=100, value=0), _make_point(end_seconds=200, value=5)),
+    ]
+    mock_monitoring_v3 = mocker.patch("deployments.utils.monitoring_v3")
+    mock_monitoring_v3.MetricServiceClient.return_value = mock_client
+
+    assert subscription_is_drained("some-sub", _configuration()) is False
+
+
+def test_subscription_is_drained_false_when_no_data_points(mocker):
+    mock_client = _mock_client()
+    mock_client.list_time_series.return_value = []  # empty series -> no data points at all
+    mock_monitoring_v3 = mocker.patch("deployments.utils.monitoring_v3")
+    mock_monitoring_v3.MetricServiceClient.return_value = mock_client
+
+    assert subscription_is_drained("some-sub", _configuration()) is False

--- a/cdip_admin/deployments/utils.py
+++ b/cdip_admin/deployments/utils.py
@@ -367,20 +367,36 @@ def subscription_is_drained(subscription_name, configuration):
     """
     env_vars = (configuration or {}).get("env_vars", {})
     project_id = env_vars.get("GCP_PROJECT_ID")
+    if not project_id:
+        logger.warning(
+            f"No GCP_PROJECT_ID configured for subscription {subscription_name}; "
+            "can't verify the backlog is drained, treating as NOT drained."
+        )
+        return False
     project_name = f"projects/{project_id}"
     metric_filter = (
         'metric.type = "pubsub.googleapis.com/subscription/num_undelivered_messages" '
         f'AND resource.labels.subscription_id = "{subscription_name}"'
     )
 
+    # Build a 10-minute [start_time, end_time) window. end_time is anchored to
+    # "now" (seconds + sub-second nanos); start_time is exactly
+    # _DRAIN_CHECK_LOOKBACK_SECONDS earlier, reusing end_time's nanos so the
+    # window is exactly that many seconds wide (not off by a sub-second
+    # rounding artifact from computing each boundary independently).
     now = time.time()
-    interval = monitoring_v3.TimeInterval()
-    interval.end_time.seconds = int(now)
-    interval.end_time.nanos = int((now - interval.end_time.seconds) * 10 ** 9)
-    interval.start_time.seconds = int(now - _DRAIN_CHECK_LOOKBACK_SECONDS)
-    interval.start_time.nanos = interval.end_time.nanos
+    end_seconds = int(now)
+    end_nanos = int((now - end_seconds) * 10 ** 9)
+    start_seconds = end_seconds - _DRAIN_CHECK_LOOKBACK_SECONDS
+    start_nanos = end_nanos
 
-    latest_end_seconds = None
+    interval = monitoring_v3.TimeInterval()
+    interval.end_time.seconds = end_seconds
+    interval.end_time.nanos = end_nanos
+    interval.start_time.seconds = start_seconds
+    interval.start_time.nanos = start_nanos
+
+    latest_end = None  # (seconds, nanos) of the most recent point seen so far
     latest_value = None
     with monitoring_v3.MetricServiceClient() as client:
         results = client.list_time_series(
@@ -393,9 +409,9 @@ def subscription_is_drained(subscription_name, configuration):
         )
         for series in results:
             for point in series.points:
-                end_seconds = point.interval.end_time.seconds
-                if latest_end_seconds is None or end_seconds > latest_end_seconds:
-                    latest_end_seconds = end_seconds
+                end_key = (point.interval.end_time.seconds, point.interval.end_time.nanos)
+                if latest_end is None or end_key > latest_end:
+                    latest_end = end_key
                     latest_value = point.value.int64_value
 
     if latest_value is None:

--- a/cdip_admin/deployments/utils.py
+++ b/cdip_admin/deployments/utils.py
@@ -360,6 +360,8 @@ def subscription_is_drained(subscription_name, configuration):
     the backlog is empty, so this conservatively returns False (don't tear
     down what we can't confirm is drained) and logs why.
 
+    A subscription deleted out-of-band produces no metric data and therefore reads as not-drained forever; reclaiming such a deployment requires manual cleanup.
+
     Requires the caller's credentials to have the ``monitoring.timeSeries.list``
     IAM permission on the project.
     """

--- a/cdip_admin/deployments/utils.py
+++ b/cdip_admin/deployments/utils.py
@@ -1,8 +1,9 @@
 import logging
 import json
+import time
 from urllib.parse import urlparse
 from google.api_core import exceptions as gcp_exceptions
-from google.cloud import secretmanager, pubsub_v1
+from google.cloud import secretmanager, monitoring_v3
 from django.conf import settings
 from core.utils import generate_short_id_milliseconds
 
@@ -340,26 +341,66 @@ def create_dispatcher_for_integration(integration):
     )
 
 
-def subscription_is_drained(subscription_name, configuration):
-    """Best-effort check that a push subscription has no deliverable backlog.
+_DRAIN_CHECK_LOOKBACK_SECONDS = 600  # 10 minutes
 
-    Peeks with a non-blocking pull: an empty response after the function has
-    been dormant for the cooling period is treated as drained. Any message
-    seen is released immediately (ack deadline 0) and the subscription is
-    treated as NOT drained.
+
+def subscription_is_drained(subscription_name, configuration):
+    """Check whether a push subscription's backlog is empty.
+
+    Portal subscriptions are push subscriptions, not pull: Pub/Sub rejects a
+    ``pull`` request against a push subscription with FAILED_PRECONDITION, so
+    a subscriber-side "peek" can never succeed here (an earlier version of
+    this helper tried exactly that and could never return True). Instead,
+    this reads the Cloud Monitoring
+    ``pubsub.googleapis.com/subscription/num_undelivered_messages`` metric
+    for the subscription over the last 10 minutes and looks at the most
+    recent data point: the subscription is drained iff that value is 0.
+
+    If no data points are returned in the lookback window, we can't verify
+    the backlog is empty, so this conservatively returns False (don't tear
+    down what we can't confirm is drained) and logs why.
+
+    Requires the caller's credentials to have the ``monitoring.timeSeries.list``
+    IAM permission on the project.
     """
     env_vars = (configuration or {}).get("env_vars", {})
     project_id = env_vars.get("GCP_PROJECT_ID")
-    subscriber = pubsub_v1.SubscriberClient()
-    subscription_path = subscriber.subscription_path(project_id, subscription_name)
-    response = subscriber.pull(
-        request={"subscription": subscription_path, "max_messages": 1},
-        timeout=10,
+    project_name = f"projects/{project_id}"
+    metric_filter = (
+        'metric.type = "pubsub.googleapis.com/subscription/num_undelivered_messages" '
+        f'AND resource.labels.subscription_id = "{subscription_name}"'
     )
-    if not response.received_messages:
-        return True
-    ack_ids = [m.ack_id for m in response.received_messages]
-    subscriber.modify_ack_deadline(
-        request={"subscription": subscription_path, "ack_ids": ack_ids, "ack_deadline_seconds": 0}
-    )
-    return False
+
+    now = time.time()
+    interval = monitoring_v3.TimeInterval()
+    interval.end_time.seconds = int(now)
+    interval.end_time.nanos = int((now - interval.end_time.seconds) * 10 ** 9)
+    interval.start_time.seconds = int(now - _DRAIN_CHECK_LOOKBACK_SECONDS)
+    interval.start_time.nanos = interval.end_time.nanos
+
+    latest_end_seconds = None
+    latest_value = None
+    with monitoring_v3.MetricServiceClient() as client:
+        results = client.list_time_series(
+            request={
+                "name": project_name,
+                "filter": metric_filter,
+                "interval": interval,
+                "view": monitoring_v3.ListTimeSeriesRequest.TimeSeriesView.FULL,
+            }
+        )
+        for series in results:
+            for point in series.points:
+                end_seconds = point.interval.end_time.seconds
+                if latest_end_seconds is None or end_seconds > latest_end_seconds:
+                    latest_end_seconds = end_seconds
+                    latest_value = point.value.int64_value
+
+    if latest_value is None:
+        logger.warning(
+            f"No Monitoring data points for num_undelivered_messages on subscription "
+            f"{subscription_name} in the last {_DRAIN_CHECK_LOOKBACK_SECONDS}s; can't verify "
+            "the backlog is drained, treating as NOT drained."
+        )
+        return False
+    return latest_value == 0

--- a/cdip_admin/deployments/utils.py
+++ b/cdip_admin/deployments/utils.py
@@ -2,7 +2,7 @@ import logging
 import json
 from urllib.parse import urlparse
 from google.api_core import exceptions as gcp_exceptions
-from google.cloud import secretmanager
+from google.cloud import secretmanager, pubsub_v1
 from django.conf import settings
 from core.utils import generate_short_id_milliseconds
 
@@ -338,3 +338,28 @@ def create_dispatcher_for_integration(integration):
             secret_id=_dispatcher_secret_id_for(integration)
         ),
     )
+
+
+def subscription_is_drained(subscription_name, configuration):
+    """Best-effort check that a push subscription has no deliverable backlog.
+
+    Peeks with a non-blocking pull: an empty response after the function has
+    been dormant for the cooling period is treated as drained. Any message
+    seen is released immediately (ack deadline 0) and the subscription is
+    treated as NOT drained.
+    """
+    env_vars = (configuration or {}).get("env_vars", {})
+    project_id = env_vars.get("GCP_PROJECT_ID")
+    subscriber = pubsub_v1.SubscriberClient()
+    subscription_path = subscriber.subscription_path(project_id, subscription_name)
+    response = subscriber.pull(
+        request={"subscription": subscription_path, "max_messages": 1},
+        timeout=10,
+    )
+    if not response.received_messages:
+        return True
+    ack_ids = [m.ack_id for m in response.received_messages]
+    subscriber.modify_ack_deadline(
+        request={"subscription": subscription_path, "ack_ids": ack_ids, "ack_deadline_seconds": 0}
+    )
+    return False

--- a/cdip_admin/integrations/models/v2/models.py
+++ b/cdip_admin/integrations/models/v2/models.py
@@ -282,7 +282,24 @@ class Integration(ChangeLogMixin, UUIDAbstractModel, TimestampedModel):
             if settings.GCP_ENVIRONMENT_ENABLED and any(
                     [self.is_er_site, self.is_smart_site, self.is_wpswatch_site, self.is_traptagger_site]
             ):
-                create_dispatcher_for_integration(self)
+                if (
+                    self.is_er_site
+                    and settings.ER_SHARED_DISPATCHER_TOPIC
+                    and not (self.additional or {}).get("dedicated_dispatcher")
+                ):
+                    # New ER destinations attach to the shared dispatcher pool
+                    # by default; a dedicated dispatcher is an explicit opt-in
+                    # via additional["dedicated_dispatcher"]. Signal-safe write:
+                    # a plain save() here would recurse through _post_save.
+                    updated_additional = {
+                        **(self.additional or {}),
+                        "broker": "gcp_pubsub",
+                        "topic": settings.ER_SHARED_DISPATCHER_TOPIC,
+                    }
+                    Integration.objects.filter(pk=self.pk).update(additional=updated_additional)
+                    self.additional = updated_additional
+                else:
+                    create_dispatcher_for_integration(self)
 
             # Create default healthcheck settings and status
             IntegrationStatus.objects.get_or_create(integration=self)

--- a/dependencies/requirements.in
+++ b/dependencies/requirements.in
@@ -68,6 +68,7 @@ gundi-core==1.12.0
 gundi-client==1.1.0
 gundi-client-v2==2.4.1
 google-cloud-functions==1.13.1
+google-cloud-monitoring==2.31.0
 google-cloud-run==0.10.1
 google-cloud-eventarc==1.10.0
 google-cloud-secret-manager==2.16.4

--- a/dependencies/requirements.txt
+++ b/dependencies/requirements.txt
@@ -188,6 +188,7 @@ google-api-core==2.25.1
     #   google-cloud-core
     #   google-cloud-eventarc
     #   google-cloud-functions
+    #   google-cloud-monitoring
     #   google-cloud-pubsub
     #   google-cloud-run
     #   google-cloud-secret-manager
@@ -197,6 +198,7 @@ google-auth==2.40.3
     # via
     #   google-api-core
     #   google-cloud-core
+    #   google-cloud-monitoring
     #   google-cloud-pubsub
     #   google-cloud-storage
     #   google-cloud-trace
@@ -205,6 +207,8 @@ google-cloud-core==2.4.3
 google-cloud-eventarc==1.10.0
     # via -r requirements.in
 google-cloud-functions==1.13.1
+    # via -r requirements.in
+google-cloud-monitoring==2.31.0
     # via -r requirements.in
 google-cloud-pubsub==2.25.0
     # via cdip-connector
@@ -240,6 +244,7 @@ grpc-google-iam-v1==0.14.2
 grpcio==1.75.0
     # via
     #   google-api-core
+    #   google-cloud-monitoring
     #   google-cloud-pubsub
     #   googleapis-common-protos
     #   grpc-google-iam-v1
@@ -375,6 +380,7 @@ proto-plus==1.26.1
     #   google-api-core
     #   google-cloud-eventarc
     #   google-cloud-functions
+    #   google-cloud-monitoring
     #   google-cloud-pubsub
     #   google-cloud-run
     #   google-cloud-secret-manager
@@ -384,6 +390,7 @@ protobuf==4.25.8
     #   google-api-core
     #   google-cloud-eventarc
     #   google-cloud-functions
+    #   google-cloud-monitoring
     #   google-cloud-pubsub
     #   google-cloud-run
     #   google-cloud-secret-manager


### PR DESCRIPTION
## Summary

Implements the shared-pool migration design (spec/plan in `gundi-dispatcher-er/docs/superpowers/`): all EarthRanger destinations move to a single shared dispatcher deployment, and dedicated dispatchers become an explicit opt-in special case.

- **`ER_SHARED_DISPATCHER_TOPIC` setting** — single source of truth; empty (default) disables everything (standardized names: `destination-earthranger-{env}`; this PR sets the **stage** value in `.github/workflows/values/stage.yml`, prod follows after the stage validation cycle and the legacy-topic cutover documented in the spec).
- **New ER destinations default to the shared pool**: `Integration._post_save` assigns the shared topic (signal-safe `.update()`) and creates no deployment; `additional["dedicated_dispatcher"]=true` opts back into a dedicated function. SMART/WPSWatch/TrapTagger/v1 unchanged.
- **`dispatchers --migrate-to-shared [--max N]`** — batched topic flip with rollback bookkeeping (`pre_migration_topic`, `shared_pool_migrated_at`); the old function keeps running as the rollback lever; refuses when the setting is unset; skips dedicated/already-migrated; never stores an undeterminable pre-migration topic.
- **`dispatchers --rollback-shared --integration <id>`** — restores the old topic while the dormant dispatcher exists; manual-recovery guidance after teardown.
- **`dispatchers --teardown-migrated [--cooling-days N]`** — after a 7-day cooling period (override logged loudly): hard refusal for any deployment recording the shared topic (deployment deletion deletes its topic), a Cloud Monitoring `num_undelivered_messages` drain check (pull is rejected on push subscriptions — caught in review), stamp-on-first-sight for previously hand-migrated integrations, FK-detach → delete → bookkeeping cleanup, per-item error envelope.
- **Guard**: `--update-source`/`--recreate` (v2) now exclude migrated integrations — redeploying one would attach a zombie push subscription to the shared root topic (duplicate delivery of all traffic).

## Review trail

Executed task-by-task with independent reviews; the final whole-branch review caught a Critical plan defect (pull-based drain check can never succeed on push subscriptions) that was fixed with the Monitoring API before merge. Two pre-existing test bugs fixed along the way (session-wide `override_settings` pollution in three tests).

## Follow-ups (non-blocking)

- Grant `monitoring.timeSeries.list` to the portal service account in each environment before running `--teardown-migrated`.
- `google-cloud-monitoring==2.31.0` was pinned by hand in the compiled requirements; run a real dependency compile before the next release.
- Rollout per the spec: set the setting in stage → full migrate/verify/teardown cycle there (compressed `--cooling-days`) → set in prod → batches.

## Testing

`deployments/` package + health-calc suite: 96 passed, 1 pre-existing skip. New coverage: shared-pool default/dedicated flag/non-ER isolation; migrate bookkeeping/skips/refusal; rollback round-trip + post-teardown refusal; teardown cooling gate, shared-topic refusal, undrained skip, stamp-on-first-sight, malformed-stamp continuation; drain-check unit tests; update-source exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112VwWNyti6VJbbKH7CrSDn