### PR TITLE
GUNDI-5550: harden PubSub event consumers against DB connection loss

### DIFF
--- a/cdip_admin/event_consumers/db_utils.py
+++ b/cdip_admin/event_consumers/db_utils.py
@@ -1,0 +1,13 @@
+from django.db import connections
+
+
+def refresh_db_connections():
+    """
+    Close errored or expired DB connections so the next ORM call opens a
+    fresh one. Equivalent to django.db.close_old_connections(), except it
+    skips connections inside an atomic block — closing mid-transaction would
+    break the transaction (pytest-django runs every test inside one).
+    """
+    for conn in connections.all(initialized_only=True):
+        if not conn.in_atomic_block:
+            conn.close_if_unusable_or_obsolete()

--- a/cdip_admin/event_consumers/dispatcher_events_consumer.py
+++ b/cdip_admin/event_consumers/dispatcher_events_consumer.py
@@ -6,6 +6,8 @@ logging_settings.init()
 django.setup()  # To use the django ORM
 from google.cloud import pubsub_v1
 from django.conf import settings
+from django.db import InterfaceError, OperationalError
+from event_consumers.db_utils import refresh_db_connections
 from gundi_core import events as system_events
 from integrations.models import GundiTrace, Integration
 from activity_log.models import ActivityLog
@@ -401,9 +403,18 @@ event_handlers = {
 
 
 def process_event(message: pubsub_v1.subscriber.message.Message) -> None:
+    logger.info(f"Received Dispatcher Event {message}.")
+    # Long-running non-request process: Django's per-request connection
+    # cleanup never runs here, so drop dead/expired connections ourselves
+    # before touching the ORM (GUNDI-5550).
+    refresh_db_connections()
     try:
-        logger.info(f"Received Dispatcher Event {message}.")
         event_dict = json.loads(message.data)
+    except (ValueError, UnicodeDecodeError):
+        logger.exception("Invalid JSON in Dispatcher Event message. Message discarded.")
+        message.ack()
+        return
+    try:
         logger.debug(f"Event Details", extra={"event": event_dict})
         event_type = event_dict.get("event_type")
         schema_version = event_dict.get("schema_version")
@@ -417,11 +428,20 @@ def process_event(message: pubsub_v1.subscriber.message.Message) -> None:
             message.ack()
             return
         event_handler(event_dict=event_dict)
+    except (InterfaceError, OperationalError) as e:
+        # Transient DB failure (e.g. "connection already closed"): drop the
+        # stale connection and nack so PubSub redelivers instead of losing
+        # the event and its activity log record.
+        logger.exception(f"Error Processing Dispatcher Event: {e}", extra={"event": event_dict})
+        refresh_db_connections()
+        message.nack()
     except Exception as e:
-        logger.exception(f"Error Processing Dispatcher Event: {e}", extra={"event": json.loads(message.data)})
+        # Treated as permanent for this message. Ack to avoid a poison-message
+        # redelivery loop — the subscription has no dead-letter topic yet.
+        logger.exception(f"Error Processing Dispatcher Event: {e}", extra={"event": event_dict})
+        message.ack()
     else:
         logger.info(f"Dispatcher Event Processed successfully.")
-    finally:
         message.ack()
 
 

--- a/cdip_admin/event_consumers/integration_events_consumer.py
+++ b/cdip_admin/event_consumers/integration_events_consumer.py
@@ -7,6 +7,8 @@ logging_settings.init()
 django.setup()  # To use the django ORM
 from google.cloud import pubsub_v1
 from django.conf import settings
+from django.db import InterfaceError, OperationalError
+from event_consumers.db_utils import refresh_db_connections
 from gundi_core import events as system_events
 from integrations.models import GundiTrace, Integration
 from activity_log.models import ActivityLog
@@ -191,9 +193,18 @@ event_handlers = {
 
 
 def process_event(message: pubsub_v1.subscriber.message.Message) -> None:
+    logger.info(f"Received Integration Event {message}.")
+    # Long-running non-request process: Django's per-request connection
+    # cleanup never runs here, so drop dead/expired connections ourselves
+    # before touching the ORM (GUNDI-5550).
+    refresh_db_connections()
     try:
-        logger.info(f"Received Integration Event {message}.")
         event_dict = json.loads(message.data)
+    except (ValueError, UnicodeDecodeError):
+        logger.exception("Invalid JSON in Integration Event message. Message discarded.")
+        message.ack()
+        return
+    try:
         logger.debug(f"Event Details", extra={"event": event_dict})
         event_type = event_dict.get("event_type")
         schema_version = event_dict.get("schema_version")
@@ -209,14 +220,26 @@ def process_event(message: pubsub_v1.subscriber.message.Message) -> None:
             message.ack()
             return
         event_handler(event_dict=event_dict)
-    except Exception as e:
+    except (InterfaceError, OperationalError) as e:
+        # Transient DB failure (e.g. "connection already closed"): drop the
+        # stale connection and nack so PubSub redelivers instead of losing
+        # the event and its activity log record.
         logger.exception(
             f"Error Processing Integration Event: {e}",
-            extra={"event": json.loads(message.data)},
+            extra={"event": event_dict},
         )
+        refresh_db_connections()
+        message.nack()
+    except Exception as e:
+        # Treated as permanent for this message. Ack to avoid a poison-message
+        # redelivery loop — the subscription has no dead-letter topic yet.
+        logger.exception(
+            f"Error Processing Integration Event: {e}",
+            extra={"event": event_dict},
+        )
+        message.ack()
     else:
         logger.info(f"Integration Event Processed successfully.")
-    finally:
         message.ack()
 
 

--- a/cdip_admin/event_consumers/tests/test_dispatcher_events_consumer.py
+++ b/cdip_admin/event_consumers/tests/test_dispatcher_events_consumer.py
@@ -623,3 +623,74 @@ def test_is_retriable_er_error_uses_normalized_er_type_check():
     assert not is_retriable_er_error(
         error=None, server_response_status=503, destination=non_er,
     )
+
+
+# --- GUNDI-5550: resilience to DB connection loss ---
+
+from django.db import InterfaceError, OperationalError
+
+
+@pytest.mark.parametrize("db_error", [
+    InterfaceError("connection already closed"),
+    OperationalError("server closed the connection unexpectedly"),
+])
+def test_transient_db_error_nacks_message_for_redelivery(
+        mocker, db_error, trap_tagger_event_trace, trap_tagger_to_er_observation_delivered_event
+):
+    # A dead DB connection must trigger redelivery, not a silent drop (GUNDI-5549)
+    mocker.patch.dict(
+        "event_consumers.dispatcher_events_consumer.event_handlers",
+        {"ObservationDelivered": mocker.MagicMock(side_effect=db_error)},
+    )
+    process_event(trap_tagger_to_er_observation_delivered_event)
+    trap_tagger_to_er_observation_delivered_event.nack.assert_called_once()
+    trap_tagger_to_er_observation_delivered_event.ack.assert_not_called()
+
+
+def test_transient_db_error_resets_connections(
+        mocker, trap_tagger_event_trace, trap_tagger_to_er_observation_delivered_event
+):
+    mocked_close = mocker.patch(
+        "event_consumers.dispatcher_events_consumer.refresh_db_connections"
+    )
+    mocker.patch.dict(
+        "event_consumers.dispatcher_events_consumer.event_handlers",
+        {"ObservationDelivered": mocker.MagicMock(side_effect=InterfaceError("connection already closed"))},
+    )
+    process_event(trap_tagger_to_er_observation_delivered_event)
+    # Once on entry (routine refresh) + once after the failure (drop the dead connection)
+    assert mocked_close.call_count == 2
+
+
+def test_unexpected_error_still_acks_message(
+        mocker, trap_tagger_event_trace, trap_tagger_to_er_observation_delivered_event
+):
+    # Non-DB errors keep the current log-and-ack behavior: without a
+    # dead-letter topic, nacking them would loop a poison message forever.
+    mocker.patch.dict(
+        "event_consumers.dispatcher_events_consumer.event_handlers",
+        {"ObservationDelivered": mocker.MagicMock(side_effect=ValueError("boom"))},
+    )
+    process_event(trap_tagger_to_er_observation_delivered_event)
+    trap_tagger_to_er_observation_delivered_event.ack.assert_called_once()
+    trap_tagger_to_er_observation_delivered_event.nack.assert_not_called()
+
+
+def test_successful_processing_acks_message_exactly_once(
+        mocker, trap_tagger_event_trace, trap_tagger_to_er_observation_delivered_event
+):
+    mocked_close = mocker.patch(
+        "event_consumers.dispatcher_events_consumer.refresh_db_connections"
+    )
+    process_event(trap_tagger_to_er_observation_delivered_event)
+    trap_tagger_to_er_observation_delivered_event.ack.assert_called_once()
+    trap_tagger_to_er_observation_delivered_event.nack.assert_not_called()
+    mocked_close.assert_called_once()  # routine per-message refresh
+
+
+def test_invalid_json_message_is_discarded_without_raising(mocker):
+    message = mocker.MagicMock()
+    message.data = b"not json {"
+    process_event(message)  # must not raise
+    message.ack.assert_called_once()
+    message.nack.assert_not_called()

--- a/cdip_admin/event_consumers/tests/test_integration_events_consumer.py
+++ b/cdip_admin/event_consumers/tests/test_integration_events_consumer.py
@@ -153,3 +153,74 @@ def test_process_webhook_custom_activity_log_event(
     assert activity_log.title == event_payload["title"]
     assert activity_log.details == event_payload
     assert activity_log.is_reversible is False
+
+
+# --- GUNDI-5550: resilience to DB connection loss ---
+
+from django.db import InterfaceError, OperationalError
+
+
+@pytest.mark.parametrize("db_error", [
+    InterfaceError("connection already closed"),
+    OperationalError("server closed the connection unexpectedly"),
+])
+def test_transient_db_error_nacks_message_for_redelivery(
+        mocker, db_error, provider_lotek_panthera, pull_observations_action_started_event
+):
+    # A dead DB connection must trigger redelivery, not a silent drop (GUNDI-5549)
+    mocker.patch.dict(
+        "event_consumers.integration_events_consumer.event_handlers",
+        {"IntegrationActionStarted": mocker.MagicMock(side_effect=db_error)},
+    )
+    process_event(pull_observations_action_started_event)
+    pull_observations_action_started_event.nack.assert_called_once()
+    pull_observations_action_started_event.ack.assert_not_called()
+
+
+def test_transient_db_error_resets_connections(
+        mocker, provider_lotek_panthera, pull_observations_action_started_event
+):
+    mocked_refresh = mocker.patch(
+        "event_consumers.integration_events_consumer.refresh_db_connections"
+    )
+    mocker.patch.dict(
+        "event_consumers.integration_events_consumer.event_handlers",
+        {"IntegrationActionStarted": mocker.MagicMock(side_effect=InterfaceError("connection already closed"))},
+    )
+    process_event(pull_observations_action_started_event)
+    # Once on entry (routine refresh) + once after the failure (drop the dead connection)
+    assert mocked_refresh.call_count == 2
+
+
+def test_unexpected_error_still_acks_message(
+        mocker, provider_lotek_panthera, pull_observations_action_started_event
+):
+    # Non-DB errors keep the current log-and-ack behavior: without a
+    # dead-letter topic, nacking them would loop a poison message forever.
+    mocker.patch.dict(
+        "event_consumers.integration_events_consumer.event_handlers",
+        {"IntegrationActionStarted": mocker.MagicMock(side_effect=ValueError("boom"))},
+    )
+    process_event(pull_observations_action_started_event)
+    pull_observations_action_started_event.ack.assert_called_once()
+    pull_observations_action_started_event.nack.assert_not_called()
+
+
+def test_successful_processing_acks_message_exactly_once(
+        mocker, provider_lotek_panthera, pull_observations_action_started_event
+):
+    mocked_refresh = mocker.patch(
+        "event_consumers.integration_events_consumer.refresh_db_connections"
+    )
+    process_event(pull_observations_action_started_event)
+    pull_observations_action_started_event.ack.assert_called_once()
+    pull_observations_action_started_event.nack.assert_not_called()
+    mocked_refresh.assert_called_once()  # routine per-message refresh
+
+
+def test_invalid_json_message_is_discarded_without_raising(mocker):
+    message = mocker.MagicMock()
+    message.data = b"not json {"
+    process_event(message)  # must not raise
+    message.ack.assert_called_once()
+    message.nack.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes the root cause of [GUNDI-5549](https://allenai.atlassian.net/browse/GUNDI-5549): when the Django DB connection in `dispatcher-events-consumer` (or `integration-events-consumer`) died, every subsequent event failed with `InterfaceError: connection already closed` — and the `finally: message.ack()` discarded the message anyway. Delivery failures stopped producing Activity Log records, so the hourly healthcheck kept reporting broken integrations as Healthy, and the dropped events were unrecoverable.

Implements [GUNDI-5550](https://allenai.atlassian.net/browse/GUNDI-5550) for both consumers:

- **Refresh DB connections per message** — new `event_consumers/db_utils.py:refresh_db_connections()`, an equivalent of `django.db.close_old_connections()` that skips connections inside an atomic block (so pytest-django's per-test transaction survives). Called at the top of each `process_event`.
- **Nack transient DB errors** — `InterfaceError`/`OperationalError` now nack the message so PubSub redelivers it instead of losing the event. Other exceptions keep the existing log-and-ack behavior: the subscriptions have no dead-letter topic yet, so nacking a permanently-failing message would loop it forever.
- **Parse message JSON once** — an unparseable payload is discarded cleanly instead of raising a second `JSONDecodeError` inside the `except` handler's `extra={"event": json.loads(message.data)}`.

The `"Error Processing Dispatcher Event"` / `"Error Processing Integration Event"` log texts are intentionally unchanged — a follow-up infra task will attach a log-based alert to them.

## Test plan

- [x] 11 new tests: nack on `InterfaceError`/`OperationalError`, connection reset on failure, ack-once on success, log-and-ack on non-DB errors, invalid-JSON discard (both consumers)
- [x] Full `event_consumers/` + `activity_log/` suites pass locally (74 passed)

## Out of scope (infra follow-ups tracked in GUNDI-5550)

- Dead-letter policy on the PubSub subscriptions
- GCP log-based alert on the error-log rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[GUNDI-5549]: https://allenai.atlassian.net/browse/GUNDI-5549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GUNDI-5550]: https://allenai.atlassian.net/browse/GUNDI-5550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ