### PR TITLE
Speed up DispatcherDeployment admin; add JSON editor for configuration

### DIFF
--- a/cdip_admin/cdip_admin/settings.py
+++ b/cdip_admin/cdip_admin/settings.py
@@ -92,6 +92,7 @@ INSTALLED_APPS = [
     "django_extensions",
     "simple_history",
     "django_jsonform",
+    "django_json_widget",
     "storages",
     "deployments",
     "activity_log",

--- a/cdip_admin/deployments/admin.py
+++ b/cdip_admin/deployments/admin.py
@@ -1,6 +1,25 @@
+from django import forms
 from django.contrib import admin
+from django_json_widget.widgets import JSONEditorWidget
 from .models import DispatcherDeployment
 from .tasks import deploy_serverless_dispatcher
+
+
+class DispatcherDeploymentForm(forms.ModelForm):
+    configuration = forms.JSONField(
+        required=False,
+        label="JSON Configuration",
+        widget=JSONEditorWidget(width="60em", height="30em"),
+    )
+
+    class Meta:
+        model = DispatcherDeployment
+        fields = "__all__"
+
+    def clean_configuration(self):
+        # The model field is NOT NULL with default=dict; an emptied textarea
+        # must save as {} rather than None.
+        return self.cleaned_data.get("configuration") or {}
 
 
 def restart_deployments(modeladmin, request, queryset):
@@ -56,6 +75,15 @@ class OrphanedFilter(admin.SimpleListFilter):
 
 @admin.register(DispatcherDeployment)
 class DispatcherDeploymentAdmin(admin.ModelAdmin):
+    form = DispatcherDeploymentForm
+    # Both FKs appear in list_display and their __str__ dereferences
+    # owner/type, so join them up front to avoid per-row queries.
+    list_select_related = (
+        "integration__owner",
+        "integration__type",
+        "legacy_integration__owner",
+        "legacy_integration__type",
+    )
     list_display = (
         "name",
         "status",
@@ -80,6 +108,13 @@ class DispatcherDeploymentAdmin(admin.ModelAdmin):
         "attempt_count",
         "last_attempt_at",
         "last_error",
+    )
+    # Render the integration FKs as AJAX search boxes. Plain selects load
+    # every Integration/OutboundIntegrationConfiguration, and their __str__
+    # dereferences owner/type per row, making the change page unusably slow.
+    autocomplete_fields = (
+        "integration",
+        "legacy_integration",
     )
     actions = [restart_deployments, recreate_dispatchers, delete_orphaned_dispatchers]
     search_fields = (

--- a/cdip_admin/deployments/admin.py
+++ b/cdip_admin/deployments/admin.py
@@ -17,9 +17,11 @@ class DispatcherDeploymentForm(forms.ModelForm):
         fields = "__all__"
 
     def clean_configuration(self):
-        # The model field is NOT NULL with default=dict; an emptied textarea
-        # must save as {} rather than None.
-        return self.cleaned_data.get("configuration") or {}
+        # The model field is NOT NULL with default=dict; an emptied editor
+        # must save as {} rather than None. Coerce only None — falsy JSON
+        # values like [], 0, or false are valid and must be preserved.
+        value = self.cleaned_data.get("configuration")
+        return {} if value is None else value
 
 
 def restart_deployments(modeladmin, request, queryset):

--- a/cdip_admin/deployments/tests/test_admin.py
+++ b/cdip_admin/deployments/tests/test_admin.py
@@ -1,6 +1,8 @@
+import pytest
 from django.contrib import admin as django_admin
 from django.contrib.admin.widgets import AutocompleteSelect
 
+from deployments.admin import DispatcherDeploymentForm
 from deployments.models import DispatcherDeployment
 
 
@@ -17,3 +19,20 @@ def test_change_form_uses_autocomplete_for_integration_fks():
             DispatcherDeployment._meta.get_field(field_name), request=None
         )
         assert isinstance(formfield.widget, AutocompleteSelect)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("", {}),  # emptied editor -> {} (column is NOT NULL, default=dict)
+        ("[]", []),  # falsy but valid JSON must be preserved as-is
+        ("0", 0),
+        ("false", False),
+        ('{"a": 1}', {"a": 1}),
+    ],
+)
+def test_configuration_cleaning_preserves_falsy_json(raw, expected):
+    form = DispatcherDeploymentForm(data={"configuration": raw})
+    form.is_valid()
+    assert "configuration" not in form.errors
+    assert form.cleaned_data["configuration"] == expected

--- a/cdip_admin/deployments/tests/test_admin.py
+++ b/cdip_admin/deployments/tests/test_admin.py
@@ -1,0 +1,19 @@
+from django.contrib import admin as django_admin
+from django.contrib.admin.widgets import AutocompleteSelect
+
+from deployments.models import DispatcherDeployment
+
+
+def test_change_form_uses_autocomplete_for_integration_fks():
+    """The change form must not render plain selects for the integration FKs.
+
+    A plain select loads every Integration/OutboundIntegrationConfiguration
+    and calls __str__ on each (which dereferences owner and type without
+    select_related), making the page unusably slow in production.
+    """
+    model_admin = django_admin.site._registry[DispatcherDeployment]
+    for field_name in ("integration", "legacy_integration"):
+        formfield = model_admin.formfield_for_foreignkey(
+            DispatcherDeployment._meta.get_field(field_name), request=None
+        )
+        assert isinstance(formfield.widget, AutocompleteSelect)

--- a/dependencies/requirements.in
+++ b/dependencies/requirements.in
@@ -15,6 +15,7 @@ django-bootstrap4==24.3
 djfernet>=0.1.0
 django-htmx==1.12.0
 django-jsonform==2.12.0
+django-json-widget==2.0.1
 django-extensions==3.2.0
 djangorestframework>=3.15.2,<3.16.0
 django-cors-headers~=3.1.1

--- a/dependencies/requirements.txt
+++ b/dependencies/requirements.txt
@@ -131,6 +131,8 @@ django-filter==2.3.0
     # via -r requirements.in
 django-htmx==1.12.0
     # via -r requirements.in
+django-json-widget==2.0.1
+    # via -r requirements.in
 django-jsonform==2.12.0
     # via -r requirements.in
 django-keycloak==0.1.1


### PR DESCRIPTION
## Summary

The DispatcherDeployment change form was unusably slow because the two integration FKs rendered as plain `<select>`s: Django loaded every `Integration` and `OutboundIntegrationConfiguration` into the page, and each option's `__str__` dereferences `owner` and `type`, firing two extra queries per row. Both fields are now admin autocomplete search boxes, and the changelist gets `list_select_related` for the same two FK columns it displays.

The `configuration` JSONField also swaps its bare textarea for django-json-widget's JSONEditorWidget: syntax highlighting, code/tree/text modes, search, and built-in formatting. Server-side validation is unchanged (malformed JSON is a normal field error), and an emptied editor saves `{}` rather than `None`, since the column is NOT NULL with `default=dict`.

## Validation

- New regression test asserts the change form renders `AutocompleteSelect` for both FKs (`deployments/tests/test_admin.py`).
- Form smoke-tested: editor renders with its media, empty submission cleans to `{}`, invalid JSON produces a field error, valid JSON round-trips.
- `deployments/` suite: 51 passed, 1 skipped; the 25 failures + 3 errors are pre-existing in this local environment (they require a live Redis) and reproduce identically on pristine `origin/main`.

## New concepts

### django-json-widget (JSONEditorWidget)

A Django form widget wrapping josdejong's JSONEditor, giving any `JSONField` a real JSON editor in the admin instead of a `<textarea>` full of single-line JSON.

**Why here:** the repo already ships `django-jsonform`, but that generates *schema-driven* forms — it needs a JSON schema and renders one input per property. A dispatcher's `configuration` is free-form JSON with no fixed schema, which is exactly the case JSONEditorWidget handles: the operator edits arbitrary JSON with formatting and syntax checking, no schema required.

```python
# The widget is presentation-only; forms.JSONField still does the parsing/validation.
configuration = forms.JSONField(
    required=False,
    widget=JSONEditorWidget(width="60em", height="30em"),
)
```

**Gotcha this PR guards:** an emptied editor posts an empty string, which `forms.JSONField(required=False)` cleans to `None` — a crash on NOT NULL JSON columns. `clean_configuration` coerces that to `{}`.

**When not to use it:** if the JSON has a known schema, prefer `django-jsonform` — structured per-field inputs beat a free-form editor for validation and discoverability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
