### PR TITLE
Use gundi-portal's Monaco editor for dispatcher configuration JSON

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,9 @@ jobs:
       - uses: actions/checkout@v4
       - id: vars
         run: |
-          echo "tag=${{ github.head_ref || github.ref_name }}-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          # Branch names may contain '/', which is invalid in a Docker tag.
+          ref_name="${{ github.head_ref || github.ref_name }}"
+          echo "tag=${ref_name//\//-}-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           echo "repository=europe-west3-docker.pkg.dev/serca-artifact-registry/gundi/admin-portal" >> $GITHUB_OUTPUT
 
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - main
       - 'release-**'
+      # TEMPORARY (revert before merging PR #456): deploy this branch to dev
+      - 'feature/dispatcher-admin-monaco-editor'
 env:
   TRACING_ENABLED: ${{secrets.TRACING_ENABLED}}
   PUBSUB_ENABLED: ${{secrets.PUBSUB_ENABLED}}
@@ -35,7 +37,8 @@ jobs:
     # PADAS/serca-argocd-apps:gundi/admin-portal/values-gundi-dev.yaml and lets
     # ArgoCD's automated selfHeal pick up the change.
     uses: PADAS/gundi-workflows/.github/workflows/deploy_argocd.yml@v8
-    if: startsWith(github.ref, 'refs/heads/main')
+    # TEMPORARY (revert before merging PR #456): second condition deploys this branch to dev
+    if: startsWith(github.ref, 'refs/heads/main') || github.ref == 'refs/heads/feature/dispatcher-admin-monaco-editor'
     needs: [vars, build]
     with:
       app-name: admin-portal

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - main
       - 'release-**'
-      # TEMPORARY (revert before merging PR #456): deploy this branch to dev
-      - 'feature/dispatcher-admin-monaco-editor'
 env:
   TRACING_ENABLED: ${{secrets.TRACING_ENABLED}}
   PUBSUB_ENABLED: ${{secrets.PUBSUB_ENABLED}}
@@ -39,8 +37,7 @@ jobs:
     # PADAS/serca-argocd-apps:gundi/admin-portal/values-gundi-dev.yaml and lets
     # ArgoCD's automated selfHeal pick up the change.
     uses: PADAS/gundi-workflows/.github/workflows/deploy_argocd.yml@v8
-    # TEMPORARY (revert before merging PR #456): second condition deploys this branch to dev
-    if: startsWith(github.ref, 'refs/heads/main') || github.ref == 'refs/heads/feature/dispatcher-admin-monaco-editor'
+    if: startsWith(github.ref, 'refs/heads/main')
     needs: [vars, build]
     with:
       app-name: admin-portal

--- a/cdip_admin/cdip_admin/settings.py
+++ b/cdip_admin/cdip_admin/settings.py
@@ -92,7 +92,6 @@ INSTALLED_APPS = [
     "django_extensions",
     "simple_history",
     "django_jsonform",
-    "django_json_widget",
     "storages",
     "deployments",
     "activity_log",

--- a/cdip_admin/deployments/admin.py
+++ b/cdip_admin/deployments/admin.py
@@ -1,15 +1,25 @@
+import json
+
 from django import forms
 from django.contrib import admin
-from django_json_widget.widgets import JSONEditorWidget
 from .models import DispatcherDeployment
 from .tasks import deploy_serverless_dispatcher
+from .widgets import MonacoJSONWidget
+
+
+class PrettyJSONEncoder(json.JSONEncoder):
+    # Monaco renders the text it is given, so indent server-side.
+    def __init__(self, *args, **kwargs):
+        kwargs["indent"] = 2
+        super().__init__(*args, **kwargs)
 
 
 class DispatcherDeploymentForm(forms.ModelForm):
     configuration = forms.JSONField(
         required=False,
         label="JSON Configuration",
-        widget=JSONEditorWidget(width="60em", height="30em"),
+        encoder=PrettyJSONEncoder,
+        widget=MonacoJSONWidget(height="30em"),
     )
 
     class Meta:

--- a/cdip_admin/deployments/tests/test_admin.py
+++ b/cdip_admin/deployments/tests/test_admin.py
@@ -36,3 +36,19 @@ def test_configuration_cleaning_preserves_falsy_json(raw, expected):
     form.is_valid()
     assert "configuration" not in form.errors
     assert form.cleaned_data["configuration"] == expected
+
+
+def test_configuration_renders_monaco_editor():
+    """The configuration field mounts the same Monaco editor gundi-portal uses.
+
+    The real textarea must stay in the form (Monaco syncs into it; it is
+    also the fallback if the CDN is unreachable), and the initial JSON is
+    indented server-side because Monaco renders the text it is given.
+    """
+    form = DispatcherDeploymentForm(initial={"configuration": {"env_vars": {"A": "1"}}})
+    html = str(form["configuration"])
+    assert "monaco-editor@" in html  # pinned CDN loader base
+    assert 'language: "json"' in html
+    assert "<textarea" in html
+    assert "id_configuration_monaco" in html
+    assert "&quot;env_vars&quot;: {" in html  # server-side pretty-printing

--- a/cdip_admin/deployments/widgets.py
+++ b/cdip_admin/deployments/widgets.py
@@ -28,12 +28,18 @@ _WIDGET_TEMPLATE = string.Template(
           window.require.config({ paths: { vs: VS_BASE } });
           // Monaco's workers can't be created cross-origin from a CDN
           // directly; the blob shim below is the documented workaround.
+          // Monaco calls getWorkerUrl once per worker, so cache the blob
+          // URL (it is released with the document on unload).
+          var workerUrl = null;
           window.MonacoEnvironment = {
             getWorkerUrl: function () {
-              return URL.createObjectURL(new Blob([
-                "self.MonacoEnvironment={baseUrl:'" + VS_BASE + "/../'};" +
-                "importScripts('" + VS_BASE + "/base/worker/workerMain.js');"
-              ], { type: "text/javascript" }));
+              if (!workerUrl) {
+                workerUrl = URL.createObjectURL(new Blob([
+                  "self.MonacoEnvironment={baseUrl:'" + VS_BASE + "/../'};" +
+                  "importScripts('" + VS_BASE + "/base/worker/workerMain.js');"
+                ], { type: "text/javascript" }));
+              }
+              return workerUrl;
             }
           };
           window.require(["vs/editor/editor.main"], function () { resolve(window.monaco); });
@@ -42,7 +48,11 @@ _WIDGET_TEMPLATE = string.Template(
         document.head.appendChild(s);
       });
     }
-    window._monacoLoaderPromise.then(cb);
+    window._monacoLoaderPromise.then(cb).catch(function (err) {
+      // The visible textarea is the fallback; just avoid an unhandled
+      // rejection in the console.
+      console.warn("Monaco failed to load; using the plain textarea.", err);
+    });
   }
   function init() {
     var textarea = document.getElementById("$widget_id");

--- a/cdip_admin/deployments/widgets.py
+++ b/cdip_admin/deployments/widgets.py
@@ -1,0 +1,117 @@
+import string
+
+from django import forms
+from django.utils.safestring import mark_safe
+
+# Same editor stack as gundi-portal (@monaco-editor/react), which loads
+# Monaco from the jsDelivr CDN by default. Pin the version so admin pages
+# don't shift under us when jsDelivr's "latest" moves.
+MONACO_VERSION = "0.52.2"
+MONACO_VS_BASE = f"https://cdn.jsdelivr.net/npm/monaco-editor@{MONACO_VERSION}/min/vs"
+
+_WIDGET_TEMPLATE = string.Template(
+    """
+<div style="width: 60em; max-width: 100%;">
+  $textarea
+  <div id="$editor_id" style="height: $height; border: 1px solid #ccc; display: none;"></div>
+</div>
+<script>
+(function () {
+  var VS_BASE = "$vs_base";
+  function withMonaco(cb) {
+    if (window.monaco) { cb(window.monaco); return; }
+    if (!window._monacoLoaderPromise) {
+      window._monacoLoaderPromise = new Promise(function (resolve, reject) {
+        var s = document.createElement("script");
+        s.src = VS_BASE + "/loader.js";
+        s.onload = function () {
+          window.require.config({ paths: { vs: VS_BASE } });
+          // Monaco's workers can't be created cross-origin from a CDN
+          // directly; the blob shim below is the documented workaround.
+          window.MonacoEnvironment = {
+            getWorkerUrl: function () {
+              return URL.createObjectURL(new Blob([
+                "self.MonacoEnvironment={baseUrl:'" + VS_BASE + "/../'};" +
+                "importScripts('" + VS_BASE + "/base/worker/workerMain.js');"
+              ], { type: "text/javascript" }));
+            }
+          };
+          window.require(["vs/editor/editor.main"], function () { resolve(window.monaco); });
+        };
+        s.onerror = reject;
+        document.head.appendChild(s);
+      });
+    }
+    window._monacoLoaderPromise.then(cb);
+  }
+  function init() {
+    var textarea = document.getElementById("$widget_id");
+    var container = document.getElementById("$editor_id");
+    if (!textarea || !container || container.dataset.monacoMounted) { return; }
+    container.dataset.monacoMounted = "1";
+    withMonaco(function (monaco) {
+      // If the CDN is unreachable this never runs and the plain
+      // textarea stays usable as a fallback.
+      textarea.style.display = "none";
+      container.style.display = "block";
+      var editor = monaco.editor.create(container, {
+        value: textarea.value,
+        language: "json",
+        theme: "vs",
+        // Mirrors gundi-portal's MONACO_OPTIONS
+        // (src/components/connections/schema-builder/editorConfig.ts).
+        minimap: { enabled: false },
+        scrollBeyondLastLine: false,
+        fontSize: 13,
+        lineHeight: 20,
+        padding: { top: 8 },
+        readOnly: false,
+        lineNumbers: "on",
+        wordWrap: "off",
+        automaticLayout: true,
+        renderLineHighlight: "none",
+        stickyScroll: { enabled: false },
+        scrollbar: { useShadows: false },
+        fontFamily: "'SF Mono', 'Fira Code', 'Cascadia Code', monospace"
+      });
+      editor.onDidChangeModelContent(function () {
+        textarea.value = editor.getValue();
+      });
+    });
+  }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();
+</script>
+"""
+)
+
+
+class MonacoJSONWidget(forms.Textarea):
+    """JSON editor matching gundi-portal's Monaco-based code editors.
+
+    The real ``<textarea>`` stays in the form (hidden once Monaco mounts)
+    and receives the editor's content on every change, so submission and
+    server-side validation are untouched. If the CDN can't be reached the
+    textarea remains visible as a plain-text fallback.
+    """
+
+    def __init__(self, attrs=None, height="30em"):
+        self.height = height
+        super().__init__(attrs)
+
+    def render(self, name, value, attrs=None, renderer=None):
+        textarea = super().render(name, value, attrs, renderer)
+        widget_id = (attrs or {}).get("id") or f"id_{name}"
+        return mark_safe(
+            _WIDGET_TEMPLATE.substitute(
+                textarea=textarea,
+                widget_id=widget_id,
+                editor_id=f"{widget_id}_monaco",
+                height=self.height,
+                vs_base=MONACO_VS_BASE,
+            )
+        )

--- a/dependencies/requirements.in
+++ b/dependencies/requirements.in
@@ -15,7 +15,6 @@ django-bootstrap4==24.3
 djfernet>=0.1.0
 django-htmx==1.12.0
 django-jsonform==2.12.0
-django-json-widget==2.0.1
 django-extensions==3.2.0
 djangorestframework>=3.15.2,<3.16.0
 django-cors-headers~=3.1.1

--- a/dependencies/requirements.txt
+++ b/dependencies/requirements.txt
@@ -131,8 +131,6 @@ django-filter==2.3.0
     # via -r requirements.in
 django-htmx==1.12.0
     # via -r requirements.in
-django-json-widget==2.0.1
-    # via -r requirements.in
 django-jsonform==2.12.0
     # via -r requirements.in
 django-keycloak==0.1.1


### PR DESCRIPTION
## Summary

The dispatcher `configuration` admin editor now uses Monaco — the same editor component gundi-portal uses for webhook schemas and JQ filters — instead of django-json-widget's jsoneditor/ace. A new `MonacoJSONWidget` mirrors the portal's setup exactly: the `@monaco-editor/react` jsDelivr CDN source (pinned to 0.52.2), `language="json"`, the `vs` theme, and a copy of the portal's `MONACO_OPTIONS` (no minimap, 13px mono font, line numbers, no line highlight), so editing JSON in the admin and in the portal feels identical.

The form's real `<textarea>` stays in the document: Monaco syncs its content into it on every change, so form submission and all server-side validation (including the falsy-JSON handling from #455) are untouched — and if the CDN is unreachable, the textarea remains visible as a plain-text fallback. Stored JSON is indented server-side because Monaco renders exactly the text it is given. `django-json-widget` is removed from INSTALLED_APPS and requirements.

## Validation

- 7 admin tests pass, including a new one asserting the Monaco mount, the pinned CDN base, and the pretty-printed initial value.
- The editor's in-browser behavior (CDN load, worker-based JSON validation) is not exercised by tests — worth a quick click-through on dev after merge.

## New concepts

### Embedding Monaco in a server-rendered page (no build pipeline)

Monaco is VS Code's editor extracted as a library. SPAs consume it via npm, but a plain Django page can load the prebuilt AMD bundle from a CDN with its `loader.js` — no bundler required. Two non-obvious parts this widget handles:

```python
# The widget renders the real <textarea> plus a mount <div>; Monaco is
# enhancement-only and the form degrades to the textarea without it.
configuration = forms.JSONField(widget=MonacoJSONWidget(height="30em"))
```

- **Hidden-textarea sync**: the `<textarea>` remains the form's submission carrier; `editor.onDidChangeModelContent` copies the editor text back into it. The server never knows Monaco exists.
- **Cross-origin worker shim**: Monaco's JSON language service runs in a web worker, and browsers refuse to start workers from a different origin (the CDN). The standard workaround — a same-origin `Blob` worker that `importScripts` the CDN's `workerMain.js` — is set via `window.MonacoEnvironment.getWorkerUrl`.

**When not to use it:** if a page needs offline operation or a strict CSP without CDN origins, vendor the Monaco assets into staticfiles instead of the CDN load (the widget's `MONACO_VS_BASE` is the single knob).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
