### PR TITLE
Add Redis memory profiler and safety-railed stale-key cleaner scripts

### DIFF
--- a/cdip_admin/scripts/redis_memory_profiler.py
+++ b/cdip_admin/scripts/redis_memory_profiler.py
@@ -1,0 +1,61 @@
+"""Read-only memory profiler for a Redis instance: per-db overview plus
+per-key-prefix memory/count/no-TTL breakdown. Never writes or deletes.
+
+Usage:
+    REDIS_HOST=... python redis_memory_profiler.py            # overview only
+    REDIS_HOST=... python redis_memory_profiler.py 0 --depth 1
+"""
+import argparse
+import sys
+import time
+from collections import defaultdict
+from dataclasses import dataclass
+
+from scripts.redis_ops_common import get_redis_from_env, iter_key_batches, key_prefix
+
+
+@dataclass
+class PrefixStats:
+    count: int = 0
+    total_bytes: int = 0
+    no_ttl_count: int = 0
+
+
+def fetch_key_stats(r, keys):
+    """Pipelined (MEMORY USAGE, TTL) per key. Memory is None if the key vanished."""
+    pipe = r.pipeline(transaction=False)
+    for k in keys:
+        pipe.memory_usage(k, samples=0)
+    for k in keys:
+        pipe.ttl(k)
+    results = pipe.execute()
+    return list(zip(results[: len(keys)], results[len(keys):]))
+
+
+def aggregate_prefix_stats(key_batches, stats_fetcher, depth=1, on_batch=None):
+    stats = defaultdict(PrefixStats)
+    for keys in key_batches:
+        for key, (mem, ttl) in zip(keys, stats_fetcher(keys)):
+            if ttl == -2:  # key expired/deleted mid-scan
+                continue
+            s = stats[key_prefix(key, depth)]
+            s.count += 1
+            s.total_bytes += mem or 0
+            if ttl == -1:
+                s.no_ttl_count += 1
+        if on_batch:
+            on_batch(len(keys))
+    return dict(stats)
+
+
+def format_stats_table(stats):
+    rows = sorted(stats.items(), key=lambda kv: kv[1].total_bytes, reverse=True)
+    lines = [f"{'prefix':<50} {'keys':>12} {'MB':>10} {'avg B':>8} {'% no-TTL':>9}"]
+    for prefix, s in rows:
+        avg = s.total_bytes // s.count if s.count else 0
+        pct = (s.no_ttl_count / s.count * 100) if s.count else 0.0
+        lines.append(
+            f"{prefix:<50} {s.count:>12,} {s.total_bytes / 1048576:>10.1f} "
+            f"{avg:>8,} {pct:>8.1f}%"
+        )
+    return "\n".join(lines)

--- a/cdip_admin/scripts/redis_memory_profiler.py
+++ b/cdip_admin/scripts/redis_memory_profiler.py
@@ -2,8 +2,8 @@
 per-key-prefix memory/count/no-TTL breakdown. Never writes or deletes.
 
 Usage:
-    REDIS_HOST=... python redis_memory_profiler.py            # overview only
-    REDIS_HOST=... python redis_memory_profiler.py 0 --depth 1
+    cd cdip_admin && REDIS_HOST=... python -m scripts.redis_memory_profiler            # overview only
+    cd cdip_admin && REDIS_HOST=... python -m scripts.redis_memory_profiler 0 --depth 1
 """
 import argparse
 import sys

--- a/cdip_admin/scripts/redis_memory_profiler.py
+++ b/cdip_admin/scripts/redis_memory_profiler.py
@@ -11,7 +11,13 @@ import time
 from collections import defaultdict
 from dataclasses import dataclass
 
-from scripts.redis_ops_common import get_redis_from_env, iter_key_batches, key_prefix
+from scripts.redis_ops_common import (
+    get_redis_from_env,
+    iter_key_batches,
+    key_prefix,
+    non_negative_float,
+    positive_int,
+)
 
 
 @dataclass
@@ -61,6 +67,18 @@ def format_stats_table(stats):
     return "\n".join(lines)
 
 
+def _db_sort_key(db_name):
+    """Order db0, db2, db10 numerically rather than lexicographically.
+
+    Names that don't look like 'db<N>' sort last, by name, so the output stays
+    deterministic whatever the server reports.
+    """
+    suffix = db_name[2:]
+    if db_name.startswith("db") and suffix.isdigit():
+        return (0, int(suffix), "")
+    return (1, 0, db_name)
+
+
 def print_overview(r):
     mem = r.info("memory")
     print(
@@ -70,7 +88,7 @@ def print_overview(r):
         f"fragmentation: {mem.get('mem_fragmentation_ratio')}"
     )
     keyspace = r.info("keyspace")
-    for db_name in sorted(keyspace):
+    for db_name in sorted(keyspace, key=_db_sort_key):
         info = keyspace[db_name]
         print(
             f"{db_name}: keys={info.get('keys'):,} expires={info.get('expires'):,} "
@@ -86,11 +104,11 @@ def parse_args():
     )
     parser.add_argument("db", type=int, nargs="?", default=None,
                         help="db number to profile by prefix (omit for overview only)")
-    parser.add_argument("--depth", type=int, default=1,
+    parser.add_argument("--depth", type=positive_int, default=1,
                         help="key segments (split on . and :) per prefix bucket (default 1)")
-    parser.add_argument("--scan-count", type=int, default=500,
+    parser.add_argument("--scan-count", type=positive_int, default=500,
                         help="SCAN COUNT hint per batch (default 500)")
-    parser.add_argument("--throttle", type=float, default=50,
+    parser.add_argument("--throttle", type=non_negative_float, default=50,
                         help="sleep between SCAN batches in ms (default 50)")
     return parser.parse_args()
 

--- a/cdip_admin/scripts/redis_memory_profiler.py
+++ b/cdip_admin/scripts/redis_memory_profiler.py
@@ -59,3 +59,75 @@ def format_stats_table(stats):
             f"{avg:>8,} {pct:>8.1f}%"
         )
     return "\n".join(lines)
+
+
+def print_overview(r):
+    mem = r.info("memory")
+    print(
+        f"used_memory: {mem.get('used_memory_human')}  "
+        f"maxmemory: {mem.get('maxmemory_human', mem.get('maxmemory'))} "
+        f"(policy: {mem.get('maxmemory_policy')})  "
+        f"fragmentation: {mem.get('mem_fragmentation_ratio')}"
+    )
+    keyspace = r.info("keyspace")
+    for db_name in sorted(keyspace):
+        info = keyspace[db_name]
+        print(
+            f"{db_name}: keys={info.get('keys'):,} expires={info.get('expires'):,} "
+            f"avg_ttl={info.get('avg_ttl')}"
+        )
+    print()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Read-only Redis memory profiler: instance overview, plus "
+        "per-prefix memory breakdown for one db."
+    )
+    parser.add_argument("db", type=int, nargs="?", default=None,
+                        help="db number to profile by prefix (omit for overview only)")
+    parser.add_argument("--depth", type=int, default=1,
+                        help="key segments (split on . and :) per prefix bucket (default 1)")
+    parser.add_argument("--scan-count", type=int, default=500,
+                        help="SCAN COUNT hint per batch (default 500)")
+    parser.add_argument("--throttle", type=float, default=50,
+                        help="sleep between SCAN batches in ms (default 50)")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    r = get_redis_from_env(args.db if args.db is not None else 0)
+    print_overview(r)
+    if args.db is None:
+        return
+
+    total = r.dbsize()
+    print(f"Profiling db {args.db} (~{total:,} keys) by prefix (depth {args.depth})...\n")
+    progress = {"scanned": 0, "start": time.time(), "last_print": 0.0}
+
+    def on_batch(n):
+        progress["scanned"] += n
+        now = time.time()
+        if now - progress["last_print"] >= 1.0:
+            elapsed = now - progress["start"]
+            rate = progress["scanned"] / elapsed if elapsed > 0 else 0
+            pct = (progress["scanned"] / total * 100) if total else 0
+            sys.stdout.write(
+                f"\rScanned {progress['scanned']:,}/{total:,} ({pct:.1f}%) | {rate:,.0f} keys/s"
+            )
+            sys.stdout.flush()
+            progress["last_print"] = now
+
+    batches = iter_key_batches(
+        r, count=args.scan_count, throttle_seconds=args.throttle / 1000.0
+    )
+    stats = aggregate_prefix_stats(
+        batches, lambda keys: fetch_key_stats(r, keys), depth=args.depth, on_batch=on_batch
+    )
+    sys.stdout.write("\n\n")
+    print(format_stats_table(stats))
+
+
+if __name__ == "__main__":
+    main()

--- a/cdip_admin/scripts/redis_ops_common.py
+++ b/cdip_admin/scripts/redis_ops_common.py
@@ -1,0 +1,47 @@
+"""Shared helpers for the standalone Redis ops scripts. No Django dependency."""
+import os
+import re
+import time
+
+import redis
+
+_SEPARATORS = re.compile(r"[.:]")
+
+
+def get_redis_from_env(db):
+    """Build a client from REDIS_HOST (required) and REDIS_PORT (default 6379)."""
+    host = os.environ.get("REDIS_HOST")
+    if not host:
+        print("Error: REDIS_HOST environment variable is not set")
+        raise SystemExit(1)
+    port_str = os.environ.get("REDIS_PORT", "6379")
+    try:
+        port = int(port_str)
+    except ValueError:
+        print(f"Error: REDIS_PORT must be an integer, got '{port_str}'")
+        raise SystemExit(1)
+    return redis.Redis(host=host, port=port, db=db)
+
+
+def key_prefix(key, depth=1):
+    """Bucket a key by its first `depth` segments, splitting on '.' and ':'."""
+    parts = _SEPARATORS.split(key.decode(errors="replace"))
+    return ".".join(parts[:depth])
+
+
+def chunked(items, size):
+    for i in range(0, len(items), size):
+        yield items[i:i + size]
+
+
+def iter_key_batches(r, match=None, count=500, throttle_seconds=0.05):
+    """Yield batches of keys via SCAN, sleeping between iterations to cap server load."""
+    cursor = 0
+    while True:
+        cursor, keys = r.scan(cursor, match=match, count=count)
+        if keys:
+            yield keys
+        if cursor == 0:
+            return
+        if throttle_seconds:
+            time.sleep(throttle_seconds)

--- a/cdip_admin/scripts/redis_ops_common.py
+++ b/cdip_admin/scripts/redis_ops_common.py
@@ -1,4 +1,5 @@
 """Shared helpers for the standalone Redis ops scripts. No Django dependency."""
+import argparse
 import os
 import re
 import time
@@ -6,6 +7,22 @@ import time
 import redis
 
 _SEPARATORS = re.compile(r"[.:]")
+
+
+def positive_int(value):
+    """argparse type for counts that must be >= 1 (batch sizes, SCAN counts)."""
+    number = int(value)
+    if number < 1:
+        raise argparse.ArgumentTypeError(f"must be 1 or greater, got {value}")
+    return number
+
+
+def non_negative_float(value):
+    """argparse type for durations that must not be negative."""
+    number = float(value)
+    if number < 0:
+        raise argparse.ArgumentTypeError(f"must be 0 or greater, got {value}")
+    return number
 
 
 def get_redis_from_env(db):

--- a/cdip_admin/scripts/redis_stale_key_cleaner.py
+++ b/cdip_admin/scripts/redis_stale_key_cleaner.py
@@ -6,8 +6,8 @@ PubSub redelivery contract (see docs/superpowers/specs/2026-08-04-redis-prod-cle
 Dry-run by default; deletion requires --delete.
 
 Usage:
-    REDIS_HOST=... python redis_stale_key_cleaner.py 0                       # dry-run, 30d
-    REDIS_HOST=... python redis_stale_key_cleaner.py 0 --match 'backfill*' --delete
+    cd cdip_admin && REDIS_HOST=... python -m scripts.redis_stale_key_cleaner 0                       # dry-run, 30d
+    cd cdip_admin && REDIS_HOST=... python -m scripts.redis_stale_key_cleaner 0 --match 'backfill*' --delete
 """
 import argparse
 import sys
@@ -100,14 +100,34 @@ def summarize_candidates(sized, depth=1):
 
 
 def delete_keys(r, keys, batch_size=500, throttle_seconds=0.05, on_progress=None):
+    """UNLINK keys in batches, re-checking TTL immediately beforehand.
+
+    Candidate selection can be followed by a long interactive confirm prompt,
+    during which a key could be re-created with a TTL (e.g. a fresh
+    dispatched_observation.* idempotency key). Re-checking TTL right before
+    UNLINK closes that window: any key whose TTL is no longer -1 is dropped
+    rather than deleted. A key that vanished entirely (TTL == -2) is also
+    dropped — UNLINKing a gone key is harmless, but skipping it keeps the
+    skipped count meaningful.
+
+    Returns (deleted, skipped).
+    """
     deleted = 0
+    skipped = 0
     for batch in chunked(keys, batch_size):
-        deleted += r.unlink(*batch)
+        pipe = r.pipeline(transaction=False)
+        for k in batch:
+            pipe.ttl(k)
+        ttls = pipe.execute()
+        to_delete = [k for k, ttl in zip(batch, ttls) if ttl == -1]
+        skipped += len(batch) - len(to_delete)
+        if to_delete:
+            deleted += r.unlink(*to_delete)
         if on_progress:
             on_progress(deleted)
         if throttle_seconds:
             time.sleep(throttle_seconds)
-    return deleted
+    return deleted, skipped
 
 
 def parse_args():
@@ -215,11 +235,13 @@ def main():
         )
         sys.stdout.flush()
 
-    deleted = delete_keys(
+    deleted, skipped = delete_keys(
         r, keys_to_delete, batch_size=args.batch_size,
         throttle_seconds=throttle_seconds, on_progress=on_delete_progress,
     )
     print(f"\n\nUnlinked {deleted:,} keys total.")
+    if skipped:
+        print(f"Skipped {skipped:,} keys that acquired a TTL since selection.")
 
 
 if __name__ == "__main__":

--- a/cdip_admin/scripts/redis_stale_key_cleaner.py
+++ b/cdip_admin/scripts/redis_stale_key_cleaner.py
@@ -1,0 +1,66 @@
+"""Find (and optionally UNLINK) keys that have NO TTL and have been idle longer
+than a threshold. Keys with any TTL are never touched: they expire on their own,
+and deleting live dispatched_observation.* idempotency keys early breaks the
+PubSub redelivery contract (see docs/superpowers/specs/2026-08-04-redis-prod-cleanup-design.md).
+
+Dry-run by default; deletion requires --delete.
+
+Usage:
+    REDIS_HOST=... python redis_stale_key_cleaner.py 0                       # dry-run, 30d
+    REDIS_HOST=... python redis_stale_key_cleaner.py 0 --match 'backfill*' --delete
+"""
+import argparse
+import sys
+import time
+
+import redis
+
+from scripts.redis_ops_common import (
+    chunked,
+    get_redis_from_env,
+    iter_key_batches,
+    key_prefix,
+)
+
+MIN_DELETE_IDLE_DAYS = 2.0
+DAY_SECONDS = 86400
+
+
+class IdleTimeUnavailable(RuntimeError):
+    pass
+
+
+def fetch_idle_times(r, keys):
+    """Pipelined OBJECT IDLETIME. Aborts loudly if the server can't answer
+    (e.g. LFU maxmemory-policy) — never treat unknown idle as 0."""
+    pipe = r.pipeline(transaction=False)
+    for k in keys:
+        pipe.execute_command("OBJECT", "IDLETIME", k)
+    try:
+        return pipe.execute()
+    except redis.exceptions.ResponseError as exc:
+        raise IdleTimeUnavailable(
+            f"OBJECT IDLETIME failed ({exc}). If maxmemory-policy is an LFU policy, "
+            "idle times are unavailable; aborting rather than treating idle as 0."
+        ) from exc
+
+
+def find_stale_candidates(r, idle_threshold_seconds, match=None, scan_count=500,
+                          throttle_seconds=0.05, idle_fetcher=None, on_progress=None):
+    """Return (key, idle_seconds) for keys with TTL == -1 and idle > threshold."""
+    idle_fetcher = idle_fetcher or fetch_idle_times
+    candidates = []
+    for keys in iter_key_batches(r, match=match, count=scan_count,
+                                 throttle_seconds=throttle_seconds):
+        pipe = r.pipeline(transaction=False)
+        for k in keys:
+            pipe.ttl(k)
+        ttls = pipe.execute()
+        no_ttl_keys = [k for k, ttl in zip(keys, ttls) if ttl == -1]
+        if no_ttl_keys:
+            for k, idle in zip(no_ttl_keys, idle_fetcher(r, no_ttl_keys)):
+                if idle is not None and idle > idle_threshold_seconds:
+                    candidates.append((k, idle))
+        if on_progress:
+            on_progress(len(keys), len(candidates))
+    return candidates

--- a/cdip_admin/scripts/redis_stale_key_cleaner.py
+++ b/cdip_admin/scripts/redis_stale_key_cleaner.py
@@ -64,3 +64,163 @@ def find_stale_candidates(r, idle_threshold_seconds, match=None, scan_count=500,
         if on_progress:
             on_progress(len(keys), len(candidates))
     return candidates
+
+
+def validate_delete_args(delete, idle_threshold_days):
+    if delete and idle_threshold_days < MIN_DELETE_IDLE_DAYS:
+        print(
+            f"Refusing --delete with --idle-threshold {idle_threshold_days} days: "
+            f"the floor is {MIN_DELETE_IDLE_DAYS} days. Keys written recently may be "
+            "live idempotency state."
+        )
+        raise SystemExit(1)
+
+
+def fetch_sizes(r, keys):
+    sizes = []
+    for batch in chunked(keys, 500):
+        pipe = r.pipeline(transaction=False)
+        for k in batch:
+            pipe.memory_usage(k, samples=0)
+        sizes.extend(size or 0 for size in pipe.execute())
+    return sizes
+
+
+def summarize_candidates(sized, depth=1):
+    totals = {}
+    for key, _idle, size in sized:
+        prefix = key_prefix(key, depth)
+        count, total = totals.get(prefix, (0, 0))
+        totals[prefix] = (count + 1, total + size)
+    return sorted(
+        ((prefix, count, total) for prefix, (count, total) in totals.items()),
+        key=lambda row: row[2],
+        reverse=True,
+    )
+
+
+def delete_keys(r, keys, batch_size=500, throttle_seconds=0.05, on_progress=None):
+    deleted = 0
+    for batch in chunked(keys, batch_size):
+        deleted += r.unlink(*batch)
+        if on_progress:
+            on_progress(deleted)
+        if throttle_seconds:
+            time.sleep(throttle_seconds)
+    return deleted
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Find (and optionally UNLINK) keys with NO TTL idle longer than "
+        "a threshold. Dry-run unless --delete is given."
+    )
+    parser.add_argument("db", type=int, help="Redis database number to scan")
+    parser.add_argument("--idle-threshold", type=float, default=30,
+                        help="idle threshold in days (default 30)")
+    parser.add_argument("--match", default=None,
+                        help="optional SCAN MATCH glob, e.g. 'backfill*'")
+    parser.add_argument("--delete", action="store_true",
+                        help="actually delete candidates (default: dry-run)")
+    parser.add_argument("--yes", "-y", action="store_true",
+                        help="skip the confirmation prompt")
+    parser.add_argument("--batch-size", type=int, default=500,
+                        help="keys per UNLINK batch (default 500)")
+    parser.add_argument("--throttle", type=float, default=50,
+                        help="sleep between SCAN/UNLINK batches in ms (default 50)")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    validate_delete_args(args.delete, args.idle_threshold)
+    threshold_seconds = int(args.idle_threshold * DAY_SECONDS)
+    throttle_seconds = args.throttle / 1000.0
+    r = get_redis_from_env(args.db)
+
+    total = r.dbsize()
+    mode = "DELETE" if args.delete else "dry-run"
+    print(
+        f"db {args.db}: ~{total:,} keys; selecting no-TTL keys idle > "
+        f"{args.idle_threshold} days (match={args.match or '*'}) [{mode}]\n"
+    )
+
+    progress = {"scanned": 0, "start": time.time(), "last_print": 0.0}
+
+    def on_progress(n_batch, n_candidates):
+        progress["scanned"] += n_batch
+        now = time.time()
+        if now - progress["last_print"] >= 1.0:
+            elapsed = now - progress["start"]
+            rate = progress["scanned"] / elapsed if elapsed > 0 else 0
+            pct = (progress["scanned"] / total * 100) if total else 0
+            sys.stdout.write(
+                f"\rScanned {progress['scanned']:,}/{total:,} ({pct:.1f}%) "
+                f"| {rate:,.0f} keys/s | {n_candidates:,} candidates"
+            )
+            sys.stdout.flush()
+            progress["last_print"] = now
+
+    try:
+        candidates = find_stale_candidates(
+            r, threshold_seconds, match=args.match, throttle_seconds=throttle_seconds,
+            on_progress=on_progress,
+        )
+    except IdleTimeUnavailable as exc:
+        print(f"\n{exc}")
+        raise SystemExit(1)
+    sys.stdout.write("\n\n")
+
+    if not candidates:
+        print("No candidates found.")
+        return
+
+    print(f"Found {len(candidates):,} candidate keys. Sizing candidates...")
+    sizes = fetch_sizes(r, [k for k, _ in candidates])
+    sized = [(k, idle, size) for (k, idle), size in zip(candidates, sizes)]
+    total_bytes = sum(size for _, _, size in sized)
+
+    print(f"\nCandidate summary ({total_bytes / 1048576:.1f} MB total):")
+    print(f"{'prefix':<50} {'keys':>12} {'MB':>10}")
+    for prefix, count, nbytes in summarize_candidates(sized):
+        print(f"{prefix:<50} {count:>12,} {nbytes / 1048576:>10.1f}")
+
+    print("\nTop 20 largest candidates:")
+    for key, idle, size in sorted(sized, key=lambda row: row[2], reverse=True)[:20]:
+        print(f"{key.decode(errors='replace')}: {size:,} B, idle {idle // DAY_SECONDS} days")
+
+    if not args.delete:
+        print("\nDry-run complete; nothing deleted. Re-run with --delete to remove these keys.")
+        return
+
+    if not args.yes:
+        try:
+            confirm = input(f"\nUNLINK {len(candidates):,} keys from db {args.db}? [y/N] ")
+        except EOFError:
+            confirm = ""
+        if confirm.strip().lower() != "y":
+            print("Aborted.")
+            raise SystemExit(0)
+
+    print()
+    keys_to_delete = [k for k, _, _ in sized]
+    del_start = time.time()
+
+    def on_delete_progress(deleted):
+        elapsed = time.time() - del_start
+        rate = deleted / elapsed if elapsed > 0 else 0
+        pct = deleted / len(keys_to_delete) * 100
+        sys.stdout.write(
+            f"\rUnlinked {deleted:,}/{len(keys_to_delete):,} ({pct:.1f}%) | {rate:,.0f} keys/s"
+        )
+        sys.stdout.flush()
+
+    deleted = delete_keys(
+        r, keys_to_delete, batch_size=args.batch_size,
+        throttle_seconds=throttle_seconds, on_progress=on_delete_progress,
+    )
+    print(f"\n\nUnlinked {deleted:,} keys total.")
+
+
+if __name__ == "__main__":
+    main()

--- a/cdip_admin/scripts/redis_stale_key_cleaner.py
+++ b/cdip_admin/scripts/redis_stale_key_cleaner.py
@@ -20,6 +20,8 @@ from scripts.redis_ops_common import (
     get_redis_from_env,
     iter_key_batches,
     key_prefix,
+    non_negative_float,
+    positive_int,
 )
 
 MIN_DELETE_IDLE_DAYS = 2.0
@@ -106,28 +108,38 @@ def delete_keys(r, keys, batch_size=500, throttle_seconds=0.05, on_progress=None
     during which a key could be re-created with a TTL (e.g. a fresh
     dispatched_observation.* idempotency key). Re-checking TTL right before
     UNLINK closes that window: any key whose TTL is no longer -1 is dropped
-    rather than deleted. A key that vanished entirely (TTL == -2) is also
-    dropped — UNLINKing a gone key is harmless, but skipping it keeps the
-    skipped count meaningful.
+    rather than deleted.
 
-    Returns (deleted, skipped).
+    The two reasons for dropping a key are counted separately because they mean
+    different things to an operator: a key that gained a TTL is live again and
+    worth investigating, while a key that vanished (TTL == -2) expired or was
+    deleted by someone else and is unremarkable.
+
+    Returns (deleted, skipped_ttl, skipped_gone).
     """
     deleted = 0
-    skipped = 0
+    skipped_ttl = 0
+    skipped_gone = 0
     for batch in chunked(keys, batch_size):
         pipe = r.pipeline(transaction=False)
         for k in batch:
             pipe.ttl(k)
         ttls = pipe.execute()
-        to_delete = [k for k, ttl in zip(batch, ttls) if ttl == -1]
-        skipped += len(batch) - len(to_delete)
+        to_delete = []
+        for key, ttl in zip(batch, ttls):
+            if ttl == -1:
+                to_delete.append(key)
+            elif ttl == -2:
+                skipped_gone += 1
+            else:
+                skipped_ttl += 1
         if to_delete:
             deleted += r.unlink(*to_delete)
         if on_progress:
             on_progress(deleted)
         if throttle_seconds:
             time.sleep(throttle_seconds)
-    return deleted, skipped
+    return deleted, skipped_ttl, skipped_gone
 
 
 def parse_args():
@@ -144,9 +156,9 @@ def parse_args():
                         help="actually delete candidates (default: dry-run)")
     parser.add_argument("--yes", "-y", action="store_true",
                         help="skip the confirmation prompt")
-    parser.add_argument("--batch-size", type=int, default=500,
+    parser.add_argument("--batch-size", type=positive_int, default=500,
                         help="keys per UNLINK batch (default 500)")
-    parser.add_argument("--throttle", type=float, default=50,
+    parser.add_argument("--throttle", type=non_negative_float, default=50,
                         help="sleep between SCAN/UNLINK batches in ms (default 50)")
     return parser.parse_args()
 
@@ -235,13 +247,15 @@ def main():
         )
         sys.stdout.flush()
 
-    deleted, skipped = delete_keys(
+    deleted, skipped_ttl, skipped_gone = delete_keys(
         r, keys_to_delete, batch_size=args.batch_size,
         throttle_seconds=throttle_seconds, on_progress=on_delete_progress,
     )
     print(f"\n\nUnlinked {deleted:,} keys total.")
-    if skipped:
-        print(f"Skipped {skipped:,} keys that acquired a TTL since selection.")
+    if skipped_ttl:
+        print(f"Skipped {skipped_ttl:,} keys that acquired a TTL since selection.")
+    if skipped_gone:
+        print(f"Skipped {skipped_gone:,} keys that no longer existed.")
 
 
 if __name__ == "__main__":

--- a/cdip_admin/scripts/tests/test_redis_memory_profiler.py
+++ b/cdip_admin/scripts/tests/test_redis_memory_profiler.py
@@ -1,7 +1,10 @@
+from unittest.mock import Mock
+
 from scripts.redis_memory_profiler import (
     PrefixStats,
     aggregate_prefix_stats,
     format_stats_table,
+    print_overview,
 )
 
 STATS_TABLE = {
@@ -55,11 +58,6 @@ class TestFormatStatsTable:
         assert "8.0" in lines[1] and "50.0%" in lines[1]
         assert lines[2].startswith("small")
         assert "0.0%" in lines[2]
-
-
-from unittest.mock import Mock
-
-from scripts.redis_memory_profiler import print_overview
 
 
 class TestPrintOverview:

--- a/cdip_admin/scripts/tests/test_redis_memory_profiler.py
+++ b/cdip_admin/scripts/tests/test_redis_memory_profiler.py
@@ -1,0 +1,57 @@
+from scripts.redis_memory_profiler import (
+    PrefixStats,
+    aggregate_prefix_stats,
+    format_stats_table,
+)
+
+STATS_TABLE = {
+    b"disp.1.a": (100, 90000),      # (memory bytes, ttl seconds)
+    b"disp.2.b": (150, 90000),
+    b"backfill.9": (1000, -1),      # leaked: no TTL
+    b"gone.1": (None, -2),          # vanished mid-scan
+}
+
+
+def fake_fetcher(keys):
+    return [STATS_TABLE[k] for k in keys]
+
+
+class TestAggregatePrefixStats:
+    def test_aggregates_counts_bytes_and_no_ttl_by_prefix(self):
+        batches = [[b"disp.1.a", b"disp.2.b"], [b"backfill.9"]]
+        stats = aggregate_prefix_stats(batches, fake_fetcher)
+        assert stats["disp"] == PrefixStats(count=2, total_bytes=250, no_ttl_count=0)
+        assert stats["backfill"] == PrefixStats(count=1, total_bytes=1000, no_ttl_count=1)
+
+    def test_key_gone_mid_scan_is_skipped(self):
+        stats = aggregate_prefix_stats([[b"gone.1", b"backfill.9"]], fake_fetcher)
+        assert "gone" not in stats
+        assert stats["backfill"].count == 1
+
+    def test_nil_memory_usage_counts_as_zero_bytes(self):
+        def fetcher(keys):
+            return [(None, -1)]
+        stats = aggregate_prefix_stats([[b"backfill.9"]], fetcher)
+        assert stats["backfill"] == PrefixStats(count=1, total_bytes=0, no_ttl_count=1)
+
+    def test_on_batch_reports_progress(self):
+        seen = []
+        aggregate_prefix_stats(
+            [[b"disp.1.a", b"disp.2.b"], [b"backfill.9"]], fake_fetcher, on_batch=seen.append
+        )
+        assert seen == [2, 1]
+
+
+class TestFormatStatsTable:
+    def test_rows_sorted_by_total_bytes_desc_with_leak_column(self):
+        stats = {
+            "small": PrefixStats(count=10, total_bytes=1000, no_ttl_count=0),
+            "big": PrefixStats(count=4, total_bytes=8 * 1048576, no_ttl_count=2),
+        }
+        out = format_stats_table(stats)
+        lines = out.splitlines()
+        assert "prefix" in lines[0] and "% no-TTL" in lines[0]
+        assert lines[1].startswith("big")
+        assert "8.0" in lines[1] and "50.0%" in lines[1]
+        assert lines[2].startswith("small")
+        assert "0.0%" in lines[2]

--- a/cdip_admin/scripts/tests/test_redis_memory_profiler.py
+++ b/cdip_admin/scripts/tests/test_redis_memory_profiler.py
@@ -83,3 +83,28 @@ class TestPrintOverview:
         out = capsys.readouterr().out
         assert "used_memory" in out
         assert "db0" in out
+
+    def test_databases_are_ordered_numerically_not_lexicographically(self, capsys):
+        sections = {
+            "memory": {
+                "used_memory_human": "100.5M",
+                "maxmemory_human": "1.0G",
+                "maxmemory": 1073741824,
+                "maxmemory_policy": "noeviction",
+                "mem_fragmentation_ratio": 1.05,
+            },
+            "keyspace": {
+                "db10": {"keys": 10, "expires": 0, "avg_ttl": 0},
+                "db2": {"keys": 2, "expires": 0, "avg_ttl": 0},
+                "db0": {"keys": 1, "expires": 0, "avg_ttl": 0},
+            },
+        }
+        r = Mock()
+        r.info.side_effect = lambda section: sections[section]
+        print_overview(r)
+        db_lines = [
+            line.split(":")[0]
+            for line in capsys.readouterr().out.splitlines()
+            if line.startswith("db")
+        ]
+        assert db_lines == ["db0", "db2", "db10"]

--- a/cdip_admin/scripts/tests/test_redis_memory_profiler.py
+++ b/cdip_admin/scripts/tests/test_redis_memory_profiler.py
@@ -55,3 +55,33 @@ class TestFormatStatsTable:
         assert "8.0" in lines[1] and "50.0%" in lines[1]
         assert lines[2].startswith("small")
         assert "0.0%" in lines[2]
+
+
+from unittest.mock import Mock
+
+from scripts.redis_memory_profiler import print_overview
+
+
+class TestPrintOverview:
+    def test_prints_memory_and_keyspace_sections(self, capsys):
+        r = Mock()
+        r.info.side_effect = [
+            {
+                "used_memory_human": "100.5M",
+                "maxmemory_human": "1.0G",
+                "maxmemory": 1073741824,
+                "maxmemory_policy": "allkeys-lru",
+                "mem_fragmentation_ratio": 1.05,
+            },
+            {
+                "db0": {
+                    "keys": 1000,
+                    "expires": 500,
+                    "avg_ttl": 3600000,
+                }
+            }
+        ]
+        print_overview(r)
+        out = capsys.readouterr().out
+        assert "used_memory" in out
+        assert "db0" in out

--- a/cdip_admin/scripts/tests/test_redis_ops_common.py
+++ b/cdip_admin/scripts/tests/test_redis_ops_common.py
@@ -1,0 +1,75 @@
+import fakeredis
+import pytest
+
+from scripts.redis_ops_common import (
+    chunked,
+    get_redis_from_env,
+    iter_key_batches,
+    key_prefix,
+)
+
+
+class TestKeyPrefix:
+    def test_dot_separated_key_buckets_to_first_segment(self):
+        assert key_prefix(b"dispatched_observation.0a1b.9f8e") == "dispatched_observation"
+
+    def test_colon_separated_key(self):
+        assert key_prefix(b"backfill:job:123") == "backfill"
+
+    def test_depth_two_joins_first_two_segments(self):
+        assert key_prefix(b"backfill.movebank.123", depth=2) == "backfill.movebank"
+
+    def test_key_without_separator_is_its_own_prefix(self):
+        assert key_prefix(b"celery") == "celery"
+
+    def test_undecodable_bytes_do_not_crash(self):
+        assert key_prefix(b"\xff\xfe.tail") == "��"
+
+
+class TestChunked:
+    def test_splits_into_batches_of_size(self):
+        assert list(chunked([1, 2, 3, 4, 5], 2)) == [[1, 2], [3, 4], [5]]
+
+    def test_empty_list_yields_nothing(self):
+        assert list(chunked([], 10)) == []
+
+
+class TestGetRedisFromEnv:
+    def test_missing_host_exits(self, monkeypatch):
+        monkeypatch.delenv("REDIS_HOST", raising=False)
+        with pytest.raises(SystemExit):
+            get_redis_from_env(0)
+
+    def test_non_integer_port_exits(self, monkeypatch):
+        monkeypatch.setenv("REDIS_HOST", "localhost")
+        monkeypatch.setenv("REDIS_PORT", "not-a-port")
+        with pytest.raises(SystemExit):
+            get_redis_from_env(0)
+
+    def test_valid_env_returns_client(self, monkeypatch):
+        monkeypatch.setenv("REDIS_HOST", "localhost")
+        monkeypatch.setenv("REDIS_PORT", "6390")
+        client = get_redis_from_env(3)
+        kwargs = client.connection_pool.connection_kwargs
+        assert (kwargs["host"], kwargs["port"], kwargs["db"]) == ("localhost", 6390, 3)
+
+
+class TestIterKeyBatches:
+    def _seeded(self):
+        r = fakeredis.FakeRedis()
+        for i in range(25):
+            r.set(f"prefix.{i}", "x")
+        r.set("other.key", "x")
+        return r
+
+    def test_yields_all_keys_across_batches(self):
+        r = self._seeded()
+        seen = [k for batch in iter_key_batches(r, count=10, throttle_seconds=0) for k in batch]
+        assert len(seen) == 26
+        assert set(seen) == set(r.keys("*"))
+
+    def test_match_filters_keys(self):
+        r = self._seeded()
+        seen = [k for batch in iter_key_batches(r, match="prefix.*", count=10, throttle_seconds=0) for k in batch]
+        assert len(seen) == 25
+        assert all(k.startswith(b"prefix.") for k in seen)

--- a/cdip_admin/scripts/tests/test_redis_ops_common.py
+++ b/cdip_admin/scripts/tests/test_redis_ops_common.py
@@ -1,3 +1,5 @@
+import argparse
+
 import fakeredis
 import pytest
 
@@ -6,7 +8,28 @@ from scripts.redis_ops_common import (
     get_redis_from_env,
     iter_key_batches,
     key_prefix,
+    non_negative_float,
+    positive_int,
 )
+
+
+class TestArgTypes:
+    def test_positive_int_accepts_one_and_above(self):
+        assert positive_int("1") == 1
+        assert positive_int("500") == 500
+
+    @pytest.mark.parametrize("value", ["0", "-1"])
+    def test_positive_int_rejects_zero_and_negative(self, value):
+        with pytest.raises(argparse.ArgumentTypeError, match="1 or greater"):
+            positive_int(value)
+
+    def test_non_negative_float_accepts_zero_and_above(self):
+        assert non_negative_float("0") == 0.0
+        assert non_negative_float("50") == 50.0
+
+    def test_non_negative_float_rejects_negative(self):
+        with pytest.raises(argparse.ArgumentTypeError, match="0 or greater"):
+            non_negative_float("-0.5")
 
 
 class TestKeyPrefix:

--- a/cdip_admin/scripts/tests/test_redis_stale_key_cleaner.py
+++ b/cdip_admin/scripts/tests/test_redis_stale_key_cleaner.py
@@ -1,0 +1,87 @@
+import fakeredis
+import pytest
+import redis
+
+from scripts.redis_stale_key_cleaner import (
+    IdleTimeUnavailable,
+    fetch_idle_times,
+    find_stale_candidates,
+)
+
+DAY = 86400
+
+
+def _seeded():
+    r = fakeredis.FakeRedis()
+    r.set("backfill.old", "x")                                   # no TTL, idle 40d
+    r.set("backfill.recent", "x")                                # no TTL, idle 1d
+    r.set("dispatched_observation.a.b", "x", ex=25 * 3600)       # has TTL, idle 40d
+    idle = {
+        b"backfill.old": 40 * DAY,
+        b"backfill.recent": 1 * DAY,
+        b"dispatched_observation.a.b": 40 * DAY,
+    }
+    return r, lambda _r, keys: [idle[k] for k in keys]
+
+
+class TestFindStaleCandidates:
+    def test_only_no_ttl_keys_over_threshold_are_candidates(self):
+        r, idle_fetcher = _seeded()
+        cands = find_stale_candidates(
+            r, idle_threshold_seconds=30 * DAY, idle_fetcher=idle_fetcher, throttle_seconds=0
+        )
+        assert cands == [(b"backfill.old", 40 * DAY)]
+
+    def test_key_with_ttl_is_never_a_candidate_even_when_idle(self):
+        r, idle_fetcher = _seeded()
+        cands = find_stale_candidates(
+            r, idle_threshold_seconds=1, idle_fetcher=idle_fetcher, throttle_seconds=0
+        )
+        assert all(not k.startswith(b"dispatched_observation") for k, _ in cands)
+
+    def test_match_constrains_scan(self):
+        r, idle_fetcher = _seeded()
+        r.set("other.old", "x")
+        cands = find_stale_candidates(
+            r, idle_threshold_seconds=1, match="backfill*",
+            idle_fetcher=idle_fetcher, throttle_seconds=0,
+        )
+        assert {k for k, _ in cands} == {b"backfill.old", b"backfill.recent"}
+
+    def test_idle_fetcher_error_propagates(self):
+        r, _ = _seeded()
+
+        def boom(_r, keys):
+            raise IdleTimeUnavailable("no idle times")
+
+        with pytest.raises(IdleTimeUnavailable):
+            find_stale_candidates(
+                r, idle_threshold_seconds=1, idle_fetcher=boom, throttle_seconds=0
+            )
+
+    def test_on_progress_reports_totals(self):
+        r, idle_fetcher = _seeded()
+        calls = []
+        find_stale_candidates(
+            r, idle_threshold_seconds=30 * DAY, idle_fetcher=idle_fetcher,
+            throttle_seconds=0, on_progress=lambda n, c: calls.append((n, c)),
+        )
+        assert sum(n for n, _ in calls) == 3
+        assert calls[-1][1] == 1
+
+
+class TestFetchIdleTimes:
+    def test_response_error_raises_idle_time_unavailable(self, monkeypatch):
+        r = fakeredis.FakeRedis()
+        r.set("k", "v")
+
+        class BoomPipe:
+            def execute_command(self, *args):
+                return self
+
+            def execute(self):
+                raise redis.exceptions.ResponseError("An LFU maxmemory policy is selected")
+
+        monkeypatch.setattr(r, "pipeline", lambda transaction=False: BoomPipe())
+        with pytest.raises(IdleTimeUnavailable, match="OBJECT IDLETIME failed"):
+            fetch_idle_times(r, [b"k"])

--- a/cdip_admin/scripts/tests/test_redis_stale_key_cleaner.py
+++ b/cdip_admin/scripts/tests/test_redis_stale_key_cleaner.py
@@ -129,10 +129,11 @@ class TestDeleteKeys:
             keys.append(f"stale.{i}".encode())
         r.set("keep.me", "x")
         progress = []
-        deleted, skipped = delete_keys(r, keys, batch_size=3, throttle_seconds=0,
-                              on_progress=progress.append)
+        deleted, skipped_ttl, skipped_gone = delete_keys(
+            r, keys, batch_size=3, throttle_seconds=0, on_progress=progress.append
+        )
         assert deleted == 10
-        assert skipped == 0
+        assert (skipped_ttl, skipped_gone) == (0, 0)
         assert r.dbsize() == 1
         assert progress[-1] == 10
 
@@ -149,11 +150,32 @@ class TestDeleteKeys:
         r.set("armed.key", "x", ex=3600)
         keys.append(b"armed.key")
 
-        deleted, skipped = delete_keys(r, keys, batch_size=10, throttle_seconds=0)
+        deleted, skipped_ttl, skipped_gone = delete_keys(
+            r, keys, batch_size=10, throttle_seconds=0
+        )
 
         assert deleted == 5
-        assert skipped == 1
+        assert skipped_ttl == 1
+        assert skipped_gone == 0
         assert r.exists(b"armed.key") == 1
         assert r.ttl(b"armed.key") > 0
         for i in range(5):
             assert r.exists(f"stale.{i}".encode()) == 0
+
+    def test_vanished_key_is_counted_separately_from_one_that_gained_a_ttl(self):
+        # A key deleted or expired between selection and UNLINK reports TTL -2.
+        # That is unremarkable, so it must not be reported as having acquired a
+        # TTL — the two counts mean different things to an operator.
+        r = fakeredis.FakeRedis()
+        r.set("stale.1", "x")
+        r.set("armed.key", "x", ex=3600)
+        keys = [b"stale.1", b"armed.key", b"never.existed"]
+
+        deleted, skipped_ttl, skipped_gone = delete_keys(
+            r, keys, batch_size=10, throttle_seconds=0
+        )
+
+        assert deleted == 1
+        assert skipped_ttl == 1
+        assert skipped_gone == 1
+        assert r.exists(b"armed.key") == 1

--- a/cdip_admin/scripts/tests/test_redis_stale_key_cleaner.py
+++ b/cdip_admin/scripts/tests/test_redis_stale_key_cleaner.py
@@ -85,3 +85,52 @@ class TestFetchIdleTimes:
         monkeypatch.setattr(r, "pipeline", lambda transaction=False: BoomPipe())
         with pytest.raises(IdleTimeUnavailable, match="OBJECT IDLETIME failed"):
             fetch_idle_times(r, [b"k"])
+
+
+from scripts.redis_stale_key_cleaner import (
+    MIN_DELETE_IDLE_DAYS,
+    delete_keys,
+    summarize_candidates,
+    validate_delete_args,
+)
+
+
+class TestValidateDeleteArgs:
+    def test_delete_below_floor_is_refused(self):
+        with pytest.raises(SystemExit):
+            validate_delete_args(delete=True, idle_threshold_days=1.9)
+
+    def test_delete_at_floor_is_allowed(self):
+        validate_delete_args(delete=True, idle_threshold_days=MIN_DELETE_IDLE_DAYS)
+
+    def test_dry_run_below_floor_is_allowed(self):
+        validate_delete_args(delete=False, idle_threshold_days=0.1)
+
+
+class TestSummarizeCandidates:
+    def test_groups_by_prefix_sorted_by_bytes_desc(self):
+        sized = [
+            (b"backfill.1", 40 * DAY, 100),
+            (b"backfill.2", 41 * DAY, 300),
+            (b"backfill_watermark.9", 50 * DAY, 5000),
+        ]
+        assert summarize_candidates(sized) == [
+            ("backfill_watermark", 1, 5000),
+            ("backfill", 2, 400),
+        ]
+
+
+class TestDeleteKeys:
+    def test_unlinks_all_keys_in_batches_and_reports_progress(self):
+        r = fakeredis.FakeRedis()
+        keys = []
+        for i in range(10):
+            r.set(f"stale.{i}", "x")
+            keys.append(f"stale.{i}".encode())
+        r.set("keep.me", "x")
+        progress = []
+        deleted = delete_keys(r, keys, batch_size=3, throttle_seconds=0,
+                              on_progress=progress.append)
+        assert deleted == 10
+        assert r.dbsize() == 1
+        assert progress[-1] == 10

--- a/cdip_admin/scripts/tests/test_redis_stale_key_cleaner.py
+++ b/cdip_admin/scripts/tests/test_redis_stale_key_cleaner.py
@@ -129,8 +129,31 @@ class TestDeleteKeys:
             keys.append(f"stale.{i}".encode())
         r.set("keep.me", "x")
         progress = []
-        deleted = delete_keys(r, keys, batch_size=3, throttle_seconds=0,
+        deleted, skipped = delete_keys(r, keys, batch_size=3, throttle_seconds=0,
                               on_progress=progress.append)
         assert deleted == 10
+        assert skipped == 0
         assert r.dbsize() == 1
         assert progress[-1] == 10
+
+    def test_key_that_acquired_ttl_since_selection_is_skipped(self):
+        # A candidate key can be re-created with a TTL between selection and
+        # UNLINK (e.g. a long interactive confirm prompt). delete_keys must
+        # re-check TTL immediately before UNLINK and drop such keys rather
+        # than deleting them.
+        r = fakeredis.FakeRedis()
+        keys = []
+        for i in range(5):
+            r.set(f"stale.{i}", "x")
+            keys.append(f"stale.{i}".encode())
+        r.set("armed.key", "x", ex=3600)
+        keys.append(b"armed.key")
+
+        deleted, skipped = delete_keys(r, keys, batch_size=10, throttle_seconds=0)
+
+        assert deleted == 5
+        assert skipped == 1
+        assert r.exists(b"armed.key") == 1
+        assert r.ttl(b"armed.key") > 0
+        for i in range(5):
+            assert r.exists(f"stale.{i}".encode()) == 0

--- a/dependencies/requirements-dev.in
+++ b/dependencies/requirements-dev.in
@@ -9,4 +9,4 @@ pre-commit==3.2.0
 pytest-mock==3.10.0
 requests-mock==1.12.1
 freezegun==1.5.1
-fakeredis
+fakeredis==2.37.0

--- a/dependencies/requirements-dev.in
+++ b/dependencies/requirements-dev.in
@@ -9,3 +9,4 @@ pre-commit==3.2.0
 pytest-mock==3.10.0
 requests-mock==1.12.1
 freezegun==1.5.1
+fakeredis

--- a/docs/superpowers/plans/2026-08-04-redis-prod-cleanup-scripts.md
+++ b/docs/superpowers/plans/2026-08-04-redis-prod-cleanup-scripts.md
@@ -1,0 +1,1033 @@
+# Prod Redis Profiler & Stale-Key Cleaner Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Two standalone CLI scripts — a read-only Redis memory profiler and a safety-railed stale-key cleaner — for trimming the ER dispatcher's production Redis (phase 1 of `docs/superpowers/specs/2026-08-04-redis-prod-cleanup-design.md`).
+
+**Architecture:** A small shared helpers module (`redis_ops_common.py`) plus two CLI scripts in `cdip_admin/scripts/`. All Redis-touching logic is factored into functions that accept injectable fetcher callables so unit tests can run on `fakeredis` (which doesn't implement `OBJECT IDLETIME`, and whose `MEMORY USAGE` support we don't rely on).
+
+**Tech Stack:** Python 3.10+, `redis` 6.4.0 (already pinned), `fakeredis` (new dev dep), pytest (repo convention: run from `cdip_admin/` with the venv at `<repo>/.venv`).
+
+## Global Constraints
+
+- Scripts live in `cdip_admin/scripts/`, import nothing from Django, and read `REDIS_HOST` (required) / `REDIS_PORT` (default `6379`) from the environment.
+- Cleaner candidate rule (spec §Cleaner): key is a candidate **only if `TTL == -1` AND `OBJECT IDLETIME > threshold`**. Keys with any TTL are NEVER candidates.
+- Dry-run is the cleaner's default; deletion requires explicit `--delete`.
+- Hard floor: `--delete` with `--idle-threshold < 2` (days) must be refused (exit 1).
+- Deletion uses `UNLINK` (never `DEL`), in batches (default 500), throttled.
+- If `OBJECT IDLETIME` errors (e.g. LFU maxmemory-policy), abort with a clear message — never treat idle as 0.
+- Keys gone mid-scan (`TTL == -2`, or nil `MEMORY USAGE`): skip silently / treat as 0 bytes.
+- SCAN loops sleep between batches (`--throttle`, default 50 ms).
+- Tests: `fakeredis` under `cdip_admin/scripts/tests/`; idle-time and (for aggregation) stats fetchers are injected in tests.
+- Dependencies via pip-compile: edit `dependencies/requirements-dev.in`, then from repo root run `pip-compile --output-file=dependencies/requirements-dev.txt dependencies/requirements-dev.in dependencies/requirements.in`.
+- Run tests as: `cd cdip_admin && ../.venv/bin/pytest scripts/tests/... -v` (pytest-django loads `cdip_admin.local_settings`; these tests never touch the DB, so no DB env overrides are needed).
+- Commit after each task with a `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` trailer.
+
+---
+
+### Task 1: Dev dependency + shared helpers module
+
+**Files:**
+- Modify: `dependencies/requirements-dev.in` (add `fakeredis`)
+- Modify: `dependencies/requirements-dev.txt` (via pip-compile)
+- Create: `cdip_admin/scripts/tests/__init__.py` (empty)
+- Create: `cdip_admin/scripts/tests/test_redis_ops_common.py`
+- Create: `cdip_admin/scripts/redis_ops_common.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces (used by Tasks 2–5):
+  - `get_redis_from_env(db: int) -> redis.Redis` — raises `SystemExit(1)` with a printed error if `REDIS_HOST` unset or `REDIS_PORT` non-integer.
+  - `key_prefix(key: bytes, depth: int = 1) -> str` — first `depth` segments split on `.`/`:`, joined with `.`; undecodable bytes replaced.
+  - `chunked(items: list, size: int)` — generator of lists of ≤ `size` items.
+  - `iter_key_batches(r, match=None, count=500, throttle_seconds=0.05)` — generator yielding non-empty key batches from SCAN, sleeping `throttle_seconds` between iterations.
+
+- [ ] **Step 1: Add fakeredis to dev requirements and install it**
+
+Append to `dependencies/requirements-dev.in`:
+
+```
+fakeredis
+```
+
+Then from the repo root:
+
+```bash
+.venv/bin/pip install pip-tools 2>/dev/null; .venv/bin/pip-compile --output-file=dependencies/requirements-dev.txt dependencies/requirements-dev.in dependencies/requirements.in
+.venv/bin/pip install fakeredis
+```
+
+(If `pip-compile` is unavailable or errors on unrelated pins, still `pip install fakeredis` so tests run, and note the compile problem in the commit message.)
+
+- [ ] **Step 2: Create the test package and write failing tests**
+
+Create empty `cdip_admin/scripts/tests/__init__.py`, then `cdip_admin/scripts/tests/test_redis_ops_common.py`:
+
+```python
+import fakeredis
+import pytest
+
+from scripts.redis_ops_common import (
+    chunked,
+    get_redis_from_env,
+    iter_key_batches,
+    key_prefix,
+)
+
+
+class TestKeyPrefix:
+    def test_dot_separated_key_buckets_to_first_segment(self):
+        assert key_prefix(b"dispatched_observation.0a1b.9f8e") == "dispatched_observation"
+
+    def test_colon_separated_key(self):
+        assert key_prefix(b"backfill:job:123") == "backfill"
+
+    def test_depth_two_joins_first_two_segments(self):
+        assert key_prefix(b"backfill.movebank.123", depth=2) == "backfill.movebank"
+
+    def test_key_without_separator_is_its_own_prefix(self):
+        assert key_prefix(b"celery") == "celery"
+
+    def test_undecodable_bytes_do_not_crash(self):
+        assert key_prefix(b"\xff\xfe.tail") == "��"
+
+
+class TestChunked:
+    def test_splits_into_batches_of_size(self):
+        assert list(chunked([1, 2, 3, 4, 5], 2)) == [[1, 2], [3, 4], [5]]
+
+    def test_empty_list_yields_nothing(self):
+        assert list(chunked([], 10)) == []
+
+
+class TestGetRedisFromEnv:
+    def test_missing_host_exits(self, monkeypatch):
+        monkeypatch.delenv("REDIS_HOST", raising=False)
+        with pytest.raises(SystemExit):
+            get_redis_from_env(0)
+
+    def test_non_integer_port_exits(self, monkeypatch):
+        monkeypatch.setenv("REDIS_HOST", "localhost")
+        monkeypatch.setenv("REDIS_PORT", "not-a-port")
+        with pytest.raises(SystemExit):
+            get_redis_from_env(0)
+
+    def test_valid_env_returns_client(self, monkeypatch):
+        monkeypatch.setenv("REDIS_HOST", "localhost")
+        monkeypatch.setenv("REDIS_PORT", "6390")
+        client = get_redis_from_env(3)
+        kwargs = client.connection_pool.connection_kwargs
+        assert (kwargs["host"], kwargs["port"], kwargs["db"]) == ("localhost", 6390, 3)
+
+
+class TestIterKeyBatches:
+    def _seeded(self):
+        r = fakeredis.FakeRedis()
+        for i in range(25):
+            r.set(f"prefix.{i}", "x")
+        r.set("other.key", "x")
+        return r
+
+    def test_yields_all_keys_across_batches(self):
+        r = self._seeded()
+        seen = [k for batch in iter_key_batches(r, count=10, throttle_seconds=0) for k in batch]
+        assert len(seen) == 26
+        assert set(seen) == set(r.keys("*"))
+
+    def test_match_filters_keys(self):
+        r = self._seeded()
+        seen = [k for batch in iter_key_batches(r, match="prefix.*", count=10, throttle_seconds=0) for k in batch]
+        assert len(seen) == 25
+        assert all(k.startswith(b"prefix.") for k in seen)
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd cdip_admin && ../.venv/bin/pytest scripts/tests/test_redis_ops_common.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'scripts.redis_ops_common'`
+
+- [ ] **Step 4: Implement the module**
+
+Create `cdip_admin/scripts/redis_ops_common.py`:
+
+```python
+"""Shared helpers for the standalone Redis ops scripts. No Django dependency."""
+import os
+import re
+import time
+
+import redis
+
+_SEPARATORS = re.compile(r"[.:]")
+
+
+def get_redis_from_env(db):
+    """Build a client from REDIS_HOST (required) and REDIS_PORT (default 6379)."""
+    host = os.environ.get("REDIS_HOST")
+    if not host:
+        print("Error: REDIS_HOST environment variable is not set")
+        raise SystemExit(1)
+    port_str = os.environ.get("REDIS_PORT", "6379")
+    try:
+        port = int(port_str)
+    except ValueError:
+        print(f"Error: REDIS_PORT must be an integer, got '{port_str}'")
+        raise SystemExit(1)
+    return redis.Redis(host=host, port=port, db=db)
+
+
+def key_prefix(key, depth=1):
+    """Bucket a key by its first `depth` segments, splitting on '.' and ':'."""
+    parts = _SEPARATORS.split(key.decode(errors="replace"))
+    return ".".join(parts[:depth])
+
+
+def chunked(items, size):
+    for i in range(0, len(items), size):
+        yield items[i:i + size]
+
+
+def iter_key_batches(r, match=None, count=500, throttle_seconds=0.05):
+    """Yield batches of keys via SCAN, sleeping between iterations to cap server load."""
+    cursor = 0
+    while True:
+        cursor, keys = r.scan(cursor, match=match, count=count)
+        if keys:
+            yield keys
+        if cursor == 0:
+            return
+        if throttle_seconds:
+            time.sleep(throttle_seconds)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd cdip_admin && ../.venv/bin/pytest scripts/tests/test_redis_ops_common.py -v`
+Expected: PASS (all)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dependencies/requirements-dev.in dependencies/requirements-dev.txt \
+  cdip_admin/scripts/tests/__init__.py cdip_admin/scripts/tests/test_redis_ops_common.py \
+  cdip_admin/scripts/redis_ops_common.py
+git commit -m "Add fakeredis dev dep and shared helpers for Redis ops scripts"
+```
+
+---
+
+### Task 2: Profiler aggregation logic
+
+**Files:**
+- Create: `cdip_admin/scripts/redis_memory_profiler.py` (logic only; CLI comes in Task 3)
+- Create: `cdip_admin/scripts/tests/test_redis_memory_profiler.py`
+
+**Interfaces:**
+- Consumes: `key_prefix` from `scripts.redis_ops_common`.
+- Produces (used by Task 3):
+  - `PrefixStats` dataclass: fields `count: int = 0`, `total_bytes: int = 0`, `no_ttl_count: int = 0`.
+  - `fetch_key_stats(r, keys) -> list[tuple[int | None, int]]` — pipelined `(MEMORY USAGE samples=0, TTL)` per key, order-aligned with `keys`.
+  - `aggregate_prefix_stats(key_batches, stats_fetcher, depth=1, on_batch=None) -> dict[str, PrefixStats]` — `stats_fetcher(keys)` must return what `fetch_key_stats` returns; `on_batch(n_keys)` called per batch.
+  - `format_stats_table(stats: dict[str, PrefixStats]) -> str` — rows sorted by `total_bytes` desc with columns: prefix, keys, MB, avg B, % no-TTL.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `cdip_admin/scripts/tests/test_redis_memory_profiler.py`:
+
+```python
+from scripts.redis_memory_profiler import (
+    PrefixStats,
+    aggregate_prefix_stats,
+    format_stats_table,
+)
+
+STATS_TABLE = {
+    b"disp.1.a": (100, 90000),      # (memory bytes, ttl seconds)
+    b"disp.2.b": (150, 90000),
+    b"backfill.9": (1000, -1),      # leaked: no TTL
+    b"gone.1": (None, -2),          # vanished mid-scan
+}
+
+
+def fake_fetcher(keys):
+    return [STATS_TABLE[k] for k in keys]
+
+
+class TestAggregatePrefixStats:
+    def test_aggregates_counts_bytes_and_no_ttl_by_prefix(self):
+        batches = [[b"disp.1.a", b"disp.2.b"], [b"backfill.9"]]
+        stats = aggregate_prefix_stats(batches, fake_fetcher)
+        assert stats["disp"] == PrefixStats(count=2, total_bytes=250, no_ttl_count=0)
+        assert stats["backfill"] == PrefixStats(count=1, total_bytes=1000, no_ttl_count=1)
+
+    def test_key_gone_mid_scan_is_skipped(self):
+        stats = aggregate_prefix_stats([[b"gone.1", b"backfill.9"]], fake_fetcher)
+        assert "gone" not in stats
+        assert stats["backfill"].count == 1
+
+    def test_nil_memory_usage_counts_as_zero_bytes(self):
+        def fetcher(keys):
+            return [(None, -1)]
+        stats = aggregate_prefix_stats([[b"backfill.9"]], fetcher)
+        assert stats["backfill"] == PrefixStats(count=1, total_bytes=0, no_ttl_count=1)
+
+    def test_on_batch_reports_progress(self):
+        seen = []
+        aggregate_prefix_stats(
+            [[b"disp.1.a", b"disp.2.b"], [b"backfill.9"]], fake_fetcher, on_batch=seen.append
+        )
+        assert seen == [2, 1]
+
+
+class TestFormatStatsTable:
+    def test_rows_sorted_by_total_bytes_desc_with_leak_column(self):
+        stats = {
+            "small": PrefixStats(count=10, total_bytes=1000, no_ttl_count=0),
+            "big": PrefixStats(count=4, total_bytes=8 * 1048576, no_ttl_count=2),
+        }
+        out = format_stats_table(stats)
+        lines = out.splitlines()
+        assert "prefix" in lines[0] and "% no-TTL" in lines[0]
+        assert lines[1].startswith("big")
+        assert "8.0" in lines[1] and "50.0%" in lines[1]
+        assert lines[2].startswith("small")
+        assert "0.0%" in lines[2]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd cdip_admin && ../.venv/bin/pytest scripts/tests/test_redis_memory_profiler.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'scripts.redis_memory_profiler'`
+
+- [ ] **Step 3: Implement the logic**
+
+Create `cdip_admin/scripts/redis_memory_profiler.py`:
+
+```python
+"""Read-only memory profiler for a Redis instance: per-db overview plus
+per-key-prefix memory/count/no-TTL breakdown. Never writes or deletes.
+
+Usage:
+    REDIS_HOST=... python redis_memory_profiler.py            # overview only
+    REDIS_HOST=... python redis_memory_profiler.py 0 --depth 1
+"""
+import argparse
+import sys
+import time
+from collections import defaultdict
+from dataclasses import dataclass
+
+from scripts.redis_ops_common import get_redis_from_env, iter_key_batches, key_prefix
+
+
+@dataclass
+class PrefixStats:
+    count: int = 0
+    total_bytes: int = 0
+    no_ttl_count: int = 0
+
+
+def fetch_key_stats(r, keys):
+    """Pipelined (MEMORY USAGE, TTL) per key. Memory is None if the key vanished."""
+    pipe = r.pipeline(transaction=False)
+    for k in keys:
+        pipe.memory_usage(k, samples=0)
+    for k in keys:
+        pipe.ttl(k)
+    results = pipe.execute()
+    return list(zip(results[: len(keys)], results[len(keys):]))
+
+
+def aggregate_prefix_stats(key_batches, stats_fetcher, depth=1, on_batch=None):
+    stats = defaultdict(PrefixStats)
+    for keys in key_batches:
+        for key, (mem, ttl) in zip(keys, stats_fetcher(keys)):
+            if ttl == -2:  # key expired/deleted mid-scan
+                continue
+            s = stats[key_prefix(key, depth)]
+            s.count += 1
+            s.total_bytes += mem or 0
+            if ttl == -1:
+                s.no_ttl_count += 1
+        if on_batch:
+            on_batch(len(keys))
+    return dict(stats)
+
+
+def format_stats_table(stats):
+    rows = sorted(stats.items(), key=lambda kv: kv[1].total_bytes, reverse=True)
+    lines = [f"{'prefix':<50} {'keys':>12} {'MB':>10} {'avg B':>8} {'% no-TTL':>9}"]
+    for prefix, s in rows:
+        avg = s.total_bytes // s.count if s.count else 0
+        pct = (s.no_ttl_count / s.count * 100) if s.count else 0.0
+        lines.append(
+            f"{prefix:<50} {s.count:>12,} {s.total_bytes / 1048576:>10.1f} "
+            f"{avg:>8,} {pct:>8.1f}%"
+        )
+    return "\n".join(lines)
+```
+
+(CLI `main()` is added in Task 3 — this task delivers importable, tested logic.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd cdip_admin && ../.venv/bin/pytest scripts/tests/test_redis_memory_profiler.py -v`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cdip_admin/scripts/redis_memory_profiler.py cdip_admin/scripts/tests/test_redis_memory_profiler.py
+git commit -m "Add prefix-aggregation logic for Redis memory profiler"
+```
+
+---
+
+### Task 3: Profiler CLI (overview + progress + wiring)
+
+**Files:**
+- Modify: `cdip_admin/scripts/redis_memory_profiler.py` (append `print_overview`, `parse_args`, `main`)
+- Modify: `cdip_admin/scripts/tests/test_redis_memory_profiler.py` (append overview test)
+
+**Interfaces:**
+- Consumes: Task 2's functions; `get_redis_from_env`, `iter_key_batches` from common.
+- Produces: `python redis_memory_profiler.py [db] [--depth N] [--scan-count N] [--throttle MS]` CLI; `print_overview(r)` printing INFO memory highlights + INFO keyspace.
+
+- [ ] **Step 1: Write failing test for the overview**
+
+Append to `cdip_admin/scripts/tests/test_redis_memory_profiler.py`:
+
+```python
+import fakeredis
+
+from scripts.redis_memory_profiler import print_overview
+
+
+class TestPrintOverview:
+    def test_prints_memory_and_keyspace_sections(self, capsys):
+        r = fakeredis.FakeRedis()
+        r.set("a", "x")
+        print_overview(r)
+        out = capsys.readouterr().out
+        assert "used_memory" in out
+        assert "db0" in out
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd cdip_admin && ../.venv/bin/pytest scripts/tests/test_redis_memory_profiler.py::TestPrintOverview -v`
+Expected: FAIL — `ImportError: cannot import name 'print_overview'`
+
+- [ ] **Step 3: Implement overview and CLI**
+
+Append to `cdip_admin/scripts/redis_memory_profiler.py`:
+
+```python
+def print_overview(r):
+    mem = r.info("memory")
+    print(
+        f"used_memory: {mem.get('used_memory_human')}  "
+        f"maxmemory: {mem.get('maxmemory_human', mem.get('maxmemory'))} "
+        f"(policy: {mem.get('maxmemory_policy')})  "
+        f"fragmentation: {mem.get('mem_fragmentation_ratio')}"
+    )
+    keyspace = r.info("keyspace")
+    for db_name in sorted(keyspace):
+        info = keyspace[db_name]
+        print(
+            f"{db_name}: keys={info.get('keys'):,} expires={info.get('expires'):,} "
+            f"avg_ttl={info.get('avg_ttl')}"
+        )
+    print()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Read-only Redis memory profiler: instance overview, plus "
+        "per-prefix memory breakdown for one db."
+    )
+    parser.add_argument("db", type=int, nargs="?", default=None,
+                        help="db number to profile by prefix (omit for overview only)")
+    parser.add_argument("--depth", type=int, default=1,
+                        help="key segments (split on . and :) per prefix bucket (default 1)")
+    parser.add_argument("--scan-count", type=int, default=500,
+                        help="SCAN COUNT hint per batch (default 500)")
+    parser.add_argument("--throttle", type=float, default=50,
+                        help="sleep between SCAN batches in ms (default 50)")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    r = get_redis_from_env(args.db if args.db is not None else 0)
+    print_overview(r)
+    if args.db is None:
+        return
+
+    total = r.dbsize()
+    print(f"Profiling db {args.db} (~{total:,} keys) by prefix (depth {args.depth})...\n")
+    progress = {"scanned": 0, "start": time.time(), "last_print": 0.0}
+
+    def on_batch(n):
+        progress["scanned"] += n
+        now = time.time()
+        if now - progress["last_print"] >= 1.0:
+            elapsed = now - progress["start"]
+            rate = progress["scanned"] / elapsed if elapsed > 0 else 0
+            pct = (progress["scanned"] / total * 100) if total else 0
+            sys.stdout.write(
+                f"\rScanned {progress['scanned']:,}/{total:,} ({pct:.1f}%) | {rate:,.0f} keys/s"
+            )
+            sys.stdout.flush()
+            progress["last_print"] = now
+
+    batches = iter_key_batches(
+        r, count=args.scan_count, throttle_seconds=args.throttle / 1000.0
+    )
+    stats = aggregate_prefix_stats(
+        batches, lambda keys: fetch_key_stats(r, keys), depth=args.depth, on_batch=on_batch
+    )
+    sys.stdout.write("\n\n")
+    print(format_stats_table(stats))
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run the full profiler test file**
+
+Run: `cd cdip_admin && ../.venv/bin/pytest scripts/tests/test_redis_memory_profiler.py -v`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cdip_admin/scripts/redis_memory_profiler.py cdip_admin/scripts/tests/test_redis_memory_profiler.py
+git commit -m "Add CLI and instance overview to Redis memory profiler"
+```
+
+---
+
+### Task 4: Cleaner candidate selection
+
+**Files:**
+- Create: `cdip_admin/scripts/redis_stale_key_cleaner.py` (selection logic; CLI in Task 5)
+- Create: `cdip_admin/scripts/tests/test_redis_stale_key_cleaner.py`
+
+**Interfaces:**
+- Consumes: `iter_key_batches` from common.
+- Produces (used by Task 5):
+  - `IdleTimeUnavailable(RuntimeError)`.
+  - `fetch_idle_times(r, keys) -> list[int | None]` — pipelined `OBJECT IDLETIME`; raises `IdleTimeUnavailable` on `redis.exceptions.ResponseError`.
+  - `find_stale_candidates(r, idle_threshold_seconds, match=None, scan_count=500, throttle_seconds=0.05, idle_fetcher=None, on_progress=None) -> list[tuple[bytes, int]]` — `(key, idle_seconds)` pairs where `TTL == -1` and idle > threshold; `idle_fetcher(r, keys)` defaults to `fetch_idle_times`; `on_progress(n_scanned_in_batch, n_candidates_total)`.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `cdip_admin/scripts/tests/test_redis_stale_key_cleaner.py`:
+
+```python
+import fakeredis
+import pytest
+import redis
+
+from scripts.redis_stale_key_cleaner import (
+    IdleTimeUnavailable,
+    fetch_idle_times,
+    find_stale_candidates,
+)
+
+DAY = 86400
+
+
+def _seeded():
+    r = fakeredis.FakeRedis()
+    r.set("backfill.old", "x")                                   # no TTL, idle 40d
+    r.set("backfill.recent", "x")                                # no TTL, idle 1d
+    r.set("dispatched_observation.a.b", "x", ex=25 * 3600)       # has TTL, idle 40d
+    idle = {
+        b"backfill.old": 40 * DAY,
+        b"backfill.recent": 1 * DAY,
+        b"dispatched_observation.a.b": 40 * DAY,
+    }
+    return r, lambda _r, keys: [idle[k] for k in keys]
+
+
+class TestFindStaleCandidates:
+    def test_only_no_ttl_keys_over_threshold_are_candidates(self):
+        r, idle_fetcher = _seeded()
+        cands = find_stale_candidates(
+            r, idle_threshold_seconds=30 * DAY, idle_fetcher=idle_fetcher, throttle_seconds=0
+        )
+        assert cands == [(b"backfill.old", 40 * DAY)]
+
+    def test_key_with_ttl_is_never_a_candidate_even_when_idle(self):
+        r, idle_fetcher = _seeded()
+        cands = find_stale_candidates(
+            r, idle_threshold_seconds=1, idle_fetcher=idle_fetcher, throttle_seconds=0
+        )
+        assert all(not k.startswith(b"dispatched_observation") for k, _ in cands)
+
+    def test_match_constrains_scan(self):
+        r, idle_fetcher = _seeded()
+        r.set("other.old", "x")
+        cands = find_stale_candidates(
+            r, idle_threshold_seconds=1, match="backfill*",
+            idle_fetcher=idle_fetcher, throttle_seconds=0,
+        )
+        assert {k for k, _ in cands} == {b"backfill.old", b"backfill.recent"}
+
+    def test_idle_fetcher_error_propagates(self):
+        r, _ = _seeded()
+
+        def boom(_r, keys):
+            raise IdleTimeUnavailable("no idle times")
+
+        with pytest.raises(IdleTimeUnavailable):
+            find_stale_candidates(
+                r, idle_threshold_seconds=1, idle_fetcher=boom, throttle_seconds=0
+            )
+
+    def test_on_progress_reports_totals(self):
+        r, idle_fetcher = _seeded()
+        calls = []
+        find_stale_candidates(
+            r, idle_threshold_seconds=30 * DAY, idle_fetcher=idle_fetcher,
+            throttle_seconds=0, on_progress=lambda n, c: calls.append((n, c)),
+        )
+        assert sum(n for n, _ in calls) == 3
+        assert calls[-1][1] == 1
+
+
+class TestFetchIdleTimes:
+    def test_response_error_raises_idle_time_unavailable(self, monkeypatch):
+        r = fakeredis.FakeRedis()
+        r.set("k", "v")
+
+        class BoomPipe:
+            def execute_command(self, *args):
+                return self
+
+            def execute(self):
+                raise redis.exceptions.ResponseError("An LFU maxmemory policy is selected")
+
+        monkeypatch.setattr(r, "pipeline", lambda transaction=False: BoomPipe())
+        with pytest.raises(IdleTimeUnavailable, match="OBJECT IDLETIME failed"):
+            fetch_idle_times(r, [b"k"])
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd cdip_admin && ../.venv/bin/pytest scripts/tests/test_redis_stale_key_cleaner.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'scripts.redis_stale_key_cleaner'`
+
+- [ ] **Step 3: Implement selection logic**
+
+Create `cdip_admin/scripts/redis_stale_key_cleaner.py`:
+
+```python
+"""Find (and optionally UNLINK) keys that have NO TTL and have been idle longer
+than a threshold. Keys with any TTL are never touched: they expire on their own,
+and deleting live dispatched_observation.* idempotency keys early breaks the
+PubSub redelivery contract (see docs/superpowers/specs/2026-08-04-redis-prod-cleanup-design.md).
+
+Dry-run by default; deletion requires --delete.
+
+Usage:
+    REDIS_HOST=... python redis_stale_key_cleaner.py 0                       # dry-run, 30d
+    REDIS_HOST=... python redis_stale_key_cleaner.py 0 --match 'backfill*' --delete
+"""
+import argparse
+import sys
+import time
+
+import redis
+
+from scripts.redis_ops_common import (
+    chunked,
+    get_redis_from_env,
+    iter_key_batches,
+    key_prefix,
+)
+
+MIN_DELETE_IDLE_DAYS = 2.0
+DAY_SECONDS = 86400
+
+
+class IdleTimeUnavailable(RuntimeError):
+    pass
+
+
+def fetch_idle_times(r, keys):
+    """Pipelined OBJECT IDLETIME. Aborts loudly if the server can't answer
+    (e.g. LFU maxmemory-policy) — never treat unknown idle as 0."""
+    pipe = r.pipeline(transaction=False)
+    for k in keys:
+        pipe.execute_command("OBJECT", "IDLETIME", k)
+    try:
+        return pipe.execute()
+    except redis.exceptions.ResponseError as exc:
+        raise IdleTimeUnavailable(
+            f"OBJECT IDLETIME failed ({exc}). If maxmemory-policy is an LFU policy, "
+            "idle times are unavailable; aborting rather than treating idle as 0."
+        ) from exc
+
+
+def find_stale_candidates(r, idle_threshold_seconds, match=None, scan_count=500,
+                          throttle_seconds=0.05, idle_fetcher=None, on_progress=None):
+    """Return (key, idle_seconds) for keys with TTL == -1 and idle > threshold."""
+    idle_fetcher = idle_fetcher or fetch_idle_times
+    candidates = []
+    for keys in iter_key_batches(r, match=match, count=scan_count,
+                                 throttle_seconds=throttle_seconds):
+        pipe = r.pipeline(transaction=False)
+        for k in keys:
+            pipe.ttl(k)
+        ttls = pipe.execute()
+        no_ttl_keys = [k for k, ttl in zip(keys, ttls) if ttl == -1]
+        if no_ttl_keys:
+            for k, idle in zip(no_ttl_keys, idle_fetcher(r, no_ttl_keys)):
+                if idle is not None and idle > idle_threshold_seconds:
+                    candidates.append((k, idle))
+        if on_progress:
+            on_progress(len(keys), len(candidates))
+    return candidates
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd cdip_admin && ../.venv/bin/pytest scripts/tests/test_redis_stale_key_cleaner.py -v`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cdip_admin/scripts/redis_stale_key_cleaner.py cdip_admin/scripts/tests/test_redis_stale_key_cleaner.py
+git commit -m "Add no-TTL idle-key candidate selection for Redis cleaner"
+```
+
+---
+
+### Task 5: Cleaner rails, summary, deletion, CLI
+
+**Files:**
+- Modify: `cdip_admin/scripts/redis_stale_key_cleaner.py` (append summary/delete/validation/CLI)
+- Modify: `cdip_admin/scripts/tests/test_redis_stale_key_cleaner.py` (append tests)
+
+**Interfaces:**
+- Consumes: Task 4's functions; `chunked`, `key_prefix` from common.
+- Produces:
+  - `validate_delete_args(delete: bool, idle_threshold_days: float) -> None` — `SystemExit(1)` if `delete` and `idle_threshold_days < MIN_DELETE_IDLE_DAYS` (2.0).
+  - `fetch_sizes(r, keys) -> list[int]` — pipelined `MEMORY USAGE` (nil → 0), chunked internally (500/pipeline).
+  - `summarize_candidates(sized: list[tuple[bytes, int, int]], depth=1) -> list[tuple[str, int, int]]` — input `(key, idle_seconds, size_bytes)`, output `(prefix, count, total_bytes)` sorted by bytes desc.
+  - `delete_keys(r, keys, batch_size=500, throttle_seconds=0.05, on_progress=None) -> int` — UNLINKs in batches, returns deleted count.
+  - CLI: `python redis_stale_key_cleaner.py DB [--idle-threshold DAYS] [--match GLOB] [--delete] [--yes] [--batch-size N] [--throttle MS]`.
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `cdip_admin/scripts/tests/test_redis_stale_key_cleaner.py`:
+
+```python
+from scripts.redis_stale_key_cleaner import (
+    MIN_DELETE_IDLE_DAYS,
+    delete_keys,
+    summarize_candidates,
+    validate_delete_args,
+)
+
+
+class TestValidateDeleteArgs:
+    def test_delete_below_floor_is_refused(self):
+        with pytest.raises(SystemExit):
+            validate_delete_args(delete=True, idle_threshold_days=1.9)
+
+    def test_delete_at_floor_is_allowed(self):
+        validate_delete_args(delete=True, idle_threshold_days=MIN_DELETE_IDLE_DAYS)
+
+    def test_dry_run_below_floor_is_allowed(self):
+        validate_delete_args(delete=False, idle_threshold_days=0.1)
+
+
+class TestSummarizeCandidates:
+    def test_groups_by_prefix_sorted_by_bytes_desc(self):
+        sized = [
+            (b"backfill.1", 40 * DAY, 100),
+            (b"backfill.2", 41 * DAY, 300),
+            (b"backfill_watermark.9", 50 * DAY, 5000),
+        ]
+        assert summarize_candidates(sized) == [
+            ("backfill_watermark", 1, 5000),
+            ("backfill", 2, 400),
+        ]
+
+
+class TestDeleteKeys:
+    def test_unlinks_all_keys_in_batches_and_reports_progress(self):
+        r = fakeredis.FakeRedis()
+        keys = []
+        for i in range(10):
+            r.set(f"stale.{i}", "x")
+            keys.append(f"stale.{i}".encode())
+        r.set("keep.me", "x")
+        progress = []
+        deleted = delete_keys(r, keys, batch_size=3, throttle_seconds=0,
+                              on_progress=progress.append)
+        assert deleted == 10
+        assert r.dbsize() == 1
+        assert progress[-1] == 10
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd cdip_admin && ../.venv/bin/pytest scripts/tests/test_redis_stale_key_cleaner.py -v`
+Expected: FAIL — `ImportError: cannot import name 'MIN_DELETE_IDLE_DAYS'` (or similar)
+
+- [ ] **Step 3: Implement rails, summary, deletion, CLI**
+
+Append to `cdip_admin/scripts/redis_stale_key_cleaner.py`:
+
+```python
+def validate_delete_args(delete, idle_threshold_days):
+    if delete and idle_threshold_days < MIN_DELETE_IDLE_DAYS:
+        print(
+            f"Refusing --delete with --idle-threshold {idle_threshold_days} days: "
+            f"the floor is {MIN_DELETE_IDLE_DAYS} days. Keys written recently may be "
+            "live idempotency state."
+        )
+        raise SystemExit(1)
+
+
+def fetch_sizes(r, keys):
+    sizes = []
+    for batch in chunked(keys, 500):
+        pipe = r.pipeline(transaction=False)
+        for k in batch:
+            pipe.memory_usage(k, samples=0)
+        sizes.extend(size or 0 for size in pipe.execute())
+    return sizes
+
+
+def summarize_candidates(sized, depth=1):
+    totals = {}
+    for key, _idle, size in sized:
+        prefix = key_prefix(key, depth)
+        count, total = totals.get(prefix, (0, 0))
+        totals[prefix] = (count + 1, total + size)
+    return sorted(
+        ((prefix, count, total) for prefix, (count, total) in totals.items()),
+        key=lambda row: row[2],
+        reverse=True,
+    )
+
+
+def delete_keys(r, keys, batch_size=500, throttle_seconds=0.05, on_progress=None):
+    deleted = 0
+    for batch in chunked(keys, batch_size):
+        deleted += r.unlink(*batch)
+        if on_progress:
+            on_progress(deleted)
+        if throttle_seconds:
+            time.sleep(throttle_seconds)
+    return deleted
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Find (and optionally UNLINK) keys with NO TTL idle longer than "
+        "a threshold. Dry-run unless --delete is given."
+    )
+    parser.add_argument("db", type=int, help="Redis database number to scan")
+    parser.add_argument("--idle-threshold", type=float, default=30,
+                        help="idle threshold in days (default 30)")
+    parser.add_argument("--match", default=None,
+                        help="optional SCAN MATCH glob, e.g. 'backfill*'")
+    parser.add_argument("--delete", action="store_true",
+                        help="actually delete candidates (default: dry-run)")
+    parser.add_argument("--yes", "-y", action="store_true",
+                        help="skip the confirmation prompt")
+    parser.add_argument("--batch-size", type=int, default=500,
+                        help="keys per UNLINK batch (default 500)")
+    parser.add_argument("--throttle", type=float, default=50,
+                        help="sleep between SCAN/UNLINK batches in ms (default 50)")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    validate_delete_args(args.delete, args.idle_threshold)
+    threshold_seconds = int(args.idle_threshold * DAY_SECONDS)
+    throttle_seconds = args.throttle / 1000.0
+    r = get_redis_from_env(args.db)
+
+    total = r.dbsize()
+    mode = "DELETE" if args.delete else "dry-run"
+    print(
+        f"db {args.db}: ~{total:,} keys; selecting no-TTL keys idle > "
+        f"{args.idle_threshold} days (match={args.match or '*'}) [{mode}]\n"
+    )
+
+    progress = {"scanned": 0, "start": time.time(), "last_print": 0.0}
+
+    def on_progress(n_batch, n_candidates):
+        progress["scanned"] += n_batch
+        now = time.time()
+        if now - progress["last_print"] >= 1.0:
+            elapsed = now - progress["start"]
+            rate = progress["scanned"] / elapsed if elapsed > 0 else 0
+            pct = (progress["scanned"] / total * 100) if total else 0
+            sys.stdout.write(
+                f"\rScanned {progress['scanned']:,}/{total:,} ({pct:.1f}%) "
+                f"| {rate:,.0f} keys/s | {n_candidates:,} candidates"
+            )
+            sys.stdout.flush()
+            progress["last_print"] = now
+
+    try:
+        candidates = find_stale_candidates(
+            r, threshold_seconds, match=args.match, throttle_seconds=throttle_seconds,
+            on_progress=on_progress,
+        )
+    except IdleTimeUnavailable as exc:
+        print(f"\n{exc}")
+        raise SystemExit(1)
+    sys.stdout.write("\n\n")
+
+    if not candidates:
+        print("No candidates found.")
+        return
+
+    print(f"Found {len(candidates):,} candidate keys. Sizing candidates...")
+    sizes = fetch_sizes(r, [k for k, _ in candidates])
+    sized = [(k, idle, size) for (k, idle), size in zip(candidates, sizes)]
+    total_bytes = sum(size for _, _, size in sized)
+
+    print(f"\nCandidate summary ({total_bytes / 1048576:.1f} MB total):")
+    print(f"{'prefix':<50} {'keys':>12} {'MB':>10}")
+    for prefix, count, nbytes in summarize_candidates(sized):
+        print(f"{prefix:<50} {count:>12,} {nbytes / 1048576:>10.1f}")
+
+    print("\nTop 20 largest candidates:")
+    for key, idle, size in sorted(sized, key=lambda row: row[2], reverse=True)[:20]:
+        print(f"{key.decode(errors='replace')}: {size:,} B, idle {idle // DAY_SECONDS} days")
+
+    if not args.delete:
+        print("\nDry-run complete; nothing deleted. Re-run with --delete to remove these keys.")
+        return
+
+    if not args.yes:
+        try:
+            confirm = input(f"\nUNLINK {len(candidates):,} keys from db {args.db}? [y/N] ")
+        except EOFError:
+            confirm = ""
+        if confirm.strip().lower() != "y":
+            print("Aborted.")
+            raise SystemExit(0)
+
+    print()
+    keys_to_delete = [k for k, _, _ in sized]
+    del_start = time.time()
+
+    def on_delete_progress(deleted):
+        elapsed = time.time() - del_start
+        rate = deleted / elapsed if elapsed > 0 else 0
+        pct = deleted / len(keys_to_delete) * 100
+        sys.stdout.write(
+            f"\rUnlinked {deleted:,}/{len(keys_to_delete):,} ({pct:.1f}%) | {rate:,.0f} keys/s"
+        )
+        sys.stdout.flush()
+
+    deleted = delete_keys(
+        r, keys_to_delete, batch_size=args.batch_size,
+        throttle_seconds=throttle_seconds, on_progress=on_delete_progress,
+    )
+    print(f"\n\nUnlinked {deleted:,} keys total.")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run the whole scripts test suite**
+
+Run: `cd cdip_admin && ../.venv/bin/pytest scripts/tests/ -v`
+Expected: PASS (all tests from Tasks 1–5)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cdip_admin/scripts/redis_stale_key_cleaner.py cdip_admin/scripts/tests/test_redis_stale_key_cleaner.py
+git commit -m "Add safety rails, candidate summary, and UNLINK deletion to Redis cleaner"
+```
+
+---
+
+### Task 6: End-to-end smoke test against a local Redis
+
+**Files:**
+- None created/modified — verification only (fix anything found, amend the relevant task's file, and commit fixes).
+
+**Interfaces:**
+- Consumes: both finished CLIs.
+- Produces: verified scripts, ready for the prod sequence in the spec (profiler → dry-run → `--match 'backfill*'` delete → full run).
+
+- [ ] **Step 1: Start a throwaway Redis and seed it**
+
+```bash
+docker run --rm -d --name redis-cleanup-smoke -p 6390:6379 redis:7
+sleep 2
+docker exec redis-cleanup-smoke redis-cli set backfill.job1 "$(head -c 2048 /dev/zero | tr '\0' 'x')"
+docker exec redis-cleanup-smoke redis-cli set backfill_watermark.42 "w"
+docker exec redis-cleanup-smoke redis-cli set dispatched_observation.aaa.bbb "d" EX 90000
+```
+
+- [ ] **Step 2: Run the profiler (overview + db 0)**
+
+```bash
+cd cdip_admin && REDIS_HOST=localhost REDIS_PORT=6390 ../.venv/bin/python -m scripts.redis_memory_profiler 0
+```
+
+Expected: overview shows `used_memory` and `db0: keys=3`; table has rows for `backfill` (% no-TTL = 100.0%), `backfill_watermark` (100.0%), `dispatched_observation` (0.0%), with `backfill` largest by MB.
+
+- [ ] **Step 3: Run the cleaner dry-run with a zero threshold**
+
+```bash
+cd cdip_admin && REDIS_HOST=localhost REDIS_PORT=6390 ../.venv/bin/python -m scripts.redis_stale_key_cleaner 0 --idle-threshold 0
+```
+
+Expected: 2 candidates (`backfill.job1`, `backfill_watermark.42`); `dispatched_observation.aaa.bbb` absent; ends with "Dry-run complete; nothing deleted."
+(Fresh keys have idle 0 and the rule is strictly `idle > threshold` — if 0 candidates appear, wait ~65s after seeding and re-run; OBJECT IDLETIME has ~second resolution and LRU-clock granularity.)
+
+- [ ] **Step 4: Verify the delete floor refuses a low threshold**
+
+```bash
+cd cdip_admin && REDIS_HOST=localhost REDIS_PORT=6390 ../.venv/bin/python -m scripts.redis_stale_key_cleaner 0 --idle-threshold 0 --delete; echo "exit=$?"
+```
+
+Expected: "Refusing --delete..." message, `exit=1`, all 3 keys still present (`docker exec redis-cleanup-smoke redis-cli dbsize` → 3).
+
+- [ ] **Step 5: Verify --match constrains the dry-run**
+
+```bash
+cd cdip_admin && REDIS_HOST=localhost REDIS_PORT=6390 ../.venv/bin/python -m scripts.redis_stale_key_cleaner 0 --idle-threshold 0 --match 'backfill.*'
+```
+
+Expected: exactly 1 candidate (`backfill.job1`; the glob `backfill.*` requires the literal dot, so `backfill_watermark.42` is excluded).
+
+- [ ] **Step 6: Tear down and run the full suite once more**
+
+```bash
+docker stop redis-cleanup-smoke
+cd cdip_admin && ../.venv/bin/pytest scripts/tests/ -v
+```
+
+Expected: container stops; all tests PASS. If any smoke step required code fixes, commit them:
+
+```bash
+git add -A cdip_admin/scripts && git commit -m "Fix issues found in Redis cleanup scripts smoke test"
+```
+
+---
+
+## Not in this plan (phase 2, per spec)
+
+The recurring CronJob (containerized cleaner, weekly `--delete --yes --idle-threshold 30`) and the fix-the-leak-at-source Movebank ticket are deliberately excluded; they get their own plan after these scripts have proven themselves against prod.

--- a/docs/superpowers/specs/2026-08-04-redis-prod-cleanup-design.md
+++ b/docs/superpowers/specs/2026-08-04-redis-prod-cleanup-design.md
@@ -1,0 +1,114 @@
+# Prod Redis Inspection & Stale-Key Cleanup — Design
+
+**Date:** 2026-08-04
+**Status:** Approved
+**Target:** ER dispatcher Redis in production (private IP, reached locally via port-forward/tunnel)
+
+## Problem
+
+The ER dispatcher's production Redis is filling up. Volume comes from two sources:
+
+1. `dispatched_observation.{gundi_id}.{destination_id}` idempotency keys — one per
+   observation per destination, 25h TTL. These self-expire and MUST NOT be deleted
+   early: they enforce the PubSub redelivery-idempotency contract
+   (`gundi-dispatcher-er/core/event_handlers.py::is_observation_dispatched`); deleting
+   a live key can cause duplicate delivery to ER (409 loops with throttling distress).
+2. Leaked keys with **no TTL** — Movebank integration `backfill.*` job-queue keys and
+   `backfill_watermark.*` keys accumulate per job and never expire. Pre-fix
+   `dispatched_observation` strays without TTL may also exist (the
+   `DISPATCHED_OBSERVATIONS_CACHE_TTL` env-var bug fixed in gundi-dispatcher-er PR #45).
+
+We need (a) visibility into which key families use how much memory, and (b) a safe way
+to delete old no-TTL keys — first as manually run scripts (phase 1), later as a
+recurring in-cluster job (phase 2).
+
+## Phase 1: Two standalone scripts
+
+Location: `cdip_admin/scripts/`. No Django dependency; plain `redis`-py, configured via
+`REDIS_HOST` / `REDIS_PORT` env vars (port defaults to 6379). Both scripts throttle
+their SCAN loops (`--throttle`, default 50ms sleep between batches) to cap prod load,
+and show progress (scanned/total, rate) like the existing idle-key script.
+
+### `redis_memory_profiler.py` (read-only)
+
+1. Always prints an instance overview first:
+   - `INFO memory`: used_memory_human, maxmemory + policy, fragmentation ratio
+   - `INFO keyspace`: key/expires counts per db
+2. Given an optional positional `db` argument, additionally profiles that db (with no
+   `db`, only the overview is printed): SCAN loop, pipelined `MEMORY USAGE` (sampled)
+   + `TTL` per key, aggregated by prefix.
+   - Prefix = first N segments of the key split on `.` or `:` (`--depth`, default 1).
+     `dispatched_observation.{uuid}.{uuid}` → `dispatched_observation`;
+     `backfill_watermark.123` → `backfill_watermark`.
+3. Output: one row per prefix, sorted by total bytes desc — key count, total MB,
+   avg bytes/key, **% of keys with no TTL** (the leak-detector column).
+
+### `redis_stale_key_cleaner.py` (destructive, railed)
+
+Selection rule: a key is a deletion candidate **only if `TTL == -1` (no expiry) AND
+`OBJECT IDLETIME` > threshold**. Keys with any TTL are never candidates.
+
+CLI:
+
+- `db` (positional, required)
+- `--idle-threshold DAYS` (float, default 30)
+- `--match GLOB` — optional `SCAN MATCH` pattern to constrain a run (e.g. `backfill*`)
+- `--delete` — actually delete; **without it the script is a dry-run** (inverted from
+  the earlier idle-key script's default)
+- `--yes` — skip the confirmation prompt (for unattended/phase-2 use)
+- `--throttle MS`, `--batch-size N` (default 500)
+
+Safety rails:
+
+1. Dry-run is the default; deletion requires explicit `--delete`.
+2. Hard floor: `--delete` combined with `--idle-threshold < 2` (days) is refused.
+3. Keys with TTL ≥ 0 are never touched (they self-expire; early deletion of
+   `dispatched_observation.*` breaks redelivery idempotency).
+4. Before the confirmation prompt, print a candidate summary: per-prefix count + MB
+   (`MEMORY USAGE` fetched for candidates only), plus the top 20 largest candidates —
+   the operator sees exactly which key families will be deleted.
+5. Deletion uses `UNLINK` (non-blocking server-side) in batches with throttle.
+6. If `OBJECT IDLETIME` returns an error (e.g. LFU maxmemory-policy), abort with a
+   clear message — never treat unknown idle as 0.
+7. Interruption-safe: state is recomputed from live Redis on every run; re-running is
+   always safe.
+
+## Error handling
+
+- Keys deleted/expired mid-scan: pipeline returns nil for that key; skip silently.
+- Connection errors: fail fast with the error; the operator re-runs.
+- `MEMORY USAGE` returning nil (key gone): treat as 0 bytes / skip.
+
+## Testing
+
+- Core logic (candidate selection, prefix bucketing, batch chunking, summary
+  aggregation) factored into pure functions importable without executing the CLI.
+- Unit tests with `fakeredis` under `cdip_admin/scripts/tests/`; `OBJECT IDLETIME`
+  is not implemented by fakeredis, so idle lookup goes through a small wrapper the
+  tests monkeypatch.
+- Manual verification sequence:
+  1. Both scripts against local docker Redis (seed keys with/without TTL).
+  2. Profiler against prod (read-only).
+  3. Cleaner dry-run against prod; sanity-check the candidate summary.
+  4. First real deletion constrained with `--match 'backfill*'`, then a full run.
+
+## Phase 2: Recurring in-cluster cleanup (planned, separate implementation)
+
+- Containerize the cleaner (slim `python:3.11` base + `redis`), deploy a Kubernetes
+  CronJob alongside the ER dispatcher, weekly schedule, running
+  `--delete --yes --idle-threshold 30`, logs to Cloud Logging.
+- **Prerequisite ticket (fix the leak at the source):** Movebank `backfill.*` /
+  `backfill_watermark.*` keys should be written with a TTL. The CronJob is a backstop,
+  not the primary mechanism.
+- Open question deferred to phase 2: which repo owns the CronJob manifest (dispatcher
+  helm chart vs. infra repo).
+- Never enable `allkeys-*` eviction on this Redis as an alternative — it would evict
+  live idempotency keys.
+
+## Out of scope
+
+- Shortening the `dispatched_observation` TTL (must stay ≥ PubSub subscription max
+  event age; see gundi-dispatcher-er PR #45 context).
+- Offline RDB analysis tooling.
+- Changes to the Movebank integration itself (tracked as the phase-2 prerequisite
+  ticket).


### PR DESCRIPTION
## Why

The ER dispatcher's production Redis is filling up. Two things drive the volume, and they need opposite treatment:

- `dispatched_observation.{gundi_id}.{destination_id}` idempotency keys carry a 25h TTL and **self-expire**. Deleting one early breaks the PubSub redelivery-idempotency contract in `gundi-dispatcher-er` (`is_observation_dispatched`), causing duplicate delivery to EarthRanger and 409 loops.
- Keys with **no TTL** leak and accumulate forever — Movebank `backfill.*` job-queue keys, `backfill_watermark.*` keys, and any pre-fix `dispatched_observation` strays from the `DISPATCHED_OBSERVATIONS_CACHE_TTL` env-var bug.

Until now there was no way to see which key families were consuming memory, and no safe way to trim the leaked ones.

## What this adds

Two standalone CLI scripts in `cdip_admin/scripts/`, plus shared helpers. They're deliberately Django-free — they run against a prod Redis over a port-forward with just `REDIS_HOST` / `REDIS_PORT`.

**`redis_memory_profiler.py`** (read-only) prints an instance overview (`used_memory`, `maxmemory` + policy, fragmentation, per-db key counts), then optionally profiles one db: memory and key count aggregated by key prefix, with a **% no-TTL column** that makes leaks obvious at a glance.

**`redis_stale_key_cleaner.py`** finds and optionally deletes stale keys. A key is a candidate **only if `TTL == -1` AND `OBJECT IDLETIME` > threshold** — keys with any TTL are never touched.

Safety rails, since this is a destructive tool pointed at production:

- Dry-run is the default; deletion requires an explicit `--delete`.
- `--delete` with `--idle-threshold` under 2 days is refused outright.
- Candidates are re-checked for a TTL immediately before each `UNLINK` batch, so a key that acquires a TTL while the confirmation prompt sits open is skipped and reported rather than deleted.
- Deletion uses `UNLINK` (non-blocking server-side) in throttled batches; SCAN loops sleep between batches to cap prod load.
- A per-prefix candidate summary plus the 20 largest candidates print *before* the confirmation prompt, so the operator sees exactly which key families would die.
- If `OBJECT IDLETIME` errors (LFU `maxmemory-policy`), the run aborts loudly instead of treating idle time as 0.
- `--match` constrains a run to a glob, e.g. `--match 'backfill*'`.

## Testing

30 unit tests using `fakeredis` (`cdip_admin/scripts/tests/`), covering prefix bucketing, aggregation, the candidate rule (including the case that a TTL'd `dispatched_observation` key is never selected even when idle), the delete floor, the pre-UNLINK TTL re-check, and batching.

End-to-end smoke test against a dockerized `redis:7` seeded with no-TTL and TTL'd keys: the profiler reported the expected prefixes and no-TTL percentages, the cleaner's dry-run selected only the no-TTL keys, the delete floor refused a low threshold, and `--match` constrained selection as intended.

## Intended prod sequence

1. Profiler (read-only) to see where the memory actually is.
2. Cleaner dry-run; sanity-check the candidate summary.
3. First real deletion constrained with `--match 'backfill*'`, then a full run.

## Follow-ups (not in this PR)

- **`dependencies/requirements-dev.txt` is not regenerated.** `fakeredis==2.37.0` is pinned in `requirements-dev.in`, but `pip-compile` currently fails on an unrelated `cryptography` pin in this repo, so the lockfile was left alone. Until that's fixed, a fresh dev environment needs `pip install fakeredis` to run these tests. (No CI job runs pytest in this repo, so nothing goes red.)
- **Fix the leak at its source:** give Movebank `backfill.*` / `backfill_watermark.*` keys a TTL when they're written. This tooling is a backstop, not the cure.
- A recurring in-cluster CronJob wrapping the cleaner is designed (phase 2 in the spec) but deliberately deferred until the scripts have proven themselves against prod.

Design spec and implementation plan are included in the branch under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
