### PR TITLE
fix: cut admin changelist query storms on activity logs and traces

### DIFF
--- a/cdip_admin/activity_log/admin.py
+++ b/cdip_admin/activity_log/admin.py
@@ -1,6 +1,10 @@
 from django.contrib import admin
 
-from core.admin import EstimatedCountPaginator
+from core.admin import (
+    CustomDateFilter,
+    EstimatedCountPaginator,
+    SelectRelatedFieldListFilter,
+)
 
 from .models import ActivityLog
 
@@ -48,7 +52,18 @@ class ActivityLogAdmin(admin.ModelAdmin):
     # count. Doesn't replace the paginator's primary count — that's the
     # job of ``paginator`` above.
     show_full_result_count = False
-    list_select_related = True
+    # These relations must be named explicitly. A bare ``select_related()`` --
+    # which is what ``list_select_related = True`` produces -- follows only
+    # *non-nullable* FKs, and both ``integration`` and ``created_by`` are
+    # nullable, so it followed neither. Every displayed row then dereferenced
+    # them lazily, and ``Integration.__str__`` walked owner and type on top of
+    # that: ~4 queries per row.
+    list_select_related = (
+        "integration",
+        "integration__owner",
+        "integration__type",
+        "created_by",
+    )
     list_display = (
         "created_at",
         "log_level",
@@ -56,23 +71,26 @@ class ActivityLogAdmin(admin.ModelAdmin):
         "title",
         "origin",
         "log_type",
-        "details",
         "is_reversible",
-        "revert_data",
         "integration",
         "created_by",
     )
     search_fields = (
         "title",
         "value",
-        "details",
     )
-    date_hierarchy = 'created_at'
+    # No ``date_hierarchy``: it issues ``SELECT DISTINCT DATE_TRUNC(...)`` over
+    # the whole filtered queryset on every render. Postgres has no skip scan in
+    # any version, so that is a sequential scan of every partition -- measured
+    # at 3,677 buffers / 131ms per 500k rows, and linear in table size.
+    # ``CustomDateFilter`` covers the same need by building its links from the
+    # clock instead of from the table.
     list_filter = (
+        ("created_at", CustomDateFilter),
         "log_level",
         "log_type",
         "origin",
         "is_reversible",
-        "integration",
+        ("integration", SelectRelatedFieldListFilter),
     )
     actions = [revert_selected]

--- a/cdip_admin/activity_log/tests/test_admin_performance.py
+++ b/cdip_admin/activity_log/tests/test_admin_performance.py
@@ -1,0 +1,136 @@
+import pytest
+from django.contrib import admin as django_admin
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+
+from activity_log.models import ActivityLog
+from integrations.models import Integration
+
+pytestmark = pytest.mark.django_db
+
+
+def _changelist_query_count(admin_client, url):
+    with CaptureQueriesContext(connection) as ctx:
+        response = admin_client.get(url)
+    assert response.status_code == 200, response.status_code
+    return len(ctx.captured_queries)
+
+
+def _bulk_logs(integration, count, title_prefix="log"):
+    ActivityLog.objects.bulk_create(
+        [
+            ActivityLog(
+                log_level=ActivityLog.LogLevels.INFO,
+                log_type=ActivityLog.LogTypes.EVENT,
+                origin=ActivityLog.Origin.DISPATCHER,
+                value=f"value_{i}",
+                title=f"{title_prefix} {i}",
+                integration=integration,
+                details={"i": i},
+                revert_data={},
+            )
+            for i in range(count)
+        ]
+    )
+
+
+@pytest.fixture
+def provider(organization, integration_type_er):
+    return Integration.objects.create(
+        type=integration_type_er,
+        owner=organization,
+        name="Provider",
+        base_url="https://provider.example.org",
+    )
+
+
+def test_changelist_query_count_does_not_scale_with_row_count(admin_client, provider):
+    """The changelist must not issue per-row queries.
+
+    ``list_select_related = True`` silently skips *nullable* FKs, and both
+    ``integration`` and ``created_by`` are nullable, so every displayed row
+    dereferences them lazily -- and ``Integration.__str__`` then touches
+    owner.name and type.name. That is ~4 queries per row on a page of 100.
+    """
+    url = reverse("admin:activity_log_activitylog_changelist")
+
+    _bulk_logs(provider, 5)
+    baseline = _changelist_query_count(admin_client, url)
+
+    _bulk_logs(provider, 95, title_prefix="extra")
+    after = _changelist_query_count(admin_client, url)
+
+    assert after - baseline <= 2, (
+        "ActivityLog changelist query count scales with the number of rows: "
+        f"{baseline} queries -> {after} queries after adding 95 more logs. "
+        "list_select_related must name the nullable FKs explicitly."
+    )
+
+
+def test_changelist_query_count_does_not_scale_with_integration_count(
+    admin_client, provider, organization, integration_type_er
+):
+    """The 'integration' sidebar filter builds a dropdown of every Integration.
+
+    RelatedFieldListFilter renders ``str(obj)`` per option, and
+    ``Integration.__str__`` dereferences owner and type without
+    select_related, so drawing the sidebar costs 2 queries per integration
+    on every changelist render.
+    """
+    url = reverse("admin:activity_log_activitylog_changelist")
+    _bulk_logs(provider, 5)
+
+    baseline = _changelist_query_count(admin_client, url)
+
+    Integration.objects.bulk_create(
+        [
+            Integration(
+                type=integration_type_er,
+                owner=organization,
+                name=f"Bulk Integration {i}",
+                base_url=f"https://bulk-{i}.example.org",
+            )
+            for i in range(100)
+        ]
+    )
+
+    after = _changelist_query_count(admin_client, url)
+
+    assert after - baseline <= 2, (
+        "ActivityLog changelist query count scales with the number of "
+        f"integrations: {baseline} -> {after} after adding 100 integrations. "
+        "The integration filter must select_related its choice queryset."
+    )
+
+
+def test_changelist_does_not_use_date_hierarchy(admin_client):
+    """``date_hierarchy`` issues ``SELECT DISTINCT DATE_TRUNC(...)`` over the
+    whole filtered queryset on every render. Postgres has no skip scan, so
+    that is an unavoidable sequential scan of every partition -- measured at
+    3,677 buffers / 131ms per 500k rows, and linear in table size.
+
+    Timeframe filtering is provided by a date filter instead, which builds
+    its links from the clock rather than from the table.
+    """
+    model_admin = django_admin.site._registry[ActivityLog]
+    assert model_admin.date_hierarchy is None
+
+    filter_targets = [
+        spec[0] if isinstance(spec, (tuple, list)) else spec
+        for spec in model_admin.list_filter
+    ]
+    assert "created_at" in filter_targets, (
+        "Removing date_hierarchy must not remove the ability to filter by "
+        "timeframe -- expected 'created_at' in list_filter."
+    )
+
+
+def test_changelist_does_not_render_json_blobs_per_row(admin_client):
+    """``details`` and ``revert_data`` are JSONFields. Rendering them for
+    every row turns the changelist HTML into megabytes of serialized JSON.
+    They remain on the detail page.
+    """
+    model_admin = django_admin.site._registry[ActivityLog]
+    assert "details" not in model_admin.list_display
+    assert "revert_data" not in model_admin.list_display

--- a/cdip_admin/core/admin.py
+++ b/cdip_admin/core/admin.py
@@ -1,7 +1,8 @@
 import logging
+import operator
 from datetime import datetime, timedelta
 
-from django.contrib.admin.filters import DateFieldListFilter
+from django.contrib.admin.filters import DateFieldListFilter, RelatedFieldListFilter
 from django.core.paginator import Paginator
 from django.db import connection
 from django.utils.functional import cached_property
@@ -9,6 +10,41 @@ from django.utils.translation import gettext_lazy as _
 
 
 logger = logging.getLogger(__name__)
+
+
+class SelectRelatedFieldListFilter(RelatedFieldListFilter):
+    """A ``RelatedFieldListFilter`` that ``select_related``s its choice queryset.
+
+    The base filter builds its sidebar dropdown by calling ``str(obj)`` on
+    every row of the related model. When that model's ``__str__`` dereferences
+    its own foreign keys -- ``Integration.__str__`` returns
+    ``f"{self.owner.name} - {self.name} - {self.type.name}"`` -- each option
+    costs one query per relation, so *every* changelist render gets slower as
+    integrations are added. Measured at 2 queries per integration.
+
+    A bare ``select_related()`` is the right tool here: it follows the target
+    model's non-nullable FKs (``Integration.owner`` and ``Integration.type``)
+    in the same query, and by definition never descends through a nullable
+    relation, so it cannot blow up into a wide join.
+
+    This mirrors ``Field.get_choices()`` rather than delegating to it, because
+    that method offers no hook for adjusting the queryset.
+    """
+
+    def field_choices(self, field, request, model_admin):
+        ordering = self.field_admin_ordering(field, request, model_admin)
+        related_model = field.remote_field.model
+        choice_func = operator.attrgetter(
+            field.remote_field.get_related_field().attname
+            if hasattr(field.remote_field, "get_related_field")
+            else "pk"
+        )
+        queryset = related_model._default_manager.complex_filter(
+            field.get_limit_choices_to()
+        ).select_related()
+        if ordering:
+            queryset = queryset.order_by(*ordering)
+        return [(choice_func(obj), str(obj)) for obj in queryset]
 
 
 class CustomDateFilter(DateFieldListFilter):

--- a/cdip_admin/integrations/admin.py
+++ b/cdip_admin/integrations/admin.py
@@ -2,7 +2,10 @@ import django_celery_beat
 import psycopg2
 from django.contrib import admin
 from django.db import IntegrityError
+from django.db.models import F
 from django.forms import ModelForm
+from django.urls import reverse
+from django.utils.html import format_html
 from django_celery_beat.admin import PeriodicTaskAdmin
 from django_celery_beat.models import PeriodicTask
 from simple_history.admin import SimpleHistoryAdmin
@@ -549,14 +552,29 @@ class GundiTraceAdmin(SimpleHistoryAdmin):
     # count. Doesn't replace the paginator's primary count — that's the
     # job of ``paginator`` above.
     show_full_result_count = False
-    list_select_related = True
+    # ``list_select_related = True`` followed only ``data_provider`` -- a bare
+    # select_related() skips *nullable* FKs, so ``destination``, ``source`` and
+    # ``created_by`` were all dereferenced per row, and Integration/Source
+    # ``__str__`` walked owner/type/integration on top of that: ~7 queries per
+    # row, 356 for a 50-row page. ``source`` is deliberately absent -- see
+    # ``source_link`` for why loading Source rows is not made cheaper by
+    # select_related.
+    list_select_related = (
+        "data_provider",
+        "data_provider__owner",
+        "data_provider__type",
+        "destination",
+        "destination__owner",
+        "destination__type",
+        "created_by",
+    )
     list_display = (
         "pk",
         "object_id",
         "related_to",
         "object_type",
         "data_provider",
-        "source",
+        "source_link",
         "destination",
         "external_id",
         "created_at",
@@ -565,7 +583,6 @@ class GundiTraceAdmin(SimpleHistoryAdmin):
         "last_update_delivered_at",
         "is_duplicate",
         "has_error",
-        "error",
         "created_by",
     )
     search_fields = (
@@ -582,8 +599,12 @@ class GundiTraceAdmin(SimpleHistoryAdmin):
         "destination__owner__name",
         "destination__type__name",
     )
-    date_hierarchy = 'created_at'
+    # No ``date_hierarchy``: it issues ``SELECT DISTINCT DATE_TRUNC(...)`` over
+    # the whole filtered queryset on every render, which Postgres can only
+    # answer with a sequential scan of this -- the largest -- table. The
+    # ``created_at`` filter below covers the same need for free.
     list_filter = (
+        ("created_at", CustomDateFilter),
         ("delivered_at", CustomDateFilter),
         "has_error",
         "is_duplicate",
@@ -591,6 +612,27 @@ class GundiTraceAdmin(SimpleHistoryAdmin):
         "data_provider__type",
         "destination__type",
     )
+
+    def get_queryset(self, request):
+        # Pull the source's external id in via the join rather than via
+        # ``list_select_related``. Constructing a ``Source`` instance runs
+        # ``ChangeLogMixin.__init__``, which resolves the instance's related
+        # integration *before* Django populates the FK cache -- so it costs a
+        # query per row that select_related cannot prevent. Annotating avoids
+        # building the instances at all.
+        return super().get_queryset(request).annotate(
+            _source_external_id=F("source__external_id")
+        )
+
+    @admin.display(description="Source", ordering="source__external_id")
+    def source_link(self, obj):
+        if not obj.source_id:
+            return self.get_empty_value_display()
+        return format_html(
+            '<a href="{}">{}</a>',
+            reverse("admin:integrations_source_change", args=[obj.source_id]),
+            obj._source_external_id,
+        )
 
 
 # Override the PeriodicTaskAdmin to allow searching and filtering by integration fields

--- a/cdip_admin/integrations/tests/test_admin.py
+++ b/cdip_admin/integrations/tests/test_admin.py
@@ -1,4 +1,5 @@
 import pytest
+from django.contrib import admin as django_admin
 from django.contrib.admin.widgets import AutocompleteSelect, RelatedFieldWidgetWrapper
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
@@ -71,3 +72,98 @@ def test_route_change_page_owner_and_configuration_use_autocomplete(
 
     assert isinstance(unwrap(form.fields["owner"].widget), AutocompleteSelect)
     assert isinstance(unwrap(form.fields["configuration"].widget), AutocompleteSelect)
+
+
+def _changelist_query_count(admin_client, url):
+    with CaptureQueriesContext(connection) as ctx:
+        response = admin_client.get(url)
+    assert response.status_code == 200, response.status_code
+    return len(ctx.captured_queries)
+
+
+@pytest.fixture
+def trace_fixtures(organization, integration_type_er):
+    from integrations.models import Source
+
+    provider = Integration.objects.create(
+        type=integration_type_er, owner=organization,
+        name="Trace Provider", base_url="https://provider.example.org",
+    )
+    destination = Integration.objects.create(
+        type=integration_type_er, owner=organization,
+        name="Trace Destination", base_url="https://destination.example.org",
+    )
+    source = Source.objects.create(external_id="source-1", integration=provider)
+    return provider, destination, source
+
+
+def _bulk_traces(provider, destination, source, count):
+    from integrations.models import GundiTrace
+
+    GundiTrace.objects.bulk_create(
+        [
+            GundiTrace(
+                object_type="ev", data_provider=provider,
+                destination=destination, source=source,
+                external_id=f"external-{i}",
+            )
+            for i in range(count)
+        ]
+    )
+
+
+def test_gundi_trace_changelist_query_count_does_not_scale_with_row_count(
+    admin_client, trace_fixtures
+):
+    """The GundiTrace changelist must not issue per-row queries.
+
+    ``list_select_related = True`` follows only non-nullable FKs, so
+    ``destination``, ``source`` and ``created_by`` are all dereferenced
+    lazily -- and Integration/Source ``__str__`` then walk owner, type and
+    integration. That was measured at ~7 queries per row.
+    """
+    provider, destination, source = trace_fixtures
+    url = reverse("admin:integrations_gunditrace_changelist")
+
+    _bulk_traces(provider, destination, source, 5)
+    baseline = _changelist_query_count(admin_client, url)
+
+    _bulk_traces(provider, destination, source, 95)
+    after = _changelist_query_count(admin_client, url)
+
+    assert after - baseline <= 2, (
+        "GundiTrace changelist query count scales with the number of rows: "
+        f"{baseline} queries -> {after} queries after adding 95 more traces."
+    )
+
+
+def test_gundi_trace_changelist_does_not_use_date_hierarchy(admin_client):
+    """date_hierarchy runs ``SELECT DISTINCT DATE_TRUNC(...)`` over the whole
+    queryset on every render -- a sequential scan of the largest table in the
+    database. A date filter provides timeframe filtering without aggregating.
+    """
+    from integrations.models import GundiTrace
+
+    model_admin = django_admin.site._registry[GundiTrace]
+    assert model_admin.date_hierarchy is None
+
+    filter_targets = [
+        spec[0] if isinstance(spec, (tuple, list)) else spec
+        for spec in model_admin.list_filter
+    ]
+    assert "created_at" in filter_targets, (
+        "Removing date_hierarchy must not remove timeframe filtering -- "
+        "expected 'created_at' in list_filter."
+    )
+
+
+def test_gundi_trace_changelist_does_not_render_error_text_per_row(admin_client):
+    """``error`` holds up to 500 characters. Rendering it for every row bloats
+    the changelist HTML; it stays on the detail page. ``has_error`` remains as
+    the scannable indicator.
+    """
+    from integrations.models import GundiTrace
+
+    model_admin = django_admin.site._registry[GundiTrace]
+    assert "error" not in model_admin.list_display
+    assert "has_error" in model_admin.list_display

--- a/cdip_admin/integrations/tests/test_admin.py
+++ b/cdip_admin/integrations/tests/test_admin.py
@@ -74,13 +74,6 @@ def test_route_change_page_owner_and_configuration_use_autocomplete(
     assert isinstance(unwrap(form.fields["configuration"].widget), AutocompleteSelect)
 
 
-def _changelist_query_count(admin_client, url):
-    with CaptureQueriesContext(connection) as ctx:
-        response = admin_client.get(url)
-    assert response.status_code == 200, response.status_code
-    return len(ctx.captured_queries)
-
-
 @pytest.fixture
 def trace_fixtures(organization, integration_type_er):
     from integrations.models import Source
@@ -126,10 +119,10 @@ def test_gundi_trace_changelist_query_count_does_not_scale_with_row_count(
     url = reverse("admin:integrations_gunditrace_changelist")
 
     _bulk_traces(provider, destination, source, 5)
-    baseline = _changelist_query_count(admin_client, url)
+    baseline = _render_query_count(admin_client, url)
 
     _bulk_traces(provider, destination, source, 95)
-    after = _changelist_query_count(admin_client, url)
+    after = _render_query_count(admin_client, url)
 
     assert after - baseline <= 2, (
         "GundiTrace changelist query count scales with the number of rows: "


### PR DESCRIPTION
## Summary

The Activity Log and Gundi Trace admin changelists were effectively unusable in production — every page load issued ~610 database queries *and* ran a full sequential scan. They now render in single digits.

| Changelist | Before | After |
|---|---|---|
| Activity Log | 612 queries | **6** |
| Gundi Trace | 610 queries | **8** |

Measured the same way both times: a 100-row page with 152 integrations, rendered end-to-end through `admin_client`, with the only difference being the three admin files in this PR.

Three independent causes, none of them the `COUNT(*)` that `EstimatedCountPaginator` already addressed:

**`list_select_related = True` was following almost nothing.** A bare `select_related()` follows only *non-nullable* FKs. On `ActivityLog` that meant it followed neither `integration` nor `created_by` (both nullable), so it bought nothing at all; on `GundiTrace` it followed only `data_provider`. Every displayed row then dereferenced the rest lazily, and `Integration.__str__` walked `owner` and `type` on top of that. The relations are now named explicitly.

**The `integration` sidebar filter cost 2 queries per integration in the database, on every render.** `RelatedFieldListFilter` calls `str(obj)` for each option and does not `select_related`, so the sidebar got measurably slower as integrations were added. `SelectRelatedFieldListFilter` (new, in `core/admin.py`) mirrors `Field.get_choices()` with a `select_related()` inserted — that method offers no hook — and is reusable for the destination/source filters in the follow-up work below.

**`date_hierarchy` was a guaranteed full scan.** It issues `SELECT DISTINCT DATE_TRUNC(...)` over the whole filtered queryset on every render. No Postgres version can answer that from an index (there is no skip scan), so it is a sequential scan of every partition: 3,677 buffers and 131 ms per 500k rows on PG 14, linear in table size. Timeframe filtering is preserved via a `created_at` `CustomDateFilter`, which builds its links from the clock rather than the table, so it costs nothing.

## What reviewers should look at

**No migration, and deliberately so.** The first draft of this work added a `(created_at DESC, id DESC)` index, on the theory that the admin's `-pk` ordering tiebreak could not use the existing `created_at DESC`-only index. That is true on PG 12 (parallel seq scan, 3,787 buffers) but **false from PG 13 onward**: Incremental Sort plus Merge Append satisfies it in 10 buffers / 0.08 ms, verified on a throwaway PG 14 instance including the partitioned case. Since production is 14+, the index would have been dead weight. Worth knowing if anyone revisits this — the repo's `docker-compose.yml` still pins PG 12, so local `EXPLAIN` output is misleading here.

**Gundi Trace's `source` column changed shape.** It is now an annotated `source__external_id` rendered as a link to the same Source change page. This is not cosmetic: constructing *any* `Source` instance runs `ChangeLogMixin.__init__`, which resolves the instance's related integration **before** Django populates the FK cache, costing one query per row that `select_related` cannot prevent. Annotating avoids building the instances at all. The click-through is preserved; the label is now just the external id rather than `external_id - integration_type`.

**One change slightly beyond pure performance:** `details` is removed from `ActivityLog.search_fields`. Leaving it means any admin search runs `UPPER(details::text) LIKE '%term%'`, casting and scanning every JSON blob in the table. Searching `title` and `value` still works. Happy to restore it if you want `details` searchable — the sound way is a GIN index plus key-specific lookups, which belongs with the search rework.

Dropped columns: `details` and `revert_data` from Activity Log, `error` from Gundi Trace. `has_error` remains as the scannable indicator and all three fields remain on the detail pages.

## Validation

Two of the new tests assert **flatness** rather than an absolute ceiling — query count must not grow when 95 more rows or 100 more integrations are added — following the pattern already in `integrations/tests/test_admin.py`. That is what stops these N+1s from silently returning; an absolute number would drift with unrelated changes. They failed at 28 -> 310 and 28 -> 228 before the fix.

7 new tests, all watched failing first. `activity_log`, `integrations/tests/test_admin.py`, `core` and `deployments` pass: 118 passed, 1 skipped.

On regressions, since this repo has pre-existing failures: I diffed the full failure set for `activity_log`, `integrations`, `core`, `deployments` and `api` with and without these changes. Baseline 83 failures, with the change 76, and the set of failures present *after* but not *before* is **empty** — the difference is exactly the 7 new tests failing against the old code. The remaining 76 are pre-existing and untouched by this PR (46 in `test_integration_views.py`, 15 in `test_device_filters.py`, 9 in `api/tests/test_api_views.py`, 5 in `test_tasks.py`, 1 in `test_routes_api.py`).

## Follow-up work, not in this PR

Each of these is worth its own change:

- **Search rework.** `GundiTrace.search_fields` matches UUID columns via `UPPER(object_id::text) LIKE '%term%'`, which no index can serve. Django's `=` prefix does *not* fix it — it yields `UPPER(object_id::text) = UPPER(...)`, still a function on the column. It needs a `get_search_results()` override that parses the term as a UUID and filters `object_id=<uuid>` for a real index seek, plus dropping the six OR'd join fields that force a hash join across the whole table. If free-text search on `title` is wanted, note that a plain `gin(title gin_trgm_ops)` index **will be ignored** because Django emits `UPPER(title) LIKE UPPER(...)`; the expression form `gin(UPPER(title::text) gin_trgm_ops)` is required (93 ms -> 3.8 ms on 200k rows).
- **Composite indexes** for the filter combinations actually used: `(data_provider_id, created_at DESC)`, `(destination_id, created_at DESC)`, `(source_id, created_at DESC)` on traces, `(log_level, created_at DESC)` on logs. Filtering activity logs by *integration type* is not currently possible at all — `integration_type` is a Python property, not a column.
- **`ChangeLogMixin.__init__` resolves the related integration on every instance loaded from the database**, before the FK cache exists, so `select_related` cannot help. This is app-wide, not admin-specific: measured at 1 extra query per row for `Source` and 4 per row for `SourceFilter`. `log_activity` already falls back to `self._original_integration or self._get_related_integration()`, so capturing only `integration_id` in `__init__` and resolving lazily would preserve the semantics.
- **Partitioning and retention.** The `cdc` partition of `activity_log_activitylog` is a single unbounded table with no retention (only `ev` is time-subpartitioned, at 3 weeks). `GundiTrace` is not partitioned at all and has no retention while growing proportionally to delivered observations.

Minor: `GundiTrace` is registered with `SimpleHistoryAdmin` but has no `HistoricalRecords` — history exists only on v1 models — so that base class does nothing and its History button will error.



Related: [GUNDI-5588](https://allenai.atlassian.net/browse/GUNDI-5588)


[GUNDI-5588]: https://allenai.atlassian.net/browse/GUNDI-5588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ