### PR TITLE
fix: stop the activity log integration filter enumerating every integration

### DIFF
--- a/cdip_admin/activity_log/admin.py
+++ b/cdip_admin/activity_log/admin.py
@@ -1,9 +1,10 @@
 from django.contrib import admin
+from django.contrib.admin.widgets import AutocompleteSelect
 
 from core.admin import (
+    AutocompleteFieldListFilter,
     CustomDateFilter,
     EstimatedCountPaginator,
-    SelectRelatedFieldListFilter,
 )
 
 from .models import ActivityLog
@@ -91,6 +92,16 @@ class ActivityLogAdmin(admin.ModelAdmin):
         "log_type",
         "origin",
         "is_reversible",
-        ("integration", SelectRelatedFieldListFilter),
+        ("integration", AutocompleteFieldListFilter),
     )
     actions = [revert_selected]
+
+    @property
+    def media(self):
+        # Django collects media from the admin and its forms, but not from
+        # list filters, so the select2 assets AutocompleteFieldListFilter
+        # depends on have to be contributed here or the widget renders as an
+        # inert <select>.
+        return super().media + AutocompleteSelect(
+            self.opts.get_field("integration"), self.admin_site
+        ).media

--- a/cdip_admin/activity_log/tests/test_admin_performance.py
+++ b/cdip_admin/activity_log/tests/test_admin_performance.py
@@ -134,3 +134,126 @@ def test_changelist_does_not_render_json_blobs_per_row(admin_client):
     model_admin = django_admin.site._registry[ActivityLog]
     assert "details" not in model_admin.list_display
     assert "revert_data" not in model_admin.list_display
+
+
+def test_integration_filter_does_not_render_an_option_per_integration(
+    admin_client, provider, organization, integration_type_er
+):
+    """The sidebar must not enumerate the Integration table.
+
+    Selecting every integration in one query (rather than two per option) is
+    not enough: the filter still emits an ``<option>`` per integration, so the
+    changelist HTML -- and the browser's parse cost -- grows without bound as
+    integrations are added. Measured at ~168 bytes per integration, which is
+    185 KB of markup at 1,200 integrations. The autocomplete widget renders
+    only the currently selected option and fetches the rest over AJAX.
+    """
+    url = reverse("admin:activity_log_activitylog_changelist")
+    _bulk_logs(provider, 5)
+
+    baseline = len(admin_client.get(url).content)
+
+    Integration.objects.bulk_create(
+        [
+            Integration(
+                type=integration_type_er,
+                owner=organization,
+                name=f"Bulk Integration {i}",
+                base_url=f"https://bulk-{i}.example.org",
+            )
+            for i in range(200)
+        ]
+    )
+
+    after = len(admin_client.get(url).content)
+
+    assert after - baseline < 2000, (
+        "Changelist HTML grows with the number of integrations: "
+        f"{baseline} bytes -> {after} bytes after adding 200 integrations. "
+        "The integration filter must not render an option per integration."
+    )
+
+
+def test_integration_filter_renders_autocomplete_widget(admin_client, provider):
+    """The filter renders Django's AutocompleteSelect, which is what makes the
+    option list lazy. Asserting on the rendered markup rather than the filter
+    class keeps this honest about what the browser actually receives.
+    """
+    url = reverse("admin:activity_log_activitylog_changelist")
+    _bulk_logs(provider, 5)
+
+    content = admin_client.get(url).content.decode()
+
+    assert "admin-autocomplete" in content
+    assert 'data-app-label="activity_log"' in content
+    assert 'data-model-name="activitylog"' in content
+    assert 'data-field-name="integration"' in content
+
+
+def test_integration_filter_ships_the_select2_assets(admin_client, provider):
+    """Django collects media from the admin and its forms but not from list
+    filters, so the select2 assets have to be contributed by the ModelAdmin.
+    Without them the widget renders as an inert <select> that still works but
+    silently loses the type-ahead.
+    """
+    url = reverse("admin:activity_log_activitylog_changelist")
+    _bulk_logs(provider, 5)
+
+    content = admin_client.get(url).content.decode()
+
+    assert "autocomplete.js" in content
+    assert "select2" in content
+
+
+def test_admin_autocomplete_endpoint_serves_the_integration_filter(
+    admin_client, provider
+):
+    """The built-in /admin/autocomplete/ endpoint must answer for this filter.
+
+    Django validates the request against the *source* field and the related
+    model's admin (which needs search_fields); it does not require the field
+    to appear in any ModelAdmin.autocomplete_fields. This test pins that,
+    because the whole approach depends on it and a future Django release
+    tightening the check would break the filter silently.
+    """
+    response = admin_client.get(
+        reverse("admin:autocomplete"),
+        {
+            "app_label": "activity_log",
+            "model_name": "activitylog",
+            "field_name": "integration",
+            "term": "Provider",
+        },
+    )
+
+    assert response.status_code == 200, response.status_code
+    results = response.json()["results"]
+    assert str(provider.pk) in [r["id"] for r in results]
+
+
+def test_integration_filter_preserves_other_active_filters(admin_client, provider):
+    """The filter submits a GET form, so every other active parameter has to
+    ride along as a hidden input or choosing an integration would silently
+    drop the search term, the date filter and the ordering.
+    """
+    url = reverse("admin:activity_log_activitylog_changelist")
+    _bulk_logs(provider, 5)
+
+    content = admin_client.get(url, {"log_level__exact": "20", "q": "log"}).content.decode()
+
+    assert '<input type="hidden" name="log_level__exact" value="20">' in content
+    assert '<input type="hidden" name="q" value="log">' in content
+
+
+def test_integration_filter_is_submittable_without_javascript(admin_client, provider):
+    """Auto-submit-on-change depends on select2 re-dispatching the event, which
+    cannot be verified without a browser. An explicit submit control keeps the
+    filter usable regardless.
+    """
+    url = reverse("admin:activity_log_activitylog_changelist")
+    _bulk_logs(provider, 5)
+
+    content = admin_client.get(url).content.decode()
+
+    assert '<form method="get" class="autocomplete-filter">' in content
+    assert '<button type="submit">' in content

--- a/cdip_admin/activity_log/tests/test_admin_performance.py
+++ b/cdip_admin/activity_log/tests/test_admin_performance.py
@@ -257,3 +257,62 @@ def test_integration_filter_is_submittable_without_javascript(admin_client, prov
 
     assert '<form method="get" class="autocomplete-filter">' in content
     assert '<button type="submit">' in content
+
+
+def test_integration_filter_offers_the_no_integration_option(admin_client, provider):
+    """``ActivityLog.integration`` is nullable with ``on_delete=SET_NULL``, so
+    orphaned logs really do accumulate. ``RelatedFieldListFilter`` offers an
+    empty choice for exactly this case; replacing its ``choices()`` must not
+    quietly drop the ability to find those rows.
+    """
+    url = reverse("admin:activity_log_activitylog_changelist")
+    _bulk_logs(provider, 3)
+
+    content = admin_client.get(url).content.decode()
+
+    assert "integration__isnull=True" in content
+
+
+def test_integration_filter_no_integration_option_selects_orphaned_logs(
+    admin_client, provider
+):
+    """The empty choice must actually filter, not just render."""
+    url = reverse("admin:activity_log_activitylog_changelist")
+    _bulk_logs(provider, 3, title_prefix="has integration")
+    ActivityLog.objects.create(
+        log_level=ActivityLog.LogLevels.INFO,
+        log_type=ActivityLog.LogTypes.EVENT,
+        origin=ActivityLog.Origin.DISPATCHER,
+        value="orphan",
+        title="orphaned log",
+        integration=None,
+        details={},
+        revert_data={},
+    )
+
+    content = admin_client.get(url, {"integration__isnull": "True"}).content.decode()
+
+    assert "orphaned log" in content
+    assert "has integration" not in content
+
+
+def test_integration_filter_choices_offer_all_and_none(rf, admin_user):
+    """Assert on the filter's own choices rather than the rendered page: every
+    other sidebar filter also renders an "All" link, so a raw HTML search for
+    one passes even when this filter offers nothing.
+    """
+    model_admin = django_admin.site._registry[ActivityLog]
+    request = rf.get("/admin/")
+    request.user = admin_user
+    changelist = model_admin.get_changelist_instance(request)
+    spec = next(
+        s
+        for s in changelist.filter_specs
+        if getattr(s, "field", None) is not None and s.field.name == "integration"
+    )
+
+    links = list(spec.choices(changelist))[0]["links"]
+    displays = [link["display"] for link in links]
+
+    assert "All" in displays
+    assert model_admin.get_empty_value_display() in displays

--- a/cdip_admin/activity_log/tests/test_admin_performance.py
+++ b/cdip_admin/activity_log/tests/test_admin_performance.py
@@ -316,3 +316,53 @@ def test_integration_filter_choices_offer_all_and_none(rf, admin_user):
 
     assert "All" in displays
     assert model_admin.get_empty_value_display() in displays
+
+
+def test_integration_filter_actually_filters_by_integration(
+    admin_client, provider, organization, integration_type_er
+):
+    """The filter's whole purpose, pinned.
+
+    ``field_choices()`` returns nothing on purpose, so nothing else here would
+    notice if Django's parameter handling changed and the filter silently
+    stopped narrowing the queryset -- the page would still render, just with
+    every row.
+    """
+    other = Integration.objects.create(
+        type=integration_type_er,
+        owner=organization,
+        name="Other Provider",
+        base_url="https://other.example.org",
+    )
+    _bulk_logs(provider, 3, title_prefix="wanted")
+    _bulk_logs(other, 3, title_prefix="unwanted")
+
+    url = reverse("admin:activity_log_activitylog_changelist")
+    content = admin_client.get(
+        url, {"integration__id__exact": str(provider.pk)}
+    ).content.decode()
+
+    assert "wanted 0" in content
+    assert "unwanted" not in content
+
+
+def test_selected_integration_label_does_not_cost_extra_queries(
+    admin_client, provider
+):
+    """Rendering the selected option calls ``Integration.__str__``, which
+    dereferences owner and type -- the very N+1 this filter exists to avoid,
+    reappearing on exactly the pages where someone is using the filter.
+    """
+    url = reverse("admin:activity_log_activitylog_changelist")
+    _bulk_logs(provider, 5)
+
+    unfiltered = _changelist_query_count(admin_client, url)
+    filtered = _changelist_query_count(
+        admin_client, f"{url}?integration__id__exact={provider.pk}"
+    )
+
+    assert filtered <= unfiltered + 1, (
+        f"Filtering costs {filtered - unfiltered} extra queries "
+        f"({unfiltered} -> {filtered}); the selected option's label should be "
+        "fetched with select_related."
+    )

--- a/cdip_admin/core/admin.py
+++ b/cdip_admin/core/admin.py
@@ -58,10 +58,16 @@ class AutocompleteFieldListFilter(RelatedFieldListFilter):
         # ``limit_choices_to`` keeps that label consistent with what
         # /admin/autocomplete/ will actually offer -- the endpoint applies the
         # same filter in ``AutocompleteJsonView.get_queryset``.
+        #
+        # ``select_related()`` matters even though only one row is ever
+        # fetched: rendering the label calls ``Integration.__str__``, which
+        # dereferences owner and type, so a filtered changelist paid 3 queries
+        # instead of 1 -- the same N+1 this filter exists to remove, reappearing
+        # on exactly the pages where the filter is in use.
         widget.choices = forms.ModelChoiceField(
             queryset=self.field.remote_field.model._default_manager.complex_filter(
                 self.field.get_limit_choices_to()
-            ),
+            ).select_related(),
             required=False,
         ).choices
 

--- a/cdip_admin/core/admin.py
+++ b/cdip_admin/core/admin.py
@@ -53,12 +53,43 @@ class AutocompleteFieldListFilter(RelatedFieldListFilter):
 
     def choices(self, changelist):
         widget = AutocompleteSelect(self.field, changelist.model_admin.admin_site)
-        # AutocompleteSelect reads ``choices.field`` and ``choices.queryset``
-        # to render the selected option, so it needs a bound form field.
+        # AutocompleteSelect reads ``choices.field`` and ``choices.queryset`` to
+        # render the selected option, so it needs a bound form field. Applying
+        # ``limit_choices_to`` keeps that label consistent with what
+        # /admin/autocomplete/ will actually offer -- the endpoint applies the
+        # same filter in ``AutocompleteJsonView.get_queryset``.
         widget.choices = forms.ModelChoiceField(
-            queryset=self.field.remote_field.model._default_manager.all(),
+            queryset=self.field.remote_field.model._default_manager.complex_filter(
+                self.field.get_limit_choices_to()
+            ),
             required=False,
         ).choices
+
+        # "All" and "(None)" mirror RelatedFieldListFilter. The empty choice
+        # matters here: ``ActivityLog.integration`` is nullable with
+        # ``on_delete=SET_NULL``, so orphaned rows accumulate and this is the
+        # only way to find them. The autocomplete widget cannot express
+        # "is null", so it stays a plain link.
+        links = [
+            {
+                "selected": self.lookup_val is None and not self.lookup_val_isnull,
+                "query_string": changelist.get_query_string(
+                    remove=[self.lookup_kwarg, self.lookup_kwarg_isnull]
+                ),
+                "display": _("All"),
+            }
+        ]
+        if self.include_empty_choice:
+            links.append(
+                {
+                    "selected": bool(self.lookup_val_isnull),
+                    "query_string": changelist.get_query_string(
+                        {self.lookup_kwarg_isnull: "True"}, [self.lookup_kwarg]
+                    ),
+                    "display": self.empty_value_display,
+                }
+            )
+
         yield {
             "widget": widget.render(
                 self.lookup_kwarg,
@@ -73,10 +104,7 @@ class AutocompleteFieldListFilter(RelatedFieldListFilter):
                 for key, value in changelist.params.items()
                 if key not in (self.lookup_kwarg, self.lookup_kwarg_isnull)
             ],
-            "clear_url": changelist.get_query_string(
-                remove=[self.lookup_kwarg, self.lookup_kwarg_isnull]
-            ),
-            "is_set": bool(self.lookup_val),
+            "links": links,
         }
 
 

--- a/cdip_admin/core/admin.py
+++ b/cdip_admin/core/admin.py
@@ -1,8 +1,9 @@
 import logging
-import operator
 from datetime import datetime, timedelta
 
+from django import forms
 from django.contrib.admin.filters import DateFieldListFilter, RelatedFieldListFilter
+from django.contrib.admin.widgets import AutocompleteSelect
 from django.core.paginator import Paginator
 from django.db import connection
 from django.utils.functional import cached_property
@@ -12,39 +13,71 @@ from django.utils.translation import gettext_lazy as _
 logger = logging.getLogger(__name__)
 
 
-class SelectRelatedFieldListFilter(RelatedFieldListFilter):
-    """A ``RelatedFieldListFilter`` that ``select_related``s its choice queryset.
+class AutocompleteFieldListFilter(RelatedFieldListFilter):
+    """A foreign-key sidebar filter that never enumerates the related table.
 
-    The base filter builds its sidebar dropdown by calling ``str(obj)`` on
-    every row of the related model. When that model's ``__str__`` dereferences
-    its own foreign keys -- ``Integration.__str__`` returns
-    ``f"{self.owner.name} - {self.name} - {self.type.name}"`` -- each option
-    costs one query per relation, so *every* changelist render gets slower as
-    integrations are added. Measured at 2 queries per integration.
+    ``RelatedFieldListFilter`` renders one ``<option>`` per row of the related
+    model, so the changelist HTML grows without bound as rows are added --
+    roughly 168 bytes per Integration, measured. Loading those options in a
+    single ``select_related`` query fixes the query count but not the payload,
+    and rendering every Integration into a ``<select>`` is what previously
+    timed out the Route change page (see
+    ``test_route_change_page_does_not_scale_with_integration_count``).
 
-    A bare ``select_related()`` is the right tool here: it follows the target
-    model's non-nullable FKs (``Integration.owner`` and ``Integration.type``)
-    in the same query, and by definition never descends through a nullable
-    relation, so it cannot blow up into a wide join.
+    ``AutocompleteSelect`` renders only the *currently selected* option --
+    ``AutocompleteMixin.optgroups`` filters the queryset to the selected keys,
+    so an unfiltered changelist emits zero options and issues zero queries --
+    and fetches the rest over AJAX, 20 at a time, as the user types.
 
-    This mirrors ``Field.get_choices()`` rather than delegating to it, because
-    that method offers no hook for adjusting the queryset.
+    This reuses Django's own ``/admin/autocomplete/`` endpoint and bundled
+    select2 assets, so it needs no extra dependency. The endpoint validates the
+    *source* field and requires the related model's admin to define
+    ``search_fields``; it does not require the field to appear in any
+    ``ModelAdmin.autocomplete_fields``, which is what makes it usable from a
+    filter that has no form field at all.
+
+    The admin using this filter must contribute the widget's media, which
+    Django does not collect from filters -- see ``ActivityLogAdmin.media``.
     """
 
+    template = "admin/autocomplete_filter.html"
+
     def field_choices(self, field, request, model_admin):
-        ordering = self.field_admin_ordering(field, request, model_admin)
-        related_model = field.remote_field.model
-        choice_func = operator.attrgetter(
-            field.remote_field.get_related_field().attname
-            if hasattr(field.remote_field, "get_related_field")
-            else "pk"
-        )
-        queryset = related_model._default_manager.complex_filter(
-            field.get_limit_choices_to()
-        ).select_related()
-        if ordering:
-            queryset = queryset.order_by(*ordering)
-        return [(choice_func(obj), str(obj)) for obj in queryset]
+        # Never enumerate the related table; that is the entire point.
+        return []
+
+    def has_output(self):
+        # The base class hides a filter offering fewer than two choices, and
+        # this one deliberately offers none up front.
+        return True
+
+    def choices(self, changelist):
+        widget = AutocompleteSelect(self.field, changelist.model_admin.admin_site)
+        # AutocompleteSelect reads ``choices.field`` and ``choices.queryset``
+        # to render the selected option, so it needs a bound form field.
+        widget.choices = forms.ModelChoiceField(
+            queryset=self.field.remote_field.model._default_manager.all(),
+            required=False,
+        ).choices
+        yield {
+            "widget": widget.render(
+                self.lookup_kwarg,
+                self.lookup_val,
+                attrs={"onchange": "this.form.submit();"},
+            ),
+            # Every other active parameter has to ride along as a hidden input
+            # or submitting this filter would silently drop the search term,
+            # the date filter and the ordering.
+            "carried_params": [
+                (key, value)
+                for key, value in changelist.params.items()
+                if key not in (self.lookup_kwarg, self.lookup_kwarg_isnull)
+            ],
+            "clear_url": changelist.get_query_string(
+                remove=[self.lookup_kwarg, self.lookup_kwarg_isnull]
+            ),
+            "is_set": bool(self.lookup_val),
+        }
 
 
 class CustomDateFilter(DateFieldListFilter):

--- a/cdip_admin/core/templates/admin/autocomplete_filter.html
+++ b/cdip_admin/core/templates/admin/autocomplete_filter.html
@@ -11,9 +11,11 @@
        without JavaScript at all. #}
     <button type="submit">{% translate "Apply" %}</button>
   </form>
-  {% if choice.is_set %}
-    <ul class="autocomplete-filter-clear">
-      <li><a href="{{ choice.clear_url }}">{% translate "All" %}</a></li>
-    </ul>
-  {% endif %}
+  <ul>
+    {% for link in choice.links %}
+      <li{% if link.selected %} class="selected"{% endif %}>
+        <a href="{{ link.query_string }}">{{ link.display }}</a>
+      </li>
+    {% endfor %}
+  </ul>
 {% endfor %}

--- a/cdip_admin/core/templates/admin/autocomplete_filter.html
+++ b/cdip_admin/core/templates/admin/autocomplete_filter.html
@@ -1,0 +1,19 @@
+{% load i18n %}
+<h3>{% blocktranslate with filter_title=title %}By {{ filter_title }}{% endblocktranslate %}</h3>
+{% for choice in choices %}
+  <form method="get" class="autocomplete-filter">
+    {% for key, value in choice.carried_params %}
+      <input type="hidden" name="{{ key }}" value="{{ value }}">
+    {% endfor %}
+    {{ choice.widget }}
+    {# The widget also submits on change, but that path depends on select2
+       re-dispatching the event, so keep an explicit control that works
+       without JavaScript at all. #}
+    <button type="submit">{% translate "Apply" %}</button>
+  </form>
+  {% if choice.is_set %}
+    <ul class="autocomplete-filter-clear">
+      <li><a href="{{ choice.clear_url }}">{% translate "All" %}</a></li>
+    </ul>
+  {% endif %}
+{% endfor %}


### PR DESCRIPTION
## Summary

The Activity Log sidebar's **By integration** filter rendered one `<option>` per Integration in the database, on every changelist load, whether or not anyone used it. #458 removed the *query* storm behind it (2 queries per option → 1 query total) but not the payload — the markup still grew without bound.

Measured on an identical fixture, 100 rows:

| Integrations | Before | After |
|---|---|---|
| 1 | 6 queries, 98.3 KB | 5 queries, 98.8 KB |
| 201 | 6 queries, 128.8 KB | 5 queries, **98.8 KB** |
| 1,201 | 6 queries, **283.0 KB** | 5 queries, **98.8 KB** |

Roughly 168 bytes of markup per integration, plus the browser's parse cost. Page cost is now completely flat — byte-identical HTML at 1 and at 1,201 integrations.

## How

`AutocompleteFieldListFilter` renders Django's `AutocompleteSelect` in place of a choice list. `AutocompleteMixin.optgroups` restricts the queryset to the *currently selected* keys, so an unfiltered changelist emits zero options and runs zero queries for them; the rest arrive over AJAX, 20 at a time, as the user types — searchable by name, owner and type, since `IntegrationAdmin.search_fields` already covers those.

**No new dependency.** This reuses Django's own `/admin/autocomplete/` endpoint and the select2 assets Django already bundles. It also matches the pattern this repo already adopted for the identical problem: rendering every Integration into a `<select>` is what timed out the Route change page, per the docstring on `test_route_change_page_does_not_scale_with_integration_count`, and the fix there was `autocomplete_fields`.

## What reviewers should look at

**The approach hinges on one piece of Django behaviour, so there's a test pinning it.** `AutocompleteJsonView.process_request` validates the *source* field and requires the *related* model's admin to define `search_fields` — it does **not** require the field to appear in any `ModelAdmin.autocomplete_fields`. That's what lets a list filter, which has no form field at all, use the built-in endpoint. `test_admin_autocomplete_endpoint_serves_the_integration_filter` will fail loudly if a future Django release tightens that check, rather than the filter silently returning nothing.

**`SelectRelatedFieldListFilter` is deleted, not kept.** The integration filter was its only caller, so leaving it would ship dead code. It was merged in #458 barely ahead of this; the autocomplete filter supersedes it for this use and is the better base for the Gundi Trace `data_provider` / `destination` / `source` filters, where a plain dropdown would be far worse — Sources scale with devices.

**Django does not collect media from list filters**, only from the admin and its forms. `ActivityLogAdmin.media` contributes the select2 assets explicitly; without it the widget degrades to an inert `<select>` that still filters but silently loses the type-ahead. `test_integration_filter_ships_the_select2_assets` covers that, verified by removing the property and watching it fail.

**The filter submits a GET form**, so every other active parameter rides along as a hidden input — otherwise choosing an integration would silently drop the search term, the date filter and the ordering. Also covered by a test verified the same way.

## Validation

6 new tests, plus the 4 from #458 still green (10 total in the file). The two tests I wrote after the implementation were validated by mutation — I removed the `media` property and the hidden-input loop and confirmed each test failed — rather than trusting that they passed.

Full suite across `activity_log`, `integrations`, `core`, `deployments`, `api`, `accounts` and `organizations`, run with and without this change: **23 pre-existing failures both ways**. The one test that differs between the two runs (`test_get_outbound_integration_configuration_list_filter_by_enabled_true`) is order-dependent — it fails on clean `main` in isolation too, in a file this PR does not touch.

**Not verified:** the auto-submit-on-change path. The widget carries `onchange="this.form.submit();"` and select2 should re-dispatch the event, but I have no browser here to confirm it. That's why there's an always-visible **Apply** button rather than a `<noscript>` fallback — the filter works either way, and the auto-submit is a bonus if it fires. Worth a quick manual check when someone runs this locally; if auto-submit works, the button could be hidden behind CSS later.

Related: [GUNDI-5588](https://allenai.atlassian.net/browse/GUNDI-5588)


[GUNDI-5588]: https://allenai.atlassian.net/browse/GUNDI-5588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ