### PR TITLE
fix: stop template comment leaking into the admin sidebar, and label the trace type filters

### DIFF
--- a/cdip_admin/activity_log/tests/test_admin_performance.py
+++ b/cdip_admin/activity_log/tests/test_admin_performance.py
@@ -366,3 +366,31 @@ def test_selected_integration_label_does_not_cost_extra_queries(
         f"({unfiltered} -> {filtered}); the selected option's label should be "
         "fetched with select_related."
     )
+
+
+def test_integration_filter_leaks_no_template_source(admin_client, provider):
+    """Django's ``{# ... #}`` comments are single-line only -- a multi-line one
+    is not a comment at all and renders as literal text in the sidebar, which
+    is exactly what shipped to dev. Asserting the Apply button exists did not
+    catch it; this asserts nothing stray comes with it.
+    """
+    url = reverse("admin:activity_log_activitylog_changelist")
+    _bulk_logs(provider, 3)
+
+    content = admin_client.get(url).content.decode()
+
+    assert "{#" not in content
+    assert "#}" not in content
+    assert "select2 re-dispatching" not in content
+
+
+def test_integration_filter_matches_admin_filter_markup(admin_client, provider):
+    """The sidebar filters are collapsible ``<details>`` elements in Django
+    4.2's admin. A bare ``<h3>`` renders as a non-collapsible odd one out.
+    """
+    url = reverse("admin:activity_log_activitylog_changelist")
+    _bulk_logs(provider, 3)
+
+    content = admin_client.get(url).content.decode()
+
+    assert '<details data-filter-title="integration"' in content

--- a/cdip_admin/core/admin.py
+++ b/cdip_admin/core/admin.py
@@ -13,6 +13,23 @@ from django.utils.translation import gettext_lazy as _
 logger = logging.getLogger(__name__)
 
 
+def titled_filter(title, base=RelatedFieldListFilter):
+    """Return a copy of ``base`` whose sidebar heading is ``title``.
+
+    A related-field filter takes its heading from the *target* model, so two
+    filters pointing at the same model render identical headings: filtering
+    Gundi Traces by provider type and by destination type produced two panels
+    both labelled "By Integration Type", with nothing to distinguish them.
+    """
+
+    class TitledFieldListFilter(base):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.title = title
+
+    return TitledFieldListFilter
+
+
 class AutocompleteFieldListFilter(RelatedFieldListFilter):
     """A foreign-key sidebar filter that never enumerates the related table.
 

--- a/cdip_admin/core/templates/admin/autocomplete_filter.html
+++ b/cdip_admin/core/templates/admin/autocomplete_filter.html
@@ -1,21 +1,32 @@
 {% load i18n %}
-<h3>{% blocktranslate with filter_title=title %}By {{ filter_title }}{% endblocktranslate %}</h3>
-{% for choice in choices %}
-  <form method="get" class="autocomplete-filter">
-    {% for key, value in choice.carried_params %}
-      <input type="hidden" name="{{ key }}" value="{{ value }}">
-    {% endfor %}
-    {{ choice.widget }}
-    {# The widget also submits on change, but that path depends on select2
-       re-dispatching the event, so keep an explicit control that works
-       without JavaScript at all. #}
-    <button type="submit">{% translate "Apply" %}</button>
-  </form>
-  <ul>
-    {% for link in choice.links %}
-      <li{% if link.selected %} class="selected"{% endif %}>
-        <a href="{{ link.query_string }}">{{ link.display }}</a>
-      </li>
-    {% endfor %}
-  </ul>
-{% endfor %}
+{% comment %}
+  Mirrors django/contrib/admin/templates/admin/filter.html so this filter sits
+  in the sidebar like every other one, but swaps the choice list for an
+  autocomplete widget. Note {% comment %} rather than {# #}: the latter is
+  single-line only, and a multi-line one renders as literal text on the page.
+{% endcomment %}
+<details data-filter-title="{{ title }}" open>
+  <summary>
+    {% blocktranslate with filter_title=title %} By {{ filter_title }} {% endblocktranslate %}
+  </summary>
+  {% for choice in choices %}
+    <form method="get" class="autocomplete-filter">
+      {% for key, value in choice.carried_params %}
+        <input type="hidden" name="{{ key }}" value="{{ value }}">
+      {% endfor %}
+      {{ choice.widget }}
+      {% comment %}
+        The widget also submits on change, but that path depends on select2
+        re-dispatching the event, so keep an explicit control that works
+        without JavaScript at all.
+      {% endcomment %}
+      <button type="submit">{% translate "Apply" %}</button>
+    </form>
+    <ul>
+      {% for link in choice.links %}
+        <li{% if link.selected %} class="selected"{% endif %}>
+        <a href="{{ link.query_string|iriencode }}">{{ link.display }}</a></li>
+      {% endfor %}
+    </ul>
+  {% endfor %}
+</details>

--- a/cdip_admin/integrations/admin.py
+++ b/cdip_admin/integrations/admin.py
@@ -10,7 +10,7 @@ from django_celery_beat.admin import PeriodicTaskAdmin
 from django_celery_beat.models import PeriodicTask
 from simple_history.admin import SimpleHistoryAdmin
 from django.contrib import messages
-from core.admin import CustomDateFilter, EstimatedCountPaginator
+from core.admin import CustomDateFilter, EstimatedCountPaginator, titled_filter
 import deployments.models
 from .models import (
     OutboundIntegrationType,
@@ -609,8 +609,10 @@ class GundiTraceAdmin(SimpleHistoryAdmin):
         "has_error",
         "is_duplicate",
         "object_type",
-        "data_provider__type",
-        "destination__type",
+        # Both point at IntegrationType, so without explicit titles the
+        # sidebar shows two identical "By Integration Type" panels.
+        ("data_provider__type", titled_filter("Provider type")),
+        ("destination__type", titled_filter("Destination type")),
     )
 
     def get_queryset(self, request):

--- a/cdip_admin/integrations/tests/test_admin.py
+++ b/cdip_admin/integrations/tests/test_admin.py
@@ -160,3 +160,33 @@ def test_gundi_trace_changelist_does_not_render_error_text_per_row(admin_client)
     model_admin = django_admin.site._registry[GundiTrace]
     assert "error" not in model_admin.list_display
     assert "has_error" in model_admin.list_display
+
+
+def test_gundi_trace_type_filters_have_distinguishable_titles(
+    admin_client, trace_fixtures, organization
+):
+    """``data_provider__type`` and ``destination__type`` both point at
+    IntegrationType, so both inherit its verbose name and the sidebar renders
+    two identical "By Integration Type" panels with no way to tell which one
+    filters the provider and which the destination.
+
+    Needs two IntegrationTypes: a related-field filter offering fewer than two
+    choices is hidden, so with one type the duplication does not appear.
+    """
+    from integrations.models import IntegrationType
+
+    IntegrationType.objects.create(name="Second Type", value="second_type")
+    provider, destination, source = trace_fixtures
+    _bulk_traces(provider, destination, source, 2)
+
+    url = reverse("admin:integrations_gunditrace_changelist")
+    content = admin_client.get(url).content.decode()
+
+    assert content.count("By Integration Type") == 0, (
+        "The sidebar renders duplicate 'By Integration Type' filters; the "
+        "provider and destination type filters need distinct titles."
+    )
+    # Assert the replacements are present too: a bare "no duplicates" check
+    # would also pass if both filters disappeared altogether.
+    assert "By Provider type" in content
+    assert "By Destination type" in content

--- a/cdip_admin/integrations/tests/test_admin.py
+++ b/cdip_admin/integrations/tests/test_admin.py
@@ -163,7 +163,7 @@ def test_gundi_trace_changelist_does_not_render_error_text_per_row(admin_client)
 
 
 def test_gundi_trace_type_filters_have_distinguishable_titles(
-    admin_client, trace_fixtures, organization
+    admin_client, trace_fixtures
 ):
     """``data_provider__type`` and ``destination__type`` both point at
     IntegrationType, so both inherit its verbose name and the sidebar renders


### PR DESCRIPTION
## Summary

Two rendering bugs visible on dev, both in the admin filter sidebar.

**1. Template source printed onto the page.** The "By integration" filter rendered a paragraph of template source directly under the widget:

> `{# The widget also submits on change, but that path depends on select2 re-dispatching the event, so keep an explicit control that works without JavaScript at all. #}`

Django's `{# ... #}` comments are **single-line only**. A multi-line one is not a comment at all, so it was emitted as literal text. Now `{% comment %}`. My tests asserted the Apply button was *present* but never that nothing stray came with it — that gap is why this shipped, so the new test asserts no `{#`, `#}` or comment prose reaches the rendered page.

**2. Two identical "By Integration Type" filters on Gundi Trace.** `data_provider__type` and `destination__type` both point at `IntegrationType`, so both inherited its verbose name and the sidebar showed two indistinguishable panels — neither saying which end of the route it filtered. Now **"By Provider type"** and **"By Destination type"**, via a small `titled_filter` helper. This one predates the autocomplete work; it has been there as long as both filters have.

## Also fixed

The autocomplete filter rendered as a bare `<h3>` while every other filter in Django 4.2's sidebar is a collapsible `<details>` element — so it was the visible odd one out and, unlike its neighbours, could not be folded away. The template now mirrors `django/contrib/admin/templates/admin/filter.html`, including `|iriencode` on the links.

## What reviewers should look at

**The comment leak is a lesson about the shape of the assertion, not about test count.** There were 15 tests on this filter and none caught a paragraph of source text rendering in the sidebar, because every one asked *is the thing I want present?* and none asked *is anything here that should not be?* The new test is the negative form.

**The duplicate-title test needed strengthening.** My first version asserted `count("By Integration Type") <= 1`, which would also pass if both filters vanished entirely. It now asserts the count is zero **and** that "By Provider type" and "By Destination type" are both present.

**That test also needed real fixtures to fail.** A related-field filter offering fewer than two choices is hidden by `has_output()`, so with a single IntegrationType in the test database the duplication never appears and the test passes green against broken code. It creates a second type explicitly.

## Validation

23 tests green across the two admin test modules (4 new). Every new test was watched failing against the unfixed code first.

Full run of `activity_log`, `integrations`, `core` and `deployments` with and without the change: 15 failures vs 14 baseline. The single difference is `test_get_outbound_integration_configuration_list_filter_by_enabled_unset`, one of the `filter_by_enabled` family in `test_integration_views.py` that rotates between runs — confirmed failing on clean `main` both in isolation and as a group, in a file this PR does not touch.

**Still unverified:** the auto-submit-on-change path, same as the parent PR. The always-visible **Apply** button means the filter works regardless. Your dev screenshot does confirm the select2 widget itself renders and populates correctly, so the media wiring is good.

Related: [GUNDI-5588](https://allenai.atlassian.net/browse/GUNDI-5588)


[GUNDI-5588]: https://allenai.atlassian.net/browse/GUNDI-5588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ