### PR TITLE
feat: sort /v2/connections/ by destination type (GUNDI-5586)

### DIFF
--- a/cdip_admin/api/v2/filters.py
+++ b/cdip_admin/api/v2/filters.py
@@ -29,13 +29,26 @@ class ConnectionOrderingFilter(filters.OrderingFilter):
     removes the backend-dependent NULLS FIRST / NULLS LAST behavior.
 
     Appends `id` as a stable tiebreaker so pages are deterministic even
-    for rows that share a destination type name.
+    for rows that share a destination type name. The tiebreaker is
+    injected in `get_ordering()` so it applies to both the filter's own
+    `order_by()` and to `CursorPagination.paginate_queryset()`, which
+    re-orders the queryset using the value it obtains from this method.
     """
 
     # A codepoint above any character IntegrationType names use, so
     # connections with no destinations sort after every real type name
     # on ASC (and before every real type name on DESC).
     _NO_DESTINATION_SENTINEL = "￿"
+
+    def get_ordering(self, request, queryset, view):
+        ordering = super().get_ordering(request, queryset, view) or []
+        ordering = list(ordering)
+        if any(field.removeprefix("-") == "destination_type" for field in ordering):
+            # Only append the tiebreaker if the caller did not already
+            # request `id` in either direction.
+            if not any(field.removeprefix("-") == "id" for field in ordering):
+                ordering.append("id")
+        return ordering
 
     def filter_queryset(self, request, queryset, view):
         ordering = self.get_ordering(request, queryset, view) or ()
@@ -46,5 +59,5 @@ class ConnectionOrderingFilter(filters.OrderingFilter):
                     Value(self._NO_DESTINATION_SENTINEL),
                 )
             )
-            return queryset.order_by(*ordering, "id")
+            return queryset.order_by(*ordering)
         return super().filter_queryset(request, queryset, view)

--- a/cdip_admin/api/v2/filters.py
+++ b/cdip_admin/api/v2/filters.py
@@ -1,3 +1,5 @@
+from django.db.models import Min, Value
+from django.db.models.functions import Coalesce
 from rest_framework import filters
 
 
@@ -10,3 +12,39 @@ class CustomizableSearchFilter(filters.SearchFilter):
             return search_fields.split(",")
         # If the query param is not set, check in the view
         return super().get_search_fields(view, request)
+
+
+class ConnectionOrderingFilter(filters.OrderingFilter):
+    """OrderingFilter for ConnectionsView that adds the aggregate needed to
+    sort by `destination_type`.
+
+    Applies the annotation only when DRF has actually resolved
+    `destination_type` as part of the ordering, so the extra join +
+    GROUP BY is not paid on every list request.
+
+    Wraps the aggregate in `Coalesce` so that connections whose routes
+    have no destinations get a concrete high-sorting value instead of
+    SQL NULL. This lets CursorPagination — which encodes the cursor
+    position as `str(annotation_value)` — round-trip across pages, and
+    removes the backend-dependent NULLS FIRST / NULLS LAST behavior.
+
+    Appends `id` as a stable tiebreaker so pages are deterministic even
+    for rows that share a destination type name.
+    """
+
+    # A codepoint above any character IntegrationType names use, so
+    # connections with no destinations sort after every real type name
+    # on ASC (and before every real type name on DESC).
+    _NO_DESTINATION_SENTINEL = "￿"
+
+    def filter_queryset(self, request, queryset, view):
+        ordering = self.get_ordering(request, queryset, view) or ()
+        if any(field.removeprefix("-") == "destination_type" for field in ordering):
+            queryset = queryset.annotate(
+                destination_type=Coalesce(
+                    Min("routing_rules_by_provider__destinations__type__name"),
+                    Value(self._NO_DESTINATION_SENTINEL),
+                )
+            )
+            return queryset.order_by(*ordering, "id")
+        return super().filter_queryset(request, queryset, view)

--- a/cdip_admin/api/v2/tests/test_connections_api.py
+++ b/cdip_admin/api/v2/tests/test_connections_api.py
@@ -616,3 +616,43 @@ def test_list_connections_ordered_by_destination_type_no_duplicates(
     assert len(provider_ids) == len(set(provider_ids))
     lotek_rows = [c for c in connections if c["provider"]["id"] == str(provider_lotek_panthera.id)]
     assert len(lotek_rows) == 1
+
+
+def test_list_connections_ordered_by_destination_type_paginates_deterministically(
+        monkeypatch, api_client, superuser, organization,
+        provider_lotek_panthera, provider_movebank_ewt, provider_trap_tagger,
+        integrations_list_er, route_1, route_2, smart_destination_1,
+):
+    # Force a page size smaller than the fixture footprint so cursor pagination
+    # actually round-trips. Reproduces the regression where NULL destination
+    # types encoded as the literal "None" filtered out no-destination rows
+    # from page 2, and where tied `Min()` values could shuffle across pages.
+    from rest_framework.pagination import CursorPagination
+    from api.v2 import views
+
+    class _SmallPageCursorPagination(CursorPagination):
+        page_size = 3
+
+    monkeypatch.setattr(
+        views.ConnectionsView, "pagination_class",
+        _SmallPageCursorPagination, raising=False,
+    )
+    provider_trap_tagger.default_route.destinations.add(smart_destination_1)
+
+    expected_ids = {
+        str(p.id) for p in list(integrations_list_er)
+        + [provider_lotek_panthera, provider_movebank_ewt, provider_trap_tagger]
+    }
+
+    api_client.force_authenticate(superuser)
+    collected_ids = []
+    next_url = reverse("connections-list") + "?ordering=destination_type"
+    while next_url:
+        response = api_client.get(next_url)
+        assert response.status_code == status.HTTP_200_OK
+        page = response.json()
+        collected_ids.extend(c["provider"]["id"] for c in page["results"])
+        next_url = page.get("next")
+
+    assert len(collected_ids) == len(set(collected_ids)), "no row appears twice across pages"
+    assert set(collected_ids) == expected_ids, "no row is dropped across pages"

--- a/cdip_admin/api/v2/tests/test_connections_api.py
+++ b/cdip_admin/api/v2/tests/test_connections_api.py
@@ -516,7 +516,10 @@ def test_list_connections_ordered_by_destination_type_asc_as_superuser(
         integrations_list_er, route_1, route_2, smart_destination_1,
 ):
     # Give trap_tagger a SMART destination so more than one distinct
-    # destination type is present across connections.
+    # destination type is present across connections. `integrations_list_er`
+    # members are providers on their own default routes (via
+    # `ensure_default_route`) with zero destinations, so they also contribute
+    # NULL destination_type rows the ordering must place last.
     provider_trap_tagger.default_route.destinations.add(smart_destination_1)
 
     api_client.force_authenticate(superuser)
@@ -533,6 +536,7 @@ def test_list_connections_ordered_by_destination_type_asc_as_superuser(
     min_types = [_min_destination_type_name(c) for c in connections]
     non_null = [t for t in min_types if t is not None]
     nulls = [t for t in min_types if t is None]
+    assert nulls, "expected at least one connection with no destinations to witness NULL ordering"
     assert non_null == sorted(non_null)
     assert min_types == non_null + nulls  # Postgres puts NULLs last on ASC
 
@@ -558,8 +562,39 @@ def test_list_connections_ordered_by_destination_type_desc_as_superuser(
     min_types = [_min_destination_type_name(c) for c in connections]
     non_null = [t for t in min_types if t is not None]
     nulls = [t for t in min_types if t is None]
+    assert nulls, "expected at least one connection with no destinations to witness NULL ordering"
     assert non_null == sorted(non_null, reverse=True)
     assert min_types == nulls + non_null  # Postgres puts NULLs first on DESC
+
+
+def test_list_connections_ordered_by_destination_type_scoped_as_org_admin(
+        api_client, org_admin_user, organization,
+        provider_lotek_panthera, provider_movebank_ewt,
+        integrations_list_er, route_1, route_2,
+):
+    # org_admin_user only owns `organization`, which owns integrations_list_er[:5]
+    # and provider_lotek_panthera. The other providers must not appear even
+    # though the Min() annotation joins across routes and destinations owned
+    # by other organizations.
+    allowed_provider_ids = {
+        str(p.id) for p in list(integrations_list_er[:5]) + [provider_lotek_panthera]
+    }
+    disallowed_provider_ids = {
+        str(p.id) for p in list(integrations_list_er[5:]) + [provider_movebank_ewt]
+    }
+
+    api_client.force_authenticate(org_admin_user)
+    response = api_client.get(
+        reverse("connections-list"),
+        data={"ordering": "destination_type"},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    connections = response.json()["results"]
+
+    provider_ids = [c["provider"]["id"] for c in connections]
+    assert set(provider_ids) == allowed_provider_ids
+    assert not (set(provider_ids) & disallowed_provider_ids)
+    assert len(provider_ids) == len(set(provider_ids))  # one row per connection
 
 
 def test_list_connections_ordered_by_destination_type_no_duplicates(

--- a/cdip_admin/api/v2/tests/test_connections_api.py
+++ b/cdip_admin/api/v2/tests/test_connections_api.py
@@ -500,3 +500,84 @@ def test_filter_connections_by_status_needs_review_as_superuser(
         },
         expected_integrations=[connection_with_disabled_destination]  # provider OK but destination disabled
     )
+
+
+def _min_destination_type_name(connection):
+    type_names = [
+        d["type"]["name"] for d in connection["destinations"]
+        if d.get("type") and d["type"].get("name")
+    ]
+    return min(type_names) if type_names else None
+
+
+def test_list_connections_ordered_by_destination_type_asc_as_superuser(
+        api_client, superuser, organization,
+        provider_lotek_panthera, provider_movebank_ewt, provider_trap_tagger,
+        integrations_list_er, route_1, route_2, smart_destination_1,
+):
+    # Give trap_tagger a SMART destination so more than one distinct
+    # destination type is present across connections.
+    provider_trap_tagger.default_route.destinations.add(smart_destination_1)
+
+    api_client.force_authenticate(superuser)
+    response = api_client.get(
+        reverse("connections-list"),
+        data={"ordering": "destination_type"},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    connections = response.json()["results"]
+
+    provider_ids = [c["provider"]["id"] for c in connections]
+    assert len(provider_ids) == len(set(provider_ids))  # one row per connection
+
+    min_types = [_min_destination_type_name(c) for c in connections]
+    non_null = [t for t in min_types if t is not None]
+    nulls = [t for t in min_types if t is None]
+    assert non_null == sorted(non_null)
+    assert min_types == non_null + nulls  # Postgres puts NULLs last on ASC
+
+
+def test_list_connections_ordered_by_destination_type_desc_as_superuser(
+        api_client, superuser, organization,
+        provider_lotek_panthera, provider_movebank_ewt, provider_trap_tagger,
+        integrations_list_er, route_1, route_2, smart_destination_1,
+):
+    provider_trap_tagger.default_route.destinations.add(smart_destination_1)
+
+    api_client.force_authenticate(superuser)
+    response = api_client.get(
+        reverse("connections-list"),
+        data={"ordering": "-destination_type"},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    connections = response.json()["results"]
+
+    provider_ids = [c["provider"]["id"] for c in connections]
+    assert len(provider_ids) == len(set(provider_ids))
+
+    min_types = [_min_destination_type_name(c) for c in connections]
+    non_null = [t for t in min_types if t is not None]
+    nulls = [t for t in min_types if t is None]
+    assert non_null == sorted(non_null, reverse=True)
+    assert min_types == nulls + non_null  # Postgres puts NULLs first on DESC
+
+
+def test_list_connections_ordered_by_destination_type_no_duplicates(
+        api_client, superuser, organization,
+        provider_lotek_panthera, provider_movebank_ewt,
+        integrations_list_er, route_1, route_2,
+):
+    # route_1 attaches 10 ER destinations to provider_lotek_panthera; without
+    # the Min() annotation a naive join would return 10 rows for that provider.
+    api_client.force_authenticate(superuser)
+    response = api_client.get(
+        reverse("connections-list"),
+        data={"ordering": "destination_type"},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    connections = response.json()["results"]
+
+    provider_ids = [c["provider"]["id"] for c in connections]
+    assert len(provider_ids) == len(set(provider_ids))
+    lotek_rows = [c for c in connections if c["provider"]["id"] == str(provider_lotek_panthera.id)]
+    assert len(lotek_rows) == 1

--- a/cdip_admin/api/v2/views.py
+++ b/cdip_admin/api/v2/views.py
@@ -1,6 +1,6 @@
 import django_filters
 from django.db import transaction
-from django.db.models import Subquery
+from django.db.models import Min, Subquery
 from rest_framework.permissions import IsAuthenticated
 
 from activity_log.models import ActivityLog
@@ -266,7 +266,7 @@ class ConnectionsView(
         custom_filters.CustomizableSearchFilter
     ]
     filterset_class = ConnectionFilter
-    ordering_fields = ['id', 'name', 'base_url', 'type__name', 'owner__name']
+    ordering_fields = ['id', 'name', 'base_url', 'type__name', 'owner__name', 'destination_type']
     ordering = ['id']
     search_fields = [  # Default search fields (used in the global search box)
         "name", "base_url", 'type__name',  # Providers
@@ -283,6 +283,12 @@ class ConnectionsView(
         Return the integrations used as providers in at least one route
         """
         providers = Integration.providers.all()
+        # Annotate only when sorting by destination type, to avoid paying
+        # the join + GROUP BY on every list request
+        if "destination_type" in self.request.query_params.get("ordering", ""):
+            providers = providers.annotate(
+                destination_type=Min("routing_rules_by_provider__destinations__type__name")
+            )
         if self.request.user.is_superuser:
             return providers  # Superusers can see all the providers
         # Filter providers to return only the ones that the user is allowed to see

--- a/cdip_admin/api/v2/views.py
+++ b/cdip_admin/api/v2/views.py
@@ -285,7 +285,11 @@ class ConnectionsView(
         providers = Integration.providers.all()
         # Annotate only when sorting by destination type, to avoid paying
         # the join + GROUP BY on every list request
-        if "destination_type" in self.request.query_params.get("ordering", ""):
+        requested_ordering = {
+            field.strip().lstrip("-")
+            for field in self.request.query_params.get("ordering", "").split(",")
+        }
+        if "destination_type" in requested_ordering:
             providers = providers.annotate(
                 destination_type=Min("routing_rules_by_provider__destinations__type__name")
             )

--- a/cdip_admin/api/v2/views.py
+++ b/cdip_admin/api/v2/views.py
@@ -1,6 +1,6 @@
 import django_filters
 from django.db import transaction
-from django.db.models import Min, Subquery
+from django.db.models import Subquery
 from rest_framework.permissions import IsAuthenticated
 
 from activity_log.models import ActivityLog
@@ -261,7 +261,7 @@ class ConnectionsView(
     """
     permission_classes = [permissions.IsSuperuser | permissions.IsOrgAdmin | permissions.IsOrgViewer]
     filter_backends = [
-        drf_filters.OrderingFilter,
+        custom_filters.ConnectionOrderingFilter,
         django_filters.rest_framework.DjangoFilterBackend,
         custom_filters.CustomizableSearchFilter
     ]
@@ -283,16 +283,6 @@ class ConnectionsView(
         Return the integrations used as providers in at least one route
         """
         providers = Integration.providers.all()
-        # Annotate only when sorting by destination type, to avoid paying
-        # the join + GROUP BY on every list request
-        requested_ordering = {
-            field.strip().lstrip("-")
-            for field in self.request.query_params.get("ordering", "").split(",")
-        }
-        if "destination_type" in requested_ordering:
-            providers = providers.annotate(
-                destination_type=Min("routing_rules_by_provider__destinations__type__name")
-            )
         if self.request.user.is_superuser:
             return providers  # Superusers can see all the providers
         # Filter providers to return only the ones that the user is allowed to see


### PR DESCRIPTION
## Summary

- Adds `destination_type` to `ConnectionsView.ordering_fields`, wiring the "Sort by Destination" control already shipped in Portal PR #339 (GUNDI-5509 follow-up).
- Sorts by `Min(routing_rules_by_provider__destinations__type__name)` so each connection appears once even when it has many destinations.
- The annotation is applied **only** when the request asks for `destination_type` ordering — the default list and other sorts stay on the same SQL as before, with no extra join or GROUP BY.

Ticket: [GUNDI-5586](https://allenai.atlassian.net/browse/GUNDI-5586)

## Test plan

- [ ] `pytest cdip_admin/api/v2/tests/test_connections_api.py -v` — the three new tests pass (`_ordered_by_destination_type_asc`, `_desc`, `_no_duplicates`) and existing tests are unaffected.
- [ ] `GET /v2/connections/?ordering=destination_type` returns one row per connection, sorted by destination type ASC (nulls last).
- [ ] `GET /v2/connections/?ordering=-destination_type` returns DESC (nulls first).
- [ ] `GET /v2/connections/` (no `ordering` param) SQL contains no `GROUP BY` and no join to `integrationtype` (verify via `DEBUG=True` or django-debug-toolbar).
- [ ] Portal Connections page: the "Sort by Destination" toggle now reorders the table both ASC and DESC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[GUNDI-5586]: https://allenai.atlassian.net/browse/GUNDI-5586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ