### PR TITLE
GUNDI-5562: type-level route for ephemeral reference execution

### DIFF
--- a/cdip_admin/api/v2/permissions.py
+++ b/cdip_admin/api/v2/permissions.py
@@ -1,3 +1,5 @@
+import uuid
+
 from rest_framework import permissions
 
 from activity_log.models import ActivityLog
@@ -46,8 +48,14 @@ def get_user_org(request, view) -> str:
             org_id = None
     elif view.basename == "integration-types" and view.action == "execute_reference_action":
         # There's no saved integration row yet — authz keys on `owner`, the
-        # workspace the caller intends to create the integration in.
-        org_id = request.data.get("owner")
+        # workspace the caller intends to create the integration in. Validate
+        # the UUID here so a malformed value results in a clean 403 rather
+        # than a 500 from the ORM filter downstream.
+        raw_owner = request.data.get("owner")
+        try:
+            org_id = str(uuid.UUID(raw_owner)) if raw_owner else None
+        except (ValueError, TypeError):
+            org_id = None
     elif view.basename == "connections":
         integration_id = request.data.get("pk")
         org_id = str(Integration.objects.get(id=integration_id).owner.id) if integration_id else None

--- a/cdip_admin/api/v2/permissions.py
+++ b/cdip_admin/api/v2/permissions.py
@@ -44,6 +44,10 @@ def get_user_org(request, view) -> str:
             org_id = str(Integration.objects.get(id=integration_id).owner.id)
         else:
             org_id = None
+    elif view.basename == "integration-types" and view.action == "execute_reference_action":
+        # There's no saved integration row yet — authz keys on `owner`, the
+        # workspace the caller intends to create the integration in.
+        org_id = request.data.get("owner")
     elif view.basename == "connections":
         integration_id = request.data.get("pk")
         org_id = str(Integration.objects.get(id=integration_id).owner.id) if integration_id else None
@@ -77,6 +81,7 @@ class IsOrgAdmin(permissions.BasePermission):
         "organizations": ["list", "retrieve", "update", "partial_update"],
         "members": ["list", "invite", "retrieve", "update", "partial_update", "remove"],
         "integrations": ["list", "create", "retrieve", "update", "partial_update", "destroy"],
+        "integration-types": ["execute_reference_action"],
         "actions": ["execute"],
         "sources": ["list", "create", "retrieve", "update", "partial_update", "destroy"],
         "routes": ["list", "create", "retrieve", "update", "partial_update", "destroy", "delete_configuration"],

--- a/cdip_admin/api/v2/serializers.py
+++ b/cdip_admin/api/v2/serializers.py
@@ -1784,6 +1784,19 @@ class ActionTriggerSerializer(serializers.Serializer):
     )
 
 
+class _DraftActionConfigSerializer(serializers.Serializer):
+    action_value = serializers.SlugField()
+    data = serializers.JSONField()
+
+
+class TypeActionExecuteSerializer(serializers.Serializer):
+    # `owner` scopes authz — the caller must be a member of that organization.
+    owner = serializers.UUIDField()
+    base_url = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+    configurations = _DraftActionConfigSerializer(many=True, default=list)
+    config_overrides = serializers.JSONField(required=False, default=dict)
+
+
 class UserAgreementSerializer(serializers.ModelSerializer):
     user = serializers.HiddenField(default=serializers.CurrentUserDefault())
     eula = serializers.HiddenField(default=EULA.objects.get_active_eula)

--- a/cdip_admin/api/v2/tests/test_actions_execution_api.py
+++ b/cdip_admin/api/v2/tests/test_actions_execution_api.py
@@ -423,3 +423,23 @@ def test_ephemeral_execute_missing_owner_is_400(
     )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_ephemeral_execute_malformed_owner_uuid_is_403(
+        api_client, mocker, requests_mock, org_admin_user, organization,
+        integration_type_cellstop, cellstop_action_list_tag_names,
+):
+    # A malformed `owner` UUID must be rejected by the permission check as
+    # 403 (not resolvable to an org the caller belongs to), not crash the
+    # ORM filter downstream as 500.
+    _mock_runner(mocker, requests_mock, integration_type_cellstop)
+    api_client.force_authenticate(org_admin_user)
+    body = _ephemeral_body(organization)
+    body["owner"] = "not-a-uuid"
+
+    response = api_client.post(
+        _ephemeral_url(integration_type_cellstop, cellstop_action_list_tag_names.value),
+        data=body, format="json",
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/cdip_admin/api/v2/tests/test_actions_execution_api.py
+++ b/cdip_admin/api/v2/tests/test_actions_execution_api.py
@@ -408,6 +408,33 @@ def test_ephemeral_execute_type_without_service_url_returns_502(
     assert response.status_code == status.HTTP_502_BAD_GATEWAY
 
 
+def test_ephemeral_execute_runner_timeout_returns_502(
+        api_client, mocker, requests_mock, superuser, organization,
+        integration_type_cellstop, cellstop_action_list_tag_names,
+):
+    # A hung/unreachable runner must surface as a clean 502 (so the portal
+    # falls back to plain text), not a 500 from an unhandled RequestException.
+    import requests as requests_lib
+    mocker.patch(
+        "integrations.models.v2.models.google.auth.transport.requests.Request",
+        mocker.MagicMock(),
+    )
+    mocker.patch(
+        "integrations.models.v2.models.google.oauth2.id_token.fetch_id_token",
+        mocker.MagicMock(return_value="fake_id_token"),
+    )
+    actions_execute_url = urljoin(integration_type_cellstop.service_url, "/v1/actions/execute")
+    requests_mock.post(actions_execute_url, exc=requests_lib.exceptions.ConnectTimeout)
+    api_client.force_authenticate(superuser)
+
+    response = api_client.post(
+        _ephemeral_url(integration_type_cellstop, cellstop_action_list_tag_names.value),
+        data=_ephemeral_body(organization), format="json",
+    )
+
+    assert response.status_code == status.HTTP_502_BAD_GATEWAY
+
+
 def test_ephemeral_execute_missing_owner_is_400(
         api_client, mocker, requests_mock, superuser, organization,
         integration_type_cellstop, cellstop_action_list_tag_names,

--- a/cdip_admin/api/v2/tests/test_actions_execution_api.py
+++ b/cdip_admin/api/v2/tests/test_actions_execution_api.py
@@ -435,6 +435,57 @@ def test_ephemeral_execute_runner_timeout_returns_502(
     assert response.status_code == status.HTTP_502_BAD_GATEWAY
 
 
+def test_ephemeral_execute_non_json_response_returns_502(
+        api_client, mocker, requests_mock, superuser, organization,
+        integration_type_cellstop, cellstop_action_list_tag_names,
+):
+    # A 200 with a non-JSON body (e.g. HTML from a broken proxy) must degrade
+    # to 502 rather than escape as an uncaught JSONDecodeError → 500.
+    mocker.patch(
+        "integrations.models.v2.models.google.auth.transport.requests.Request",
+        mocker.MagicMock(),
+    )
+    mocker.patch(
+        "integrations.models.v2.models.google.oauth2.id_token.fetch_id_token",
+        mocker.MagicMock(return_value="fake_id_token"),
+    )
+    actions_execute_url = urljoin(integration_type_cellstop.service_url, "/v1/actions/execute")
+    requests_mock.post(actions_execute_url, text="<html>oops</html>", status_code=200)
+    api_client.force_authenticate(superuser)
+
+    response = api_client.post(
+        _ephemeral_url(integration_type_cellstop, cellstop_action_list_tag_names.value),
+        data=_ephemeral_body(organization), format="json",
+    )
+
+    assert response.status_code == status.HTTP_502_BAD_GATEWAY
+
+
+def test_ephemeral_execute_auth_failure_returns_502(
+        api_client, mocker, requests_mock, superuser, organization,
+        integration_type_cellstop, cellstop_action_list_tag_names,
+):
+    # A GCP metadata / auth-service outage during id_token fetch must degrade
+    # to 502, not bubble up as an unhandled GoogleAuthError → 500.
+    from google.auth.exceptions import RefreshError
+    mocker.patch(
+        "integrations.models.v2.models.google.auth.transport.requests.Request",
+        mocker.MagicMock(),
+    )
+    mocker.patch(
+        "integrations.models.v2.models.google.oauth2.id_token.fetch_id_token",
+        mocker.MagicMock(side_effect=RefreshError("metadata unreachable")),
+    )
+    api_client.force_authenticate(superuser)
+
+    response = api_client.post(
+        _ephemeral_url(integration_type_cellstop, cellstop_action_list_tag_names.value),
+        data=_ephemeral_body(organization), format="json",
+    )
+
+    assert response.status_code == status.HTTP_502_BAD_GATEWAY
+
+
 def test_ephemeral_execute_missing_owner_is_400(
         api_client, mocker, requests_mock, superuser, organization,
         integration_type_cellstop, cellstop_action_list_tag_names,

--- a/cdip_admin/api/v2/tests/test_actions_execution_api.py
+++ b/cdip_admin/api/v2/tests/test_actions_execution_api.py
@@ -228,3 +228,198 @@ def test_execute_action_forwards_explicit_triggered_by(
         triggered_by="auto",
         expected_triggered_by="auto",
     )
+
+
+def _ephemeral_url(integration_type, action_value):
+    from django.urls import reverse
+    return reverse(
+        "integration-types-execute-reference-action",
+        kwargs={"value": integration_type.value, "action_value": action_value},
+    )
+
+
+def _mock_runner(mocker, requests_mock, integration_type, response_body=None, status_code=status.HTTP_200_OK):
+    mocker.patch(
+        "integrations.models.v2.models.google.auth.transport.requests.Request",
+        mocker.MagicMock(),
+    )
+    mocker.patch(
+        "integrations.models.v2.models.google.oauth2.id_token.fetch_id_token",
+        mocker.MagicMock(return_value="fake_id_token"),
+    )
+    actions_execute_url = urljoin(integration_type.service_url, "/v1/actions/execute")
+    return requests_mock.post(
+        actions_execute_url, json=response_body or {}, status_code=status_code,
+    )
+
+
+def _ephemeral_body(organization, base_url="https://sandbox.example.com", token="ephemeral-token-abc"):
+    return {
+        "owner": str(organization.id),
+        "base_url": base_url,
+        "configurations": [
+            {"action_value": "auth", "data": {"username": "user@example.com", "password": token}},
+        ],
+        "config_overrides": {"tag_type": "vessel"},
+    }
+
+
+def test_ephemeral_execute_as_superuser_forwards_draft_state(
+        api_client, mocker, requests_mock, superuser, organization,
+        integration_type_cellstop, cellstop_action_list_tag_names, cellstop_list_tag_names_response,
+):
+    gcp_mock = _mock_runner(
+        mocker, requests_mock, integration_type_cellstop, cellstop_list_tag_names_response,
+    )
+    api_client.force_authenticate(superuser)
+    body = _ephemeral_body(organization)
+
+    response = api_client.post(
+        _ephemeral_url(integration_type_cellstop, cellstop_action_list_tag_names.value),
+        data=body, format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == cellstop_list_tag_names_response
+    sent = gcp_mock.last_request.json()
+    assert sent["integration_id"] is None
+    assert sent["action_id"] == "list_tag_names"
+    assert sent["run_in_background"] is False
+    assert sent["config_overrides"] == {"tag_type": "vessel"}
+    integration_state = sent["integration_state"]
+    assert integration_state["type_value"] == "cellstop"
+    assert integration_state["base_url"] == "https://sandbox.example.com"
+    assert integration_state["configurations"] == [
+        {"action_value": "auth", "data": {"username": "user@example.com", "password": "ephemeral-token-abc"}},
+    ]
+
+
+def test_ephemeral_execute_as_org_admin_of_owner(
+        api_client, mocker, requests_mock, org_admin_user, organization,
+        integration_type_cellstop, cellstop_action_list_tag_names, cellstop_list_tag_names_response,
+):
+    _mock_runner(
+        mocker, requests_mock, integration_type_cellstop, cellstop_list_tag_names_response,
+    )
+    api_client.force_authenticate(org_admin_user)
+
+    response = api_client.post(
+        _ephemeral_url(integration_type_cellstop, cellstop_action_list_tag_names.value),
+        data=_ephemeral_body(organization), format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+
+def test_ephemeral_execute_rejects_non_member_org_admin(
+        api_client, mocker, requests_mock, org_admin_user_2, organization,
+        integration_type_cellstop, cellstop_action_list_tag_names,
+):
+    _mock_runner(mocker, requests_mock, integration_type_cellstop)
+    api_client.force_authenticate(org_admin_user_2)
+
+    response = api_client.post(
+        _ephemeral_url(integration_type_cellstop, cellstop_action_list_tag_names.value),
+        data=_ephemeral_body(organization), format="json",
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_ephemeral_execute_rejects_org_viewer(
+        api_client, mocker, requests_mock, org_viewer_user, organization,
+        integration_type_cellstop, cellstop_action_list_tag_names,
+):
+    _mock_runner(mocker, requests_mock, integration_type_cellstop)
+    api_client.force_authenticate(org_viewer_user)
+
+    response = api_client.post(
+        _ephemeral_url(integration_type_cellstop, cellstop_action_list_tag_names.value),
+        data=_ephemeral_body(organization), format="json",
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_ephemeral_execute_rejects_non_reference_action(
+        api_client, mocker, requests_mock, superuser, organization,
+        integration_type_cellstop, cellstop_action_auth,
+):
+    gcp_mock = _mock_runner(mocker, requests_mock, integration_type_cellstop)
+    api_client.force_authenticate(superuser)
+
+    response = api_client.post(
+        _ephemeral_url(integration_type_cellstop, cellstop_action_auth.value),
+        data=_ephemeral_body(organization), format="json",
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert not gcp_mock.called
+
+
+def test_ephemeral_execute_unknown_action_returns_404(
+        api_client, mocker, requests_mock, superuser, organization,
+        integration_type_cellstop,
+):
+    _mock_runner(mocker, requests_mock, integration_type_cellstop)
+    api_client.force_authenticate(superuser)
+
+    response = api_client.post(
+        _ephemeral_url(integration_type_cellstop, "nonexistent_action"),
+        data=_ephemeral_body(organization), format="json",
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_ephemeral_execute_creates_no_activity_log(
+        api_client, mocker, requests_mock, superuser, organization,
+        integration_type_cellstop, cellstop_action_list_tag_names, cellstop_list_tag_names_response,
+):
+    from activity_log.models import ActivityLog
+    _mock_runner(
+        mocker, requests_mock, integration_type_cellstop, cellstop_list_tag_names_response,
+    )
+    api_client.force_authenticate(superuser)
+    starting_count = ActivityLog.objects.count()
+
+    response = api_client.post(
+        _ephemeral_url(integration_type_cellstop, cellstop_action_list_tag_names.value),
+        data=_ephemeral_body(organization), format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert ActivityLog.objects.count() == starting_count
+
+
+def test_ephemeral_execute_type_without_service_url_returns_502(
+        api_client, mocker, requests_mock, superuser, organization,
+        integration_type_cellstop, cellstop_action_list_tag_names,
+):
+    integration_type_cellstop.service_url = ""
+    integration_type_cellstop.save()
+    api_client.force_authenticate(superuser)
+
+    response = api_client.post(
+        _ephemeral_url(integration_type_cellstop, cellstop_action_list_tag_names.value),
+        data=_ephemeral_body(organization), format="json",
+    )
+
+    assert response.status_code == status.HTTP_502_BAD_GATEWAY
+
+
+def test_ephemeral_execute_missing_owner_is_400(
+        api_client, mocker, requests_mock, superuser, organization,
+        integration_type_cellstop, cellstop_action_list_tag_names,
+):
+    _mock_runner(mocker, requests_mock, integration_type_cellstop)
+    api_client.force_authenticate(superuser)
+    body = _ephemeral_body(organization)
+    body.pop("owner")
+
+    response = api_client.post(
+        _ephemeral_url(integration_type_cellstop, cellstop_action_list_tag_names.value),
+        data=body, format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/cdip_admin/api/v2/views.py
+++ b/cdip_admin/api/v2/views.py
@@ -248,7 +248,52 @@ class IntegrationTypeView(viewsets.ModelViewSet):
             return v2_serializers.IntegrationTypeIdempotentCreateSerializer
         elif self.action in ["update", "partial_update"]:
             return v2_serializers.IntegrationTypeUpdateSerializer
+        elif self.action == "execute_reference_action":
+            return v2_serializers.TypeActionExecuteSerializer
         return v2_serializers.IntegrationTypeFullSerializer
+
+    @action(
+        detail=True,
+        methods=["post"],
+        url_path=r"actions/(?P<action_value>[-\w]+)/execute",
+        url_name="execute-reference-action",
+    )
+    def execute_reference_action(self, request, action_value=None, value=None):
+        """Execute a reference action against a draft integration.
+
+        Nothing is persisted or logged — the payload carries user-typed
+        credentials. Restricted to reference actions; the runner enforces the
+        same rule independently.
+        """
+        integration_type = self.get_object()
+        integration_action = IntegrationAction.objects.filter(
+            integration_type=integration_type, value=action_value,
+        ).first()
+        if integration_action is None:
+            return Response(
+                {"detail": f"Action '{action_value}' not found for integration type '{integration_type.value}'."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        if integration_action.type != IntegrationAction.ActionTypes.REFERENCE:
+            return Response(
+                {"detail": "Only reference actions can be executed on integration types."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        try:
+            response_data = integration_type.execute_reference_action_ephemeral(
+                action_value=action_value,
+                base_url=serializer.validated_data.get("base_url"),
+                configurations=[
+                    {"action_value": c["action_value"], "data": c["data"]}
+                    for c in serializer.validated_data.get("configurations", [])
+                ],
+                config_overrides=serializer.validated_data.get("config_overrides") or {},
+            )
+        except ValueError as e:
+            return Response({"detail": str(e)}, status=status.HTTP_502_BAD_GATEWAY)
+        return Response(response_data, status=status.HTTP_200_OK)
 
 
 class ConnectionsView(

--- a/cdip_admin/integrations/models/v2/models.py
+++ b/cdip_admin/integrations/models/v2/models.py
@@ -51,6 +51,41 @@ class IntegrationType(UUIDAbstractModel, TimestampedModel):
     def __str__(self):
         return f"{self.name}"
 
+    def execute_reference_action_ephemeral(
+        self, action_value, base_url, configurations, config_overrides=None,
+    ):
+        """Forward a reference action to this type's runner with a draft payload.
+
+        Never persists or logs the payload — it carries user-typed credentials.
+        The runner enforces the reference-only constraint independently.
+        """
+        service_url = self.service_url
+        if not service_url:
+            raise ValueError(
+                f"Integration Type '{self}' does not have a service endpoint configured"
+            )
+        actions_execute_url = urljoin(service_url, "v1/actions/execute")
+        auth_req = google.auth.transport.requests.Request()
+        id_token = google.oauth2.id_token.fetch_id_token(auth_req, service_url)
+        response = requests.post(
+            url=actions_execute_url,
+            headers={"Authorization": f"Bearer {id_token}"},
+            json={
+                "integration_id": None,
+                "action_id": action_value,
+                "run_in_background": False,
+                "triggered_by": "manual",
+                "config_overrides": config_overrides or {},
+                "integration_state": {
+                    "type_value": self.value,
+                    "base_url": base_url or "",
+                    "configurations": configurations,
+                },
+            },
+        )
+        response.raise_for_status()
+        return response.json()
+
 
 class IntegrationAction(UUIDAbstractModel, TimestampedModel):
 

--- a/cdip_admin/integrations/models/v2/models.py
+++ b/cdip_admin/integrations/models/v2/models.py
@@ -51,6 +51,10 @@ class IntegrationType(UUIDAbstractModel, TimestampedModel):
     def __str__(self):
         return f"{self.name}"
 
+    # (connect, read) — connect fast so a dead runner surfaces quickly; the
+    # read budget covers cold starts on the runner's Cloud Run instance.
+    _EPHEMERAL_RUNNER_TIMEOUT = (5, 20)
+
     def execute_reference_action_ephemeral(
         self, action_value, base_url, configurations, config_overrides=None,
     ):
@@ -58,6 +62,9 @@ class IntegrationType(UUIDAbstractModel, TimestampedModel):
 
         Never persists or logs the payload — it carries user-typed credentials.
         The runner enforces the reference-only constraint independently.
+
+        Raises ValueError on any network/HTTP failure — the view converts that
+        into a 502 so the portal falls back to plain text rather than hanging.
         """
         service_url = self.service_url
         if not service_url:
@@ -67,24 +74,28 @@ class IntegrationType(UUIDAbstractModel, TimestampedModel):
         actions_execute_url = urljoin(service_url, "v1/actions/execute")
         auth_req = google.auth.transport.requests.Request()
         id_token = google.oauth2.id_token.fetch_id_token(auth_req, service_url)
-        response = requests.post(
-            url=actions_execute_url,
-            headers={"Authorization": f"Bearer {id_token}"},
-            json={
-                "integration_id": None,
-                "action_id": action_value,
-                "run_in_background": False,
-                "triggered_by": "manual",
-                "config_overrides": config_overrides or {},
-                "integration_state": {
-                    "type_value": self.value,
-                    "base_url": base_url or "",
-                    "configurations": configurations,
+        try:
+            response = requests.post(
+                url=actions_execute_url,
+                headers={"Authorization": f"Bearer {id_token}"},
+                json={
+                    "integration_id": None,
+                    "action_id": action_value,
+                    "run_in_background": False,
+                    "triggered_by": "manual",
+                    "config_overrides": config_overrides or {},
+                    "integration_state": {
+                        "type_value": self.value,
+                        "base_url": base_url or "",
+                        "configurations": configurations,
+                    },
                 },
-            },
-        )
-        response.raise_for_status()
-        return response.json()
+                timeout=self._EPHEMERAL_RUNNER_TIMEOUT,
+            )
+            response.raise_for_status()
+            return response.json()
+        except requests.RequestException as e:
+            raise ValueError(f"Action runner unreachable for '{self}': {type(e).__name__}") from e
 
 
 class IntegrationAction(UUIDAbstractModel, TimestampedModel):

--- a/cdip_admin/integrations/models/v2/models.py
+++ b/cdip_admin/integrations/models/v2/models.py
@@ -7,6 +7,7 @@ import jsonschema
 import psycopg2
 import requests
 import google.oauth2.id_token
+from google.auth.exceptions import GoogleAuthError
 from urllib.parse import urljoin, urlparse
 from core.models import UUIDAbstractModel, TimestampedModel
 from django_celery_beat.models import IntervalSchedule, PeriodicTask
@@ -72,9 +73,11 @@ class IntegrationType(UUIDAbstractModel, TimestampedModel):
                 f"Integration Type '{self}' does not have a service endpoint configured"
             )
         actions_execute_url = urljoin(service_url, "v1/actions/execute")
-        auth_req = google.auth.transport.requests.Request()
-        id_token = google.oauth2.id_token.fetch_id_token(auth_req, service_url)
         try:
+            # `fetch_id_token` hits GCP metadata; wrap it in the same try so
+            # a transient auth-service outage is a 502, not a 500.
+            auth_req = google.auth.transport.requests.Request()
+            id_token = google.oauth2.id_token.fetch_id_token(auth_req, service_url)
             response = requests.post(
                 url=actions_execute_url,
                 headers={"Authorization": f"Bearer {id_token}"},
@@ -94,7 +97,10 @@ class IntegrationType(UUIDAbstractModel, TimestampedModel):
             )
             response.raise_for_status()
             return response.json()
-        except requests.RequestException as e:
+        except (requests.RequestException, ValueError, GoogleAuthError) as e:
+            # ValueError covers a non-JSON response body on older `requests`
+            # versions (recent versions wrap it as RequestException). GoogleAuthError
+            # covers metadata-server failures from `fetch_id_token`.
             raise ValueError(f"Action runner unreachable for '{self}': {type(e).__name__}") from e
 
 


### PR DESCRIPTION
Adds `POST /v2/integrations/types/{value}/actions/{action_value}/execute/` — a companion to `ActionTriggerView.execute` for the case where there's no saved integration yet.

Needed by the portal wizard ([GUNDI-5562](https://allenai.atlassian.net/browse/GUNDI-5562)) to populate reference-select dropdowns against user-typed credentials during first-time setup.

## What's here
- New `execute_reference_action` on `IntegrationTypeView` (via `@action`)
- `TypeActionExecuteSerializer` — `owner`, `base_url`, `configurations`, `config_overrides`
- `IntegrationType.execute_reference_action_ephemeral` — forwards to the runner with `integration_id: null` and an `integration_state` payload
- Authz: `IsSuperuser | IsOrgAdmin | IsOrgViewer` — `get_user_org` now reads `owner` from the request body for this action, so only members of the target workspace can call it
- Reference-only (403 for non-reference actions), synchronous only, no ActivityLog

## Depends on
- Runner: `gundi-integration-action-runner` needs the `integration_state` support before this route is usable.

## Test plan
- [x] 9 new view tests: authz (superuser, org admin, non-member, viewer), reference-only enforcement, no ActivityLog created, missing owner → 400, missing service_url → 502

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[GUNDI-5562]: https://allenai.atlassian.net/browse/GUNDI-5562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ